### PR TITLE
test: add edge case and negative test for getNetWorth in Player

### DIFF
--- a/src/test/java/edu/ntnu/idatt2003/millions/model/PlayerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/PlayerTest.java
@@ -232,6 +232,20 @@ class PlayerTest {
             // Act & Assert
             assertEquals(0, player.getMoney().compareTo(player.getNetWorth()));
         }
+
+        @Test
+        @DisplayName("Should not retunr a value less than current money balance")
+        void returnsNotValueLessBalance() {
+            //Arrange
+            Stock stock = new Stock("DCL", "Dara, Inc",
+                    new ArrayList<>(List.of(new BigDecimal("1000.00"))));
+            Share share = new Share(stock, new BigDecimal("10"), new BigDecimal("700.00"));
+            player.getPortfolio().addShare(share);
+            //Act
+            BigDecimal result = player.getNetWorth();
+            //Assert
+            assertTrue(result.compareTo(player.getMoney()) >= 0);
+        }
     }
 
     @Nested


### PR DESCRIPTION
Adds unit tests for getNetWorth() in Player. Tests cover empty portfolio, portfolio with shares, after money withdrawal, and after share removal. Negative test verifies that net worth is never less than the player's current cash balance.