### PR TITLE
test: Add unit tests for getStatus in PlayerTest

### DIFF
--- a/src/test/java/edu/ntnu/idatt2003/millions/model/PlayerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/PlayerTest.java
@@ -237,7 +237,8 @@ class PlayerTest {
         }
 
         @Test
-        @DisplayName("Should return NOVICE when player has traded 10 weeks but not increased net worth by 20%")
+        @DisplayName("Should return NOVICE when player has traded 10 weeks but not increased net " +
+                "worth by 20%")
         void returnNoviceStatusWhenEnoughWeeksNotEnoughGrowth() {
             // Arrange
             player = new Player("AKL", new BigDecimal("800.00"));
@@ -289,6 +290,57 @@ class PlayerTest {
             //Act & Assert
             assertNotEquals(PlayerStatusLevel.INVESTOR, player.getStatus());
         }
-    }
 
+        @Test
+        @DisplayName("Should return SPECULATOR when player has traded 20 weeks and doubled" +
+                " net worth")
+        void returnsSpeculatorWhenConditionsMet() {
+            //Arrange
+            player = new Player("DCL", new BigDecimal("1000.00"));
+            for (int week = 1; week <= 20; week++) {
+                Stock stock = new Stock("MR" + week,"Majid Company" + week,
+                        new ArrayList<>(List.of((new BigDecimal("10.00")))));
+                Share share = new Share(stock, new BigDecimal("1"), new BigDecimal("1.00"));
+                Purchase purchase = new Purchase(share, week);
+                purchase.commit(player);
+            }
+            player.addMoney(new BigDecimal("2000.00"));
+            //Act & Arrange
+            assertEquals(PlayerStatusLevel.SPECULATOR, player.getStatus());
+        }
+        @Test
+        @DisplayName("Should not return SPECULATOR when player has traded 20 weeks " +
+                "but not doubled their net worth")
+        void returnsNotSpeculatorWhenNotEnoughGrowth() {
+            //Arrange
+            player = new Player("AKL", new BigDecimal("1000.00"));
+            for (int week = 1; week <= 20; week++) {
+                Stock stock = new Stock("DCL" + week, "Dara, Inc" + week,
+                        new ArrayList<>(List.of((new BigDecimal("10.00")))));
+                Share share = new Share(stock, new BigDecimal("1"), new BigDecimal("1.00"));
+                Purchase purchase = new Purchase(share, week);
+                purchase.commit(player);
+            }
+            player.addMoney(new BigDecimal("500.00"));
+            //Act & Assert
+            assertNotEquals(PlayerStatusLevel.SPECULATOR, player.getStatus());
+        }
+
+        @Test
+        @DisplayName("Should not return SPECULATOR when player has doubled net worth " +
+                "but traded less than 20 weeks")
+        void returnsNotSpeculatorWhenNotEnoughWeeks(){
+            player = new Player("AKL", new BigDecimal("1000.00"));
+            for (int week = 1; week <= 10; week++) {
+                Stock stock = new Stock("DCL" + week, "Dara, Inc" + week,
+                        new ArrayList<>(List.of((new BigDecimal("10.00")))));
+                Share share = new Share(stock, new BigDecimal("1"), new BigDecimal("1.00"));
+                Purchase purchase = new Purchase(share, week);
+                purchase.commit(player);
+            }
+            player.addMoney(new BigDecimal("2000.00"));
+            //Act & Assert
+            assertNotEquals(PlayerStatusLevel.SPECULATOR, player.getStatus());
+        }
+    }
 }


### PR DESCRIPTION
Adds unit tests for getStatus() in Player. Tests cover all three status levels, NOVICE, INVESTOR, and SPECULATOR.
These tests with both positive and negative cases. Negative tests verify that status is not awarded when only one of the two required conditions is met, either insufficient weeks traded or insufficient net worth growth.