### PR TITLE
Feat/portfolio view

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/DashboardController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/DashboardController.java
@@ -1,0 +1,33 @@
+package edu.ntnu.idatt2003.millions.controller;
+
+import edu.ntnu.idatt2003.millions.manager.GameManager;
+import edu.ntnu.idatt2003.millions.view.dashboard.DashboardView;
+
+/**
+ * Controller for the dashboard view.
+ * Binds tab buttons to their corresponding content views.
+ */
+public class DashboardController {
+
+    private final DashboardView view;
+    private final GameManager gameManager;
+
+    /**
+     * Constructs a new DashboardController and binds tab events.
+     *
+     * @param view        the dashboard view to control
+     * @param gameManager the game manager containing player and exchange
+     */
+    public DashboardController(DashboardView view, GameManager gameManager) {
+        this.view = view;
+        this.gameManager = gameManager;
+        bindEvents();
+    }
+
+    private void bindEvents() {
+        view.getPortfolioButton().setOnAction(e -> view.showPortfolio());
+        view.getTransactionsButton().setOnAction(e -> view.showTransactions());
+        view.getWatchlistButton().setOnAction(e -> view.showWatchlist());
+        view.getLoansButton().setOnAction(e -> view.showLoans());
+    }
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/manager/GameManager.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/manager/GameManager.java
@@ -26,6 +26,7 @@ public class GameManager {
     private Exchange exchange;
     private final GameFileHandler gameFileHandler;
     private final List<GameObserver> observers = new ArrayList<>();
+    private BigDecimal previousNetWorth;
 
     /**
      * Constructs a new GameManager.
@@ -90,8 +91,11 @@ public class GameManager {
 
     /**
      * Advances the game by one week and notifies all registered observers.
+     * Stores the player's current net worth before advancing so that
+     * weekly change can be calculated after the week has passed.
      */
     public void advanceWeek() {
+        previousNetWorth = player.getNetWorth();
         exchange.advance();
         notifyObservers();
     }
@@ -112,6 +116,16 @@ public class GameManager {
      */
     public Exchange getExchange() {
         return exchange;
+    }
+
+    /**
+     * Returns the player's net worth from before the last week advance.
+     * Returns null if the week has not been advanced yet.
+     *
+     * @return the previous net worth, or null if not yet available
+     */
+    public BigDecimal getPreviousNetWorth() {
+        return previousNetWorth;
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/manager/GameManager.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/manager/GameManager.java
@@ -91,12 +91,14 @@ public class GameManager {
 
     /**
      * Advances the game by one week and notifies all registered observers.
-     * Stores the player's current net worth before advancing so that
-     * weekly change can be calculated after the week has passed.
+     * Records the player's current net worth before advancing so that
+     * weekly change and historical net worth data are available after
+     * the week has passed.
      */
     public void advanceWeek() {
         player.setPreviousNetWorth(player.getNetWorth());
         exchange.advance();
+        player.recordNetWorth();
         notifyObservers();
     }
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/manager/GameManager.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/manager/GameManager.java
@@ -95,7 +95,7 @@ public class GameManager {
      * weekly change can be calculated after the week has passed.
      */
     public void advanceWeek() {
-        previousNetWorth = player.getNetWorth();
+        player.setPreviousNetWorth(player.getNetWorth());
         exchange.advance();
         notifyObservers();
     }
@@ -125,7 +125,7 @@ public class GameManager {
      * @return the previous net worth, or null if not yet available
      */
     public BigDecimal getPreviousNetWorth() {
-        return previousNetWorth;
+        return player.getPreviousNetWorth();
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/player/Player.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/player/Player.java
@@ -18,6 +18,8 @@ public class Player {
     private final Portfolio portfolio;
     private final TransactionArchive transactionArchive;
 
+    private BigDecimal previousNetWorth;
+
     /**
      * Constructs a new Player with the specified name and starting balance.
      *
@@ -146,5 +148,13 @@ public class Player {
         } else {
             return PlayerStatusLevel.NOVICE;
         }
+    }
+
+    public BigDecimal getPreviousNetWorth() {
+        return previousNetWorth;
+    }
+
+    public void setPreviousNetWorth(BigDecimal previousNetWorth) {
+        this.previousNetWorth = previousNetWorth;
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/player/Player.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/player/Player.java
@@ -150,10 +150,23 @@ public class Player {
         }
     }
 
+    /**
+     * Returns the player's net worth from before the last week advance.
+     * Returns null if no week has been advanced yet.
+     *
+     * @return the previous net worth, or null if not yet available
+     */
     public BigDecimal getPreviousNetWorth() {
         return previousNetWorth;
     }
 
+    /**
+     * Sets the player's previous net worth.
+     * Called by {@link edu.ntnu.idatt2003.millions.manager.GameManager}
+     * before advancing the week.
+     *
+     * @param previousNetWorth the net worth to store
+     */
     public void setPreviousNetWorth(BigDecimal previousNetWorth) {
         this.previousNetWorth = previousNetWorth;
     }

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/player/Player.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/player/Player.java
@@ -3,6 +3,8 @@ package edu.ntnu.idatt2003.millions.model.player;
 import edu.ntnu.idatt2003.millions.model.transaction.TransactionArchive;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -19,6 +21,7 @@ public class Player {
     private final TransactionArchive transactionArchive;
 
     private BigDecimal previousNetWorth;
+    private List<BigDecimal> netWorthHistory;
 
     /**
      * Constructs a new Player with the specified name and starting balance.
@@ -41,6 +44,9 @@ public class Player {
 
         this.portfolio = new Portfolio();
         this.transactionArchive = new TransactionArchive();
+
+        this.netWorthHistory = new ArrayList<>();
+        netWorthHistory.add(startingMoney);
     }
 
     /**
@@ -122,6 +128,49 @@ public class Player {
         return money.add(portfolio.getNetWorth());
     }
 
+    /**
+     * Records the player's current net worth in the history.
+     * Called by {@link edu.ntnu.idatt2003.millions.manager.GameManager}
+     * before advancing the week.
+     */
+    public void recordNetWorth() {
+        if (netWorthHistory == null) netWorthHistory = new ArrayList<>();
+        netWorthHistory.add(getNetWorth());
+    }
+
+    /**
+     * Returns a list of all recorded net worth values over time.
+     * Each entry corresponds to the net worth at the end of a week.
+     * Returns an empty list if no history has been recorded yet.
+     *
+     * @return a copy of the net worth history
+     */
+    public List<BigDecimal> getNetWorthHistory() {
+        if (netWorthHistory == null) return List.of();
+        return new ArrayList<>(netWorthHistory);
+    }
+
+    /**
+     * Returns the player's net worth from before the last week advance.
+     * Returns null if no week has been advanced yet.
+     *
+     * @return the previous net worth, or null if not yet available
+     */
+    public BigDecimal getPreviousNetWorth() {
+        return previousNetWorth;
+    }
+
+    /**
+     * Sets the player's previous net worth.
+     * Called by {@link edu.ntnu.idatt2003.millions.manager.GameManager}
+     * before advancing the week.
+     *
+     * @param previousNetWorth the net worth to store
+     */
+    public void setPreviousNetWorth(BigDecimal previousNetWorth) {
+        this.previousNetWorth = previousNetWorth;
+    }
+
     /***
      * Returns the players current status based on net worth growth and number of weeks with active
      * trading.
@@ -148,26 +197,5 @@ public class Player {
         } else {
             return PlayerStatusLevel.NOVICE;
         }
-    }
-
-    /**
-     * Returns the player's net worth from before the last week advance.
-     * Returns null if no week has been advanced yet.
-     *
-     * @return the previous net worth, or null if not yet available
-     */
-    public BigDecimal getPreviousNetWorth() {
-        return previousNetWorth;
-    }
-
-    /**
-     * Sets the player's previous net worth.
-     * Called by {@link edu.ntnu.idatt2003.millions.manager.GameManager}
-     * before advancing the week.
-     *
-     * @param previousNetWorth the net worth to store
-     */
-    public void setPreviousNetWorth(BigDecimal previousNetWorth) {
-        this.previousNetWorth = previousNetWorth;
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/player/PlayerStatusLevel.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/player/PlayerStatusLevel.java
@@ -15,5 +15,15 @@ package edu.ntnu.idatt2003.millions.model.player;
 public enum PlayerStatusLevel {
     NOVICE,
     INVESTOR,
-    SPECULATOR
+    SPECULATOR;
+
+    /**
+     * Returns the i18n key for this status level.
+     * Used to retrieve the localized display name from the resource bundle.
+     *
+     * @return the i18n key, e.g. "status.novice"
+     */
+    public String getI18nKey() {
+        return "status." + name().toLowerCase();
+    }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/stock/Stock.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/stock/Stock.java
@@ -2,6 +2,7 @@ package edu.ntnu.idatt2003.millions.model.stock;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Currency;
 import java.util.List;
 import java.util.Objects;
 
@@ -15,21 +16,26 @@ public class Stock {
     private final String company;
     private final List<BigDecimal> prices;
 
+    private final Currency currency;
+
     /**
      * Constructs a new Stock with the specified symbol, company name, and price history.
      *
      * @param symbol  the stock's trading symbol (e.g., "AAPL")
      * @param company the company name (e.g., "Apple Inc.")
      * @param prices  the list of historical prices
-     * @throws NullPointerException     if the symbol, company, or prices is null
+     * @param currency the currency the stock is traded in (e.g., USD)
+     * @throws NullPointerException     if the symbol, company, prices or currency is null
      * @throws IllegalArgumentException if the symbol is blank
      * @throws IllegalArgumentException if the company is blank
      * @throws IllegalArgumentException if the list of prices is empty
      */
-    public Stock(String symbol, String company, List<BigDecimal> prices) {
+    public Stock(String symbol, String company, List<BigDecimal> prices, Currency currency) {
         Objects.requireNonNull(symbol, "Symbol cannot be null");
         Objects.requireNonNull(company, "Company cannot be null");
         Objects.requireNonNull(prices, "Prices cannot be null");
+        Objects.requireNonNull(currency, "Currency cannot be null");
+
         if (symbol.isBlank()) {
             throw new IllegalArgumentException("Symbol cannot be blank");
         }
@@ -43,6 +49,24 @@ public class Stock {
         this.symbol = symbol;
         this.company = company;
         this.prices = prices;
+        this.currency = currency;
+    }
+
+
+    /**
+     * Constructs a new Stock with the specified symbol, company name, and price history.
+     * Defaults to USD as the currency.
+     *
+     * @param symbol  the stock's trading symbol (e.g., "AAPL")
+     * @param company the company name (e.g., "Apple Inc.")
+     * @param prices  the list of historical prices
+     * @throws NullPointerException     if the symbol, company, or prices is null
+     * @throws IllegalArgumentException if the symbol is blank
+     * @throws IllegalArgumentException if the company is blank
+     * @throws IllegalArgumentException if the list of prices is empty
+     */
+    public Stock(String symbol, String company, List<BigDecimal> prices) {
+        this(symbol, company, prices, Currency.getInstance("USD"));
     }
 
     /**
@@ -71,6 +95,15 @@ public class Stock {
 
     public BigDecimal getSalesPrice() {
         return prices.getLast();
+    }
+
+    /**
+     * Returns the currency the stock is traded in.
+     *
+     * @return the currency
+     */
+    public Currency getCurrency() {
+        return currency;
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/util/CurrencyFormatter.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/util/CurrencyFormatter.java
@@ -1,0 +1,33 @@
+package edu.ntnu.idatt2003.millions.util;
+
+import java.math.BigDecimal;
+import java.text.NumberFormat;
+import java.util.Locale;
+
+/**
+ * Utility class for formatting monetary values.
+ */
+public class CurrencyFormatter {
+
+    private static final NumberFormat FORMAT;
+
+    static {
+        FORMAT = NumberFormat.getNumberInstance(Locale.of("no"));
+        FORMAT.setMinimumFractionDigits(2);
+        FORMAT.setMaximumFractionDigits(2);
+    }
+
+    private CurrencyFormatter() {
+        // Utility class - should not be instantiated
+    }
+
+    /**
+     * Formats the given amount as a NOK string.
+     *
+     * @param amount the amount to format
+     * @return the formatted string, e.g. "5 000,00 NOK"
+     */
+    public static String format(BigDecimal amount) {
+        return FORMAT.format(amount) + " NOK";
+    }
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/Card.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/Card.java
@@ -2,6 +2,7 @@ package edu.ntnu.idatt2003.millions.view.component;
 
 import edu.ntnu.idatt2003.millions.manager.GameManager;
 import edu.ntnu.idatt2003.millions.observer.GameObserver;
+import edu.ntnu.idatt2003.millions.util.LanguageManager;
 import javafx.scene.layout.VBox;
 
 /**
@@ -19,7 +20,14 @@ public abstract class Card extends VBox implements GameObserver {
     protected Card(GameManager gameManager) {
         getStyleClass().add("card");
         gameManager.addObserver(this);
+        LanguageManager.addObserver(this::onLanguageChanged);
     }
+
+    /**
+     * Called when the language changes.
+     * Subclasses must implement this to update their displayed text.
+     */
+    protected abstract void onLanguageChanged();
 
     /**
      * Called when the game state has changed.

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/Card.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/Card.java
@@ -1,0 +1,30 @@
+package edu.ntnu.idatt2003.millions.view.component;
+
+import edu.ntnu.idatt2003.millions.manager.GameManager;
+import edu.ntnu.idatt2003.millions.observer.GameObserver;
+import javafx.scene.layout.VBox;
+
+/**
+ * Abstract base class for all card components in the application.
+ * Provides consistent styling and registers itself as a {@link GameObserver}
+ * so subclasses can react to game state changes.
+ */
+public abstract class Card extends VBox implements GameObserver {
+
+    /**
+     * Constructs a new Card and registers itself as a game observer.
+     *
+     * @param gameManager the game manager to observe
+     */
+    protected Card(GameManager gameManager) {
+        getStyleClass().add("card");
+        gameManager.addObserver(this);
+    }
+
+    /**
+     * Called when the game state has changed.
+     * Subclasses must implement this to update their displayed data.
+     */
+    @Override
+    public abstract void onGameUpdated();
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/ViewHeader.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/ViewHeader.java
@@ -99,4 +99,14 @@ public class ViewHeader extends VBox {
             ((Button) buttons.get(i)).setText(LanguageManager.get(labelKeys.get(i)));
         }
     }
+
+    /**
+     * Returns the tab button at the given index.
+     *
+     * @param index the zero-based index of the tab button
+     * @return the tab button at the given index
+     */
+    public Button getTabButton(int index) {
+        return (Button) tabBar.getChildren().get(index);
+    }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/WeekBar.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/WeekBar.java
@@ -39,6 +39,18 @@ public class WeekBar extends HBox implements GameObserver {
         advanceButton.getStyleClass().add("advance-button");
 
         getChildren().addAll(weekLabel, advanceButton);
+
+        LanguageManager.addObserver(this::onLanguageChanged);
+    }
+
+    /**
+     * Updates text elements to the current language.
+     * Called automatically when the language changes.
+     */
+    private void onLanguageChanged() {
+        advanceButton.setText(LanguageManager.get("app.advanceWeek"));
+        weekLabel.setText(LanguageManager.get("app.week") + " "
+                + gameManager.getExchange().getWeek());
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/DashboardView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/DashboardView.java
@@ -3,6 +3,9 @@ package edu.ntnu.idatt2003.millions.view.dashboard;
 import edu.ntnu.idatt2003.millions.manager.GameManager;
 import edu.ntnu.idatt2003.millions.view.component.ViewHeader;
 import edu.ntnu.idatt2003.millions.view.component.WeekBar;
+import edu.ntnu.idatt2003.millions.view.dashboard.portfolio.PortfolioView;
+import javafx.scene.control.Button;
+import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 
 import java.util.List;
@@ -15,6 +18,8 @@ import java.util.List;
 public class DashboardView extends VBox {
 
     private final GameManager gameManager;
+    private final ViewHeader viewHeader;
+    private final VBox contentArea;
 
     /**
      * Constructs a new DashboardView with a tab bar.
@@ -23,7 +28,7 @@ public class DashboardView extends VBox {
         this.gameManager = gameManager;
         getStyleClass().add("content-area");
 
-        ViewHeader viewHeader = new ViewHeader(
+        viewHeader = new ViewHeader(
                 "dashboard.title",
                 List.of(
                         "dashboard.tab.portfolio",
@@ -33,6 +38,43 @@ public class DashboardView extends VBox {
                 ),
                 weekBar
         );
-        getChildren().add(viewHeader);
+
+        contentArea = new VBox();
+        VBox.setVgrow(contentArea, Priority.ALWAYS);
+
+        getChildren().addAll(viewHeader, contentArea);
+        showPortfolio();
+    }
+
+    public Button getPortfolioButton() {
+        return viewHeader.getTabButton(0);
+    }
+
+    public Button getTransactionsButton() {
+        return viewHeader.getTabButton(1);
+    }
+
+    public Button getWatchlistButton() {
+        return viewHeader.getTabButton(2);
+    }
+
+    public Button getLoansButton() {
+        return viewHeader.getTabButton(3);
+    }
+
+    public void showPortfolio() {
+        contentArea.getChildren().setAll(new PortfolioView(gameManager));
+    }
+
+    public void showTransactions() {
+        //contentArea.getChildren().setAll(new TransactionsView(gameManager));
+    }
+
+    public void showWatchlist() {
+        //contentArea.getChildren().setAll(new WatchlistView(gameManager));
+    }
+
+    public void showLoans() {
+        //contentArea.getChildren().setAll(new LoansView(gameManager));
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/PortfolioView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/PortfolioView.java
@@ -1,0 +1,38 @@
+package edu.ntnu.idatt2003.millions.view.dashboard.portfolio;
+
+import edu.ntnu.idatt2003.millions.manager.GameManager;
+import edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card.WeeklyChangeCard;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.VBox;
+
+/**
+ * The portfolio tab view displayed under the dashboard.
+ * Shows net worth with chart, weekly performance, available funds,
+ * portfolio value and player status.
+ */
+public class PortfolioView extends HBox {
+
+    private final GameManager gameManager;
+
+    /**
+     * Constructs a new PortfolioView.
+     *
+     * @param gameManager the game manager containing player and exchange
+     */
+    public PortfolioView(GameManager gameManager) {
+        this.gameManager = gameManager;
+
+        setSpacing(16);
+
+        WeeklyChangeCard weeklyChangeCard = new WeeklyChangeCard(gameManager);
+
+
+        VBox rightCards = new VBox(12,
+                weeklyChangeCard
+        );
+        rightCards.setMinWidth(220);
+        rightCards.setMaxWidth(260);
+
+        getChildren().addAll(rightCards);
+    }
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/PortfolioView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/PortfolioView.java
@@ -1,11 +1,9 @@
 package edu.ntnu.idatt2003.millions.view.dashboard.portfolio;
 
 import edu.ntnu.idatt2003.millions.manager.GameManager;
-import edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card.AvailableFundsCard;
-import edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card.PortfolioValueCard;
-import edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card.StatusCard;
-import edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card.WeeklyChangeCard;
+import edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card.*;
 import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 
 /**
@@ -24,24 +22,23 @@ public class PortfolioView extends HBox {
      */
     public PortfolioView(GameManager gameManager) {
         this.gameManager = gameManager;
-
         setSpacing(16);
 
-        WeeklyChangeCard weeklyChangeCard = new WeeklyChangeCard(gameManager);
-        AvailableFundsCard availableFundsCard = new AvailableFundsCard(gameManager);
-        PortfolioValueCard portfolioValueCard = new PortfolioValueCard(gameManager);
-        StatusCard statusCard = new StatusCard(gameManager);
-
+        NetWorthCard netWorthCard = new NetWorthCard(gameManager);
+        HBox.setHgrow(netWorthCard, Priority.ALWAYS);
 
         VBox rightCards = new VBox(12,
-                weeklyChangeCard,
-                availableFundsCard,
-                portfolioValueCard,
-                statusCard
+                new WeeklyChangeCard(gameManager),
+                new AvailableFundsCard(gameManager),
+                new PortfolioValueCard(gameManager),
+                new StatusCard(gameManager)
         );
         rightCards.setMinWidth(220);
         rightCards.setMaxWidth(260);
 
-        getChildren().addAll(rightCards);
+        netWorthCard.prefHeightProperty().bind(rightCards.heightProperty());
+        netWorthCard.maxHeightProperty().bind(rightCards.heightProperty());
+
+        getChildren().addAll(netWorthCard, rightCards);
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/PortfolioView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/PortfolioView.java
@@ -3,6 +3,7 @@ package edu.ntnu.idatt2003.millions.view.dashboard.portfolio;
 import edu.ntnu.idatt2003.millions.manager.GameManager;
 import edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card.AvailableFundsCard;
 import edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card.PortfolioValueCard;
+import edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card.StatusCard;
 import edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card.WeeklyChangeCard;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
@@ -29,12 +30,14 @@ public class PortfolioView extends HBox {
         WeeklyChangeCard weeklyChangeCard = new WeeklyChangeCard(gameManager);
         AvailableFundsCard availableFundsCard = new AvailableFundsCard(gameManager);
         PortfolioValueCard portfolioValueCard = new PortfolioValueCard(gameManager);
+        StatusCard statusCard = new StatusCard(gameManager);
 
 
         VBox rightCards = new VBox(12,
                 weeklyChangeCard,
                 availableFundsCard,
-                portfolioValueCard
+                portfolioValueCard,
+                statusCard
         );
         rightCards.setMinWidth(220);
         rightCards.setMaxWidth(260);

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/PortfolioView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/PortfolioView.java
@@ -1,6 +1,7 @@
 package edu.ntnu.idatt2003.millions.view.dashboard.portfolio;
 
 import edu.ntnu.idatt2003.millions.manager.GameManager;
+import edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card.AvailableFundsCard;
 import edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card.WeeklyChangeCard;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
@@ -25,10 +26,12 @@ public class PortfolioView extends HBox {
         setSpacing(16);
 
         WeeklyChangeCard weeklyChangeCard = new WeeklyChangeCard(gameManager);
+        AvailableFundsCard availableFundsCard = new AvailableFundsCard(gameManager);
 
 
         VBox rightCards = new VBox(12,
-                weeklyChangeCard
+                weeklyChangeCard,
+                availableFundsCard
         );
         rightCards.setMinWidth(220);
         rightCards.setMaxWidth(260);

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/PortfolioView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/PortfolioView.java
@@ -2,6 +2,7 @@ package edu.ntnu.idatt2003.millions.view.dashboard.portfolio;
 
 import edu.ntnu.idatt2003.millions.manager.GameManager;
 import edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card.AvailableFundsCard;
+import edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card.PortfolioValueCard;
 import edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card.WeeklyChangeCard;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
@@ -27,11 +28,13 @@ public class PortfolioView extends HBox {
 
         WeeklyChangeCard weeklyChangeCard = new WeeklyChangeCard(gameManager);
         AvailableFundsCard availableFundsCard = new AvailableFundsCard(gameManager);
+        PortfolioValueCard portfolioValueCard = new PortfolioValueCard(gameManager);
 
 
         VBox rightCards = new VBox(12,
                 weeklyChangeCard,
-                availableFundsCard
+                availableFundsCard,
+                portfolioValueCard
         );
         rightCards.setMinWidth(220);
         rightCards.setMaxWidth(260);

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/AvailableFundsCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/AvailableFundsCard.java
@@ -13,6 +13,7 @@ public class AvailableFundsCard extends Card {
 
     private final GameManager gameManager;
     private final Label valueLabel;
+    private final Label titleLabel;
 
     /**
      * Constructs a new AvailableFundsCard and initializes the display.
@@ -24,7 +25,7 @@ public class AvailableFundsCard extends Card {
         this.gameManager = gameManager;
         setSpacing(4);
 
-        Label titleLabel = new Label(LanguageManager.get("dashboard.availableFunds"));
+        titleLabel = new Label(LanguageManager.get("dashboard.availableFunds"));
         titleLabel.getStyleClass().add("card-label");
 
         valueLabel = new Label();
@@ -33,6 +34,14 @@ public class AvailableFundsCard extends Card {
         getChildren().addAll(titleLabel, valueLabel);
 
         valueLabel.setText(CurrencyFormatter.format(gameManager.getPlayer().getMoney()));
+    }
+
+    /**
+     * Updates the title label to the current language.
+     */
+    @Override
+    protected void onLanguageChanged() {
+        titleLabel.setText(LanguageManager.get("dashboard.availableFunds"));
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/AvailableFundsCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/AvailableFundsCard.java
@@ -1,0 +1,4 @@
+package edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card;
+
+public class AvailableFundsCard {
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/AvailableFundsCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/AvailableFundsCard.java
@@ -1,4 +1,46 @@
 package edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card;
 
-public class AvailableFundsCard {
+import edu.ntnu.idatt2003.millions.manager.GameManager;
+import edu.ntnu.idatt2003.millions.util.CurrencyFormatter;
+import edu.ntnu.idatt2003.millions.util.LanguageManager;
+import edu.ntnu.idatt2003.millions.view.component.Card;
+import javafx.scene.control.Label;
+
+/**
+ * Card displaying the player's currently available funds for trading.
+ */
+public class AvailableFundsCard extends Card {
+
+    private final GameManager gameManager;
+    private final Label valueLabel;
+
+    /**
+     * Constructs a new AvailableFundsCard and initializes the display.
+     *
+     * @param gameManager the game manager containing player and exchange
+     */
+    public AvailableFundsCard(GameManager gameManager) {
+        super(gameManager);
+        this.gameManager = gameManager;
+        setSpacing(4);
+
+        Label titleLabel = new Label(LanguageManager.get("dashboard.availableFunds"));
+        titleLabel.getStyleClass().add("card-label");
+
+        valueLabel = new Label();
+        valueLabel.getStyleClass().add("card-value");
+
+        getChildren().addAll(titleLabel, valueLabel);
+
+        valueLabel.setText(CurrencyFormatter.format(gameManager.getPlayer().getMoney()));
+    }
+
+    /**
+     * Called when the game state has changed.
+     * Refreshes the displayed available funds.
+     */
+    @Override
+    public void onGameUpdated() {
+        valueLabel.setText(CurrencyFormatter.format(gameManager.getPlayer().getMoney()));
+    }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/NetWorthCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/NetWorthCard.java
@@ -1,4 +1,151 @@
 package edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card;
 
-public class NetWorthCard {
+import edu.ntnu.idatt2003.millions.manager.GameManager;
+import edu.ntnu.idatt2003.millions.util.CurrencyFormatter;
+import edu.ntnu.idatt2003.millions.util.LanguageManager;
+import edu.ntnu.idatt2003.millions.view.component.Card;
+import javafx.collections.ListChangeListener;
+import javafx.scene.chart.AreaChart;
+import javafx.scene.chart.NumberAxis;
+import javafx.scene.chart.XYChart;
+import javafx.scene.control.Label;
+import javafx.util.StringConverter;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Card displaying the player's net worth over time as an area chart.
+ * Also shows total change in value and percentage since the start of the game.
+ */
+public class NetWorthCard extends Card {
+
+    private final GameManager gameManager;
+    private final Label titleLabel;
+    private final Label netWorthLabel;
+    private final Label changeLabel;
+    private final NumberAxis xAxis;
+    private final XYChart.Series<Number, Number> series;
+
+    /**
+     * Constructs a new NetWorthCard and initializes the display.
+     *
+     * @param gameManager the game manager containing player and exchange
+     */
+    public NetWorthCard(GameManager gameManager) {
+        super(gameManager);
+        this.gameManager = gameManager;
+        setSpacing(4);
+
+        titleLabel = new Label(LanguageManager.get("dashboard.netWorth"));
+        titleLabel.getStyleClass().add("card-label");
+
+        netWorthLabel = new Label();
+        netWorthLabel.getStyleClass().add("card-value");
+
+        changeLabel = new Label();
+
+        List<BigDecimal> history = gameManager.getPlayer().getNetWorthHistory();
+        int historySize = history.size();
+
+        xAxis = new NumberAxis(1, Math.max(historySize, 1), Math.max(1, historySize / 8));
+        xAxis.setAutoRanging(false);
+        xAxis.setLabel(LanguageManager.get("app.week"));
+
+        NumberAxis yAxis = new NumberAxis();
+        yAxis.setAutoRanging(true);
+        yAxis.setForceZeroInRange(false);
+        yAxis.setTickLabelFormatter(new StringConverter<>() {
+            @Override
+            public String toString(Number n) {
+                return String.format(Locale.of("no"), "%,.0f", n.doubleValue());
+            }
+            @Override
+            public Number fromString(String s) { return null; }
+        });
+
+        series = new XYChart.Series<>();
+
+        series.getData().addListener((ListChangeListener<XYChart.Data<Number, Number>>) change -> {
+            while (change.next()) {
+                change.getAddedSubList().forEach(d -> {
+                    if (d.getNode() != null) d.getNode().setVisible(false);
+                });
+            }
+        });
+
+        AreaChart<Number, Number> chart = new AreaChart<>(xAxis, yAxis);
+        chart.getData().add(series);
+        chart.setLegendVisible(false);
+        chart.setAnimated(false);
+        chart.getStyleClass().add("area-chart");
+
+        getChildren().addAll(titleLabel, netWorthLabel, changeLabel, chart);
+
+        loadHistory();
+        updateDisplay();
+    }
+
+    /**
+     * Loads existing net worth history into the chart.
+     * Called once at construction to populate the chart with historical data.
+     */
+    private void loadHistory() {
+        List<BigDecimal> history = gameManager.getPlayer().getNetWorthHistory();
+        for (int i = 0; i < history.size(); i++) {
+            series.getData().add(new XYChart.Data<>(i + 1, history.get(i).doubleValue()));
+        }
+    }
+
+    /**
+     * Updates the net worth label and change label with current values.
+     */
+    private void updateDisplay() {
+        BigDecimal netWorth = gameManager.getPlayer().getNetWorth();
+        BigDecimal startingMoney = gameManager.getPlayer().getStartingMoney();
+        BigDecimal change = netWorth.subtract(startingMoney);
+        BigDecimal percentChange = change
+                .divide(startingMoney, 4, RoundingMode.HALF_UP)
+                .multiply(BigDecimal.valueOf(100))
+                .setScale(1, RoundingMode.HALF_UP);
+
+        String sign = change.compareTo(BigDecimal.ZERO) >= 0 ? "+" : "";
+        String formattedPercent = String.format(Locale.of("no"), "%.1f", percentChange);
+
+        netWorthLabel.setText(CurrencyFormatter.format(netWorth));
+        changeLabel.setText(sign + CurrencyFormatter.format(change.abs())
+                + "  " + sign + formattedPercent + "% "
+                + LanguageManager.get("dashboard.sinceStart"));
+
+        changeLabel.getStyleClass().removeAll("card-value-positive", "card-value-negative");
+        changeLabel.getStyleClass().add(
+                change.compareTo(BigDecimal.ZERO) >= 0 ? "card-value-positive" : "card-value-negative"
+        );
+    }
+
+    /**
+     * Updates the title label to the current language.
+     * Also refreshes the display in case number formatting changes.
+     */
+    @Override
+    protected void onLanguageChanged() {
+        titleLabel.setText(LanguageManager.get("dashboard.netWorth"));
+        updateDisplay();
+    }
+
+    /**
+     * Called when the game state has changed.
+     * Adds a new data point to the chart, extends the x-axis and refreshes the display.
+     */
+    @Override
+    public void onGameUpdated() {
+        int nextPoint = series.getData().size() + 1;
+        double netWorth = gameManager.getPlayer().getNetWorth().doubleValue();
+        series.getData().add(new XYChart.Data<>(nextPoint, netWorth));
+        xAxis.setUpperBound(nextPoint);
+        xAxis.setTickUnit(Math.max(1, nextPoint / 8));
+        updateDisplay();
+    }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/NetWorthCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/NetWorthCard.java
@@ -1,0 +1,4 @@
+package edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card;
+
+public class NetWorthCard {
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/PortfolioValueCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/PortfolioValueCard.java
@@ -1,4 +1,56 @@
 package edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card;
 
-public class PortfolioValueCard {
+import edu.ntnu.idatt2003.millions.manager.GameManager;
+import edu.ntnu.idatt2003.millions.util.CurrencyFormatter;
+import edu.ntnu.idatt2003.millions.util.LanguageManager;
+import edu.ntnu.idatt2003.millions.view.component.Card;
+import javafx.scene.control.Label;
+
+/**
+ * Card displaying the total value of the player's portfolio.
+ */
+public class PortfolioValueCard extends Card {
+
+    private final GameManager gameManager;
+    private final Label titleLabel;
+    private final Label valueLabel;
+
+    /**
+     * Constructs a new PortfolioValueCard and initializes the display.
+     *
+     * @param gameManager the game manager containing player and exchange
+     */
+    public PortfolioValueCard(GameManager gameManager) {
+        super(gameManager);
+        this.gameManager = gameManager;
+        setSpacing(4);
+
+        titleLabel = new Label(LanguageManager.get("dashboard.portfolioValue"));
+        titleLabel.getStyleClass().add("card-label");
+
+        valueLabel = new Label();
+        valueLabel.getStyleClass().add("card-value");
+
+        getChildren().addAll(titleLabel, valueLabel);
+
+        valueLabel.setText(CurrencyFormatter.format(
+                gameManager.getPlayer().getPortfolio().getNetWorth()));
+    }
+
+    /**
+     * Updates the title label to the current language.
+     */
+    @Override
+    protected void onLanguageChanged() {
+        titleLabel.setText(LanguageManager.get("dashboard.portfolioValue"));
+    }
+
+    /**
+     * Called when the game state has changed.
+     * Refreshes the displayed portfolio value.
+     */
+    @Override
+    public void onGameUpdated() {
+        valueLabel.setText(CurrencyFormatter.format(gameManager.getPlayer().getPortfolio().getNetWorth()));
+    }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/PortfolioValueCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/PortfolioValueCard.java
@@ -1,0 +1,4 @@
+package edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card;
+
+public class PortfolioValueCard {
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/StatusCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/StatusCard.java
@@ -1,0 +1,4 @@
+package edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card;
+
+public class StatusCard {
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/StatusCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/StatusCard.java
@@ -1,4 +1,58 @@
 package edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card;
 
-public class StatusCard {
+import edu.ntnu.idatt2003.millions.manager.GameManager;
+import edu.ntnu.idatt2003.millions.util.LanguageManager;
+import edu.ntnu.idatt2003.millions.view.component.Card;
+import javafx.scene.control.Label;
+
+/**
+ * Card displaying the player's current status level.
+ */
+public class StatusCard extends Card {
+
+    private final GameManager gameManager;
+    private final Label titleLabel;
+    private final Label valueLabel;
+
+    /**
+     * Constructs a new StatusCard and initializes the display.
+     *
+     * @param gameManager the game manager containing player and exchange
+     */
+    public StatusCard(GameManager gameManager) {
+        super(gameManager);
+        this.gameManager = gameManager;
+        setSpacing(4);
+
+        titleLabel = new Label(LanguageManager.get("dashboard.status"));
+        titleLabel.getStyleClass().add("card-label");
+
+        valueLabel = new Label();
+        valueLabel.getStyleClass().add("card-value");
+
+        getChildren().addAll(titleLabel, valueLabel);
+
+        valueLabel.setText(LanguageManager.get(
+                gameManager.getPlayer().getStatus().getI18nKey()));
+    }
+
+    /**
+     * Updates all text elements to the current language.
+     */
+    @Override
+    protected void onLanguageChanged() {
+        titleLabel.setText(LanguageManager.get("dashboard.status"));
+        valueLabel.setText(LanguageManager.get(
+                gameManager.getPlayer().getStatus().getI18nKey()));
+    }
+
+    /**
+     * Called when the game state has changed.
+     * Refreshes the displayed status level.
+     */
+    @Override
+    public void onGameUpdated() {
+        valueLabel.setText(LanguageManager.get(
+                gameManager.getPlayer().getStatus().getI18nKey()));
+    }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/WeeklyChangeCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/WeeklyChangeCard.java
@@ -1,0 +1,79 @@
+package edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card;
+
+import edu.ntnu.idatt2003.millions.manager.GameManager;
+import edu.ntnu.idatt2003.millions.util.LanguageManager;
+import edu.ntnu.idatt2003.millions.view.component.Card;
+import javafx.scene.control.Label;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+/**
+ * Card displaying the player's net worth change for the current week.
+ * Shows percentage change and absolute change in NOK since last week.
+ * Displays a dash if no week has been advanced yet.
+ */
+public class WeeklyChangeCard extends Card {
+
+    private final GameManager gameManager;
+    private final Label changeLabel;
+
+    /**
+     * Constructs a new WeeklyChangeCard.
+     *
+     * @param gameManager the game manager containing player and exchange
+     */
+    public WeeklyChangeCard(GameManager gameManager) {
+        super(gameManager);
+        this.gameManager = gameManager;
+        setSpacing(4);
+
+        Label titleLabel = new Label(LanguageManager.get("dashboard.weeklyChange"));
+        titleLabel.getStyleClass().add("card-label");
+
+        changeLabel = new Label();
+        changeLabel.getStyleClass().add("card-value");
+
+        getChildren().addAll(titleLabel, changeLabel);
+
+        updateDisplay();
+    }
+
+    /**
+     * Updates the displayed week change based on the current and previous net worth.
+     * Shows a dash if no week has been advanced yet.
+     */
+    private void updateDisplay() {
+        BigDecimal previousNetWorth = gameManager.getPreviousNetWorth();
+        if (previousNetWorth == null) {
+            changeLabel.setText("–");
+            return;
+        }
+
+        BigDecimal currentNetWorth = gameManager.getPlayer().getNetWorth();
+        BigDecimal change = currentNetWorth.subtract(previousNetWorth);
+        BigDecimal percentChange = change
+                .divide(previousNetWorth, 4, RoundingMode.HALF_UP)
+                .multiply(BigDecimal.valueOf(100))
+                .setScale(1, RoundingMode.HALF_UP);
+
+        String arrow = change.compareTo(BigDecimal.ZERO) >= 0 ? "↗" : "↘";
+        String sign = change.compareTo(BigDecimal.ZERO) >= 0 ? "+" : "";
+
+        changeLabel.setText(arrow + " " + sign + percentChange + "%  "
+                + sign + change.setScale(2, RoundingMode.HALF_UP) + " NOK");
+        changeLabel.getStyleClass().removeAll("card-value-positive", "card-value-negative");
+        changeLabel.getStyleClass().add(
+                change.compareTo(BigDecimal.ZERO) >= 0 ? "card-value-positive" : "card-value-negative"
+        );
+    }
+
+    /**
+     * Called when the game state has changed.
+     * Refreshes the displayed week change.
+     */
+    @Override
+    public void onGameUpdated() {
+        updateDisplay();
+    }
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/WeeklyChangeCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/WeeklyChangeCard.java
@@ -19,6 +19,7 @@ public class WeeklyChangeCard extends Card {
 
     private final GameManager gameManager;
     private final Label changeLabel;
+    private final Label titleLabel;
 
     /**
      * Constructs a new WeeklyChangeCard.
@@ -30,7 +31,7 @@ public class WeeklyChangeCard extends Card {
         this.gameManager = gameManager;
         setSpacing(4);
 
-        Label titleLabel = new Label(LanguageManager.get("dashboard.weeklyChange"));
+        titleLabel = new Label(LanguageManager.get("dashboard.weeklyChange"));
         titleLabel.getStyleClass().add("card-label");
 
         changeLabel = new Label();
@@ -69,6 +70,16 @@ public class WeeklyChangeCard extends Card {
         changeLabel.getStyleClass().add(
                 change.compareTo(BigDecimal.ZERO) >= 0 ? "card-value-positive" : "card-value-negative"
         );
+    }
+
+    /**
+     * Updates the title label to the current language.
+     * Also refreshes the display in case number formatting changes.
+     */
+    @Override
+    protected void onLanguageChanged() {
+        titleLabel.setText(LanguageManager.get("dashboard.weeklyChange"));
+        updateDisplay();
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/WeeklyChangeCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/WeeklyChangeCard.java
@@ -1,12 +1,14 @@
 package edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card;
 
 import edu.ntnu.idatt2003.millions.manager.GameManager;
+import edu.ntnu.idatt2003.millions.util.CurrencyFormatter;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
 import edu.ntnu.idatt2003.millions.view.component.Card;
 import javafx.scene.control.Label;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.Locale;
 
 /**
  * Card displaying the player's net worth change for the current week.
@@ -60,8 +62,9 @@ public class WeeklyChangeCard extends Card {
         String arrow = change.compareTo(BigDecimal.ZERO) >= 0 ? "↗" : "↘";
         String sign = change.compareTo(BigDecimal.ZERO) >= 0 ? "+" : "";
 
-        changeLabel.setText(arrow + " " + sign + percentChange + "%  "
-                + sign + change.setScale(2, RoundingMode.HALF_UP) + " NOK");
+        String formattedPercent = String.format(Locale.of("no"), "%.1f", percentChange);
+        changeLabel.setText(arrow + " " + sign + formattedPercent + "%  "
+                + sign + CurrencyFormatter.format(change.abs()));
         changeLabel.getStyleClass().removeAll("card-value-positive", "card-value-negative");
         changeLabel.getStyleClass().add(
                 change.compareTo(BigDecimal.ZERO) >= 0 ? "card-value-positive" : "card-value-negative"

--- a/src/main/resources/css/style.css
+++ b/src/main/resources/css/style.css
@@ -114,3 +114,39 @@
     -fx-text-fill: #e74c3c;
     -fx-font-size: 16;
 }
+
+.area-chart {
+    -fx-background-color: transparent;
+}
+
+.area-chart .chart-plot-background {
+    -fx-background-color: transparent;
+}
+
+.area-chart .chart-vertical-grid-lines {
+    -fx-stroke: transparent;
+}
+
+.area-chart .chart-horizontal-grid-lines {
+    -fx-stroke: transparent;
+}
+
+.area-chart .chart-alternative-row-fill {
+    -fx-background-color: transparent;
+}
+
+.area-chart .chart-series-area-fill {
+    -fx-fill: rgba(41, 128, 185, 0.2);
+    -fx-stroke: transparent;
+}
+
+.area-chart .chart-series-area-line {
+    -fx-stroke: #2980b9;
+    -fx-stroke-width: 2;
+}
+
+.area-chart .chart-symbol {
+    -fx-background-color: transparent, transparent;
+    -fx-background-radius: 0;
+    -fx-padding: 0;
+}

--- a/src/main/resources/css/style.css
+++ b/src/main/resources/css/style.css
@@ -101,16 +101,16 @@
 }
 
 .card-value {
-    -fx-font-size: 22;
+    -fx-font-size: 20;
     -fx-font-weight: bold;
 }
 
 .card-value-positive {
     -fx-text-fill: #27ae60;
-    -fx-font-size: 13;
+    -fx-font-size: 16;
 }
 
 .card-value-negative {
     -fx-text-fill: #e74c3c;
-    -fx-font-size: 13;
+    -fx-font-size: 16;
 }

--- a/src/main/resources/css/style.css
+++ b/src/main/resources/css/style.css
@@ -87,3 +87,30 @@
 .advance-button:hover {
     -fx-background-color: #f5f5f5;
 }
+
+.card {
+    -fx-background-color: white;
+    -fx-background-radius: 12;
+    -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.06), 12, 0, 0, 2);
+    -fx-padding: 16;
+}
+
+.card-label {
+    -fx-font-size: 12;
+    -fx-text-fill: #888888;
+}
+
+.card-value {
+    -fx-font-size: 22;
+    -fx-font-weight: bold;
+}
+
+.card-value-positive {
+    -fx-text-fill: #27ae60;
+    -fx-font-size: 13;
+}
+
+.card-value-negative {
+    -fx-text-fill: #e74c3c;
+    -fx-font-size: 13;
+}

--- a/src/main/resources/css/style.css
+++ b/src/main/resources/css/style.css
@@ -101,7 +101,7 @@
 }
 
 .card-value {
-    -fx-font-size: 20;
+    -fx-font-size: 18;
     -fx-font-weight: bold;
 }
 

--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -63,3 +63,7 @@ exit.confirmContent=You can save the game before exiting.
 exit.saveAndExit=Save and exit
 exit.exitWithoutSaving=Exit without saving
 exit.cancel=Cancel
+# Player status
+status.novice=Novice
+status.investor=Investor
+status.speculator=Speculator

--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -52,6 +52,7 @@ dashboard.realized.gain=Realized gain
 dashboard.realized.loss=Realized loss
 dashboard.realized.net=Net realized
 dashboard.realized.tax=Total tax paid
+dashboard.sinceStart=since start
 # Exchange
 exchange.title=Exchange
 exchange.tab.overview=Overview

--- a/src/main/resources/i18n/messages_no.properties
+++ b/src/main/resources/i18n/messages_no.properties
@@ -52,6 +52,7 @@ dashboard.realized.gain=Realisert gevinst
 dashboard.realized.loss=Realisert tap
 dashboard.realized.net=Netto realisert
 dashboard.realized.tax=Total skatt betalt
+dashboard.sinceStart=siden start
 # Exchange
 exchange.title=Børs
 exchange.tab.overview=Oversikt

--- a/src/main/resources/i18n/messages_no.properties
+++ b/src/main/resources/i18n/messages_no.properties
@@ -63,3 +63,7 @@ exit.confirmContent=Du kan lagre spillet før du avslutter.
 exit.saveAndExit=Lagre og avslutt
 exit.exitWithoutSaving=Avslutt uten å lagre
 exit.cancel=Avbryt
+# Player status
+status.novice=Nybegynner
+status.investor=Investor
+status.speculator=Spekulant

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/PlayerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/PlayerTest.java
@@ -405,4 +405,41 @@ class PlayerTest {
             assertNotEquals(PlayerStatusLevel.SPECULATOR, player.getStatus());
         }
     }
+
+    @Nested
+    @DisplayName("previousNetWorth")
+    class PreviousNetWorth {
+
+        @Test
+        @DisplayName("Should return null when previousNetWorth has not been set")
+        void returnsNullWhenNotSet() {
+            assertNull(player.getPreviousNetWorth());
+        }
+
+        @Test
+        @DisplayName("Should return the value that was set")
+        void returnsValueWhenSet() {
+            // Arrange
+            BigDecimal expected = new BigDecimal("5000.00");
+
+            // Act
+            player.setPreviousNetWorth(expected);
+
+            // Assert
+            assertEquals(expected, player.getPreviousNetWorth());
+        }
+
+        @Test
+        @DisplayName("Should update when set multiple times")
+        void updatesWhenSetMultipleTimes() {
+            // Arrange
+            player.setPreviousNetWorth(new BigDecimal("5000.00"));
+
+            // Act
+            player.setPreviousNetWorth(new BigDecimal("7500.00"));
+
+            // Assert
+            assertEquals(new BigDecimal("7500.00"), player.getPreviousNetWorth());
+        }
+    }
 }

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/StockTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/StockTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Currency;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -87,6 +88,14 @@ class StockTest {
             assertThrows(NullPointerException.class, () ->
                     new Stock("NKE", "Nike, Inc", null));
         }
+
+        @Test
+        @DisplayName("Should throw exception when currency is null")
+        void throwsExceptionWhenCurrencyIsNull() {
+            // Act & Assert
+            assertThrows(NullPointerException.class, () ->
+                    new Stock("NKE", "Nike, Inc", prices, null));
+        }
     }
 
     @Nested
@@ -131,6 +140,33 @@ class StockTest {
             BigDecimal result = multiPriceStock.getSalesPrice();
             // Assert
             assertEquals(new BigDecimal("150.00"), result);
+        }
+    }
+
+    @Nested
+    @DisplayName("getCurrency()")
+    class GetCurrency {
+
+        @Test
+        @DisplayName("Should return USD when no currency is specified")
+        void returnsUsdWhenNoCurrencySpecified() {
+            // Act
+            Currency result = stock.getCurrency();
+            // Assert
+            assertEquals(Currency.getInstance("USD"), result);
+        }
+
+        @Test
+        @DisplayName("Should return the specified currency")
+        void returnsSpecifiedCurrency() {
+            // Arrange
+            Stock nokStock = new Stock("EQR", "Equinor",
+                    new ArrayList<>(List.of(new BigDecimal("100.00"))),
+                    Currency.getInstance("NOK"));
+            // Act
+            Currency result = nokStock.getCurrency();
+            // Assert
+            assertEquals(Currency.getInstance("NOK"), result);
         }
     }
 


### PR DESCRIPTION
## Portfolio View - Cards and Dashboard Controller

### Summary
This PR implements the portfolio tab view under the dashboard, including all 
summary cards, the net worth chart, and the dashboard controller.

### Changes
**New components:**
- `PortfolioView` - main layout for the portfolio tab with net worth card and right-side cards
- `NetWorthCard` - area chart showing net worth history over time, with change since start
- `WeeklyChangeCard` - shows net worth change since last week in % and NOK
- `AvailableFundsCard` - shows player's current cash balance
- `PortfolioValueCard` - shows total portfolio value
- `StatusCard` - shows player's current status level (Novice/Investor/Speculator)
- `DashboardController` - binds tab buttons to their corresponding views

**Supporting changes:**
- `CurrencyFormatter` - utility class for consistent NOK formatting
- `PlayerStatusLevel` - added `getI18nKey()` and i18n keys in both languages
- `Player` - added `previousNetWorth`, `netWorthHistory`, `recordNetWorth()` and related methods
- `PlayerTest` - updated with tests for new methods
- All new components support language switching via `LanguageManager`

### Note on `Stock.currency`
The last commit on this branch adds a `currency` field to `Stock`. This was 
initially intended as a small addition, but it became clear that proper currency 
conversion requires a larger refactoring of `Exchange`, `Purchase`, `Sale` and 
the calculator classes. The field has been added here to lay the groundwork, 
but the full implementation will be handled in a separate branch. 
A GitHub issue has been created to track this work.

### Testing
- Run `mvn clean javafx:run` to verify the portfolio view renders correctly
- Advance week several times to verify chart updates and weekly change card
- Switch language to verify all labels update correctly