### PR TITLE
refactor: replace setCommitted with a protected method

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/Purchase.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/Purchase.java
@@ -44,6 +44,6 @@ public class Purchase extends Transaction {
         player.getPortfolio().addShare(getShare());
         player.getTransactionArchive().add(this);
 
-        setCommitted(true);
+        markAsCommitted();
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/Sale.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/Sale.java
@@ -44,6 +44,6 @@ public class Sale extends Transaction {
         player.addMoney(totalValue);
         player.getPortfolio().removeShare(getShare());
         player.getTransactionArchive().add(this);
-        setCommitted(true);
+        markAsCommitted();
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/Transaction.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/Transaction.java
@@ -84,12 +84,10 @@ public abstract class Transaction {
     }
 
     /**
-     * Sets whether this transaction has been committed.
-     *
-     * @param committed {@code true} to mark the transaction as committed, {@code false} otherwise
+     * Marks this transactionn as committed.
      */
-    public void setCommitted(boolean committed) {
-        this.committed = committed;
+    protected void markAsCommitted() {
+        this.committed = true;
     }
 
     /**


### PR DESCRIPTION
setCommitted(boolean) was public and accepted a parameter that was
always true, making it both a security risk and a code smell.

Replaced with a protected markAsCommitted() method with no parameter.
This ensures only Purchase and Sale can mark a transaction as committed,
and only as part of a real commit.

Changes:
- Transaction: replaced setCommitted(boolean) with protected markAsCommitted()
- Purchase: updated to call markAsCommitted()
- Sale: updated to call markAsCommitted()
- Updated JavaDoc accordingly