### PR TITLE
test: add negative tests to Stock price statistics

### DIFF
--- a/src/test/java/edu/ntnu/idatt2003/millions/model/StockTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/StockTest.java
@@ -249,6 +249,7 @@ class StockTest {
             assertNotEquals(0,new BigDecimal("100.00").compareTo(result));
         }
     }
+
     @Nested
     @DisplayName("getLowestPrice()")
     class GetLowestPrice {
@@ -276,7 +277,23 @@ class StockTest {
             // Assert
             assertEquals(0, new BigDecimal("100.00").compareTo(result));
         }
+
+        @Test
+        @DisplayName("Should not return the highest price as the lowest")
+        void returnNotHighestPriceAsLowest() {
+            //Arrange
+            Stock multiPriceStock = new Stock("DCL", "Dara, Inc",
+                    new ArrayList<>(List.of(
+                            new BigDecimal("120"),
+                            new BigDecimal("150.00"),
+                            new BigDecimal("160.00"))));
+            //Act
+            BigDecimal result = multiPriceStock.getLowestPrice();
+            //Assert
+            assertNotEquals(0,new BigDecimal("160.00").compareTo(result));
+        }
     }
+
     @Nested
     @DisplayName("getLatestPriceChange()")
     class GetLatestPriceChange {


### PR DESCRIPTION
Added negative test cases for the methods getHighestPrice, getLowestPrice, and getHistoricalPrices. These tests ensures that the methods do not return incorrect or invalid values. Specifically, the tests verify that the lowest price is not returned as the highest, the highest price is not returned as the lowest, and that historical prices do not include values that were never registered. 