### PR TITLE
test: add edge case for getLosers and getGainers in ExchangeTest

### DIFF
--- a/src/test/java/edu/ntnu/idatt2003/millions/model/ExchangeTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/ExchangeTest.java
@@ -500,6 +500,16 @@ class ExchangeTest {
             //Act & Assert
             assertThrows(IllegalArgumentException.class, () -> exchange.getLosers(-1));
         }
+
+        @Test
+        @DisplayName("Should return all losers when limit exceeds number of losing stocks")
+        void returnsAllLosersWhenLimitExceedsNumberLoserCount() {
+            //Act
+            List<Stock> result = exchange.getLosers(100);
+            //Assert
+            assertEquals(1, result.size());
+            assertTrue(result.contains(loser));
+        }
     }
 
     @Nested


### PR DESCRIPTION
Adds edge case tests for getGainers() and getLosers() in Exchange. Tests verify that all qualifying stocks are returned when the limit exceeds the number of gaining or losing stocks.