### PR TITLE
refactor: introduce gamemanager facade for net worth and status

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/millions/manager/GameManager.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/manager/GameManager.java
@@ -7,6 +7,7 @@ import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
 import edu.ntnu.idatt2003.millions.model.currency.FixedRateCurrencyConverter;
 import edu.ntnu.idatt2003.millions.model.exchange.Exchange;
 import edu.ntnu.idatt2003.millions.model.player.Player;
+import edu.ntnu.idatt2003.millions.model.player.PlayerStatusLevel;
 import edu.ntnu.idatt2003.millions.model.stock.Share;
 import edu.ntnu.idatt2003.millions.model.transaction.Transaction;
 import edu.ntnu.idatt2003.millions.observer.GameObserver;
@@ -28,6 +29,11 @@ import java.util.Objects;
  * ({@link Player}, {@link Exchange}), exposes a stable API to controllers,
  * and ensures that observers are notified consistently after every
  * state-changing operation.</p>
+ *
+ * <p>Also exposes facade query methods for derived values such as net worth,
+ * weekly change and player status. These methods let the view layer read
+ * derived state without composing {@link Player} and {@link Exchange}
+ * directly through {@link CurrencyConverter}.</p>
  */
 public class GameManager {
 
@@ -181,6 +187,77 @@ public class GameManager {
      */
     public BigDecimal getPreviousNetWorth() {
         return player.getPreviousNetWorth();
+    }
+
+    /**
+     * Returns the player's current net worth in NOK.
+     * Facade method that fetches the converter from the active {@link Exchange}
+     * and delegates to {@link Player}.
+     *
+     * @return the player's net worth in NOK
+     */
+    public BigDecimal getPlayerNetWorth() {
+        return player.getNetWorth(exchange.getCurrencyConverter());
+    }
+
+    /**
+     * Returns the absolute change in the player's net worth since the start of the game,
+     * in NOK. Facade method that delegates to {@link Player}.
+     *
+     * @return current net worth minus starting money, in NOK
+     */
+    public BigDecimal getPlayerNetWorthChangeSinceStart() {
+        return player.getNetWorthChangeSinceStart(exchange.getCurrencyConverter());
+    }
+
+    /**
+     * Returns the percentage change in the player's net worth since the start of the game.
+     * Facade method that delegates to {@link Player}.
+     *
+     * @return percent change since start, e.g. 12.5 means +12.5%
+     */
+    public BigDecimal getPlayerNetWorthChangePercentSinceStart() {
+        return player.getNetWorthChangePercentSinceStart(exchange.getCurrencyConverter());
+    }
+
+    /**
+     * Returns the absolute change in the player's net worth since the previous week, in NOK.
+     * Returns null if no week has been advanced yet. Facade method that delegates to {@link Player}.
+     *
+     * @return current net worth minus previous net worth, or null if not available
+     */
+    public BigDecimal getPlayerWeeklyNetWorthChange() {
+        return player.getWeeklyNetWorthChange(exchange.getCurrencyConverter());
+    }
+
+    /**
+     * Returns the percentage change in the player's net worth since the previous week.
+     * Returns null if no week has been advanced yet. Facade method that delegates to {@link Player}.
+     *
+     * @return percent change since last week, or null if not available
+     */
+    public BigDecimal getPlayerWeeklyNetWorthChangePercent() {
+        return player.getWeeklyNetWorthChangePercent(exchange.getCurrencyConverter());
+    }
+
+    /**
+     * Returns the player's current status level. Facade method that delegates to
+     * {@link Player#getStatus(CurrencyConverter)}.
+     *
+     * @return the player's status level
+     */
+    public PlayerStatusLevel getPlayerStatus() {
+        return player.getStatus(exchange.getCurrencyConverter());
+    }
+
+    /**
+     * Returns the total value of the player's portfolio in NOK.
+     * Facade method that delegates to {@link Player}.
+     *
+     * @return the portfolio value in NOK
+     */
+    public BigDecimal getPortfolioValue() {
+        return player.getPortfolio().getNetWorth(exchange.getCurrencyConverter());
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/NetWorthCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/NetWorthCard.java
@@ -101,14 +101,12 @@ public class NetWorthCard extends Card {
 
     /**
      * Updates the net worth label and change label with current values.
+     * Reads derived values from {@link GameManager} via facade methods.
      */
     private void updateDisplay() {
-        var converter = gameManager.getExchange().getCurrencyConverter();
-        var player = gameManager.getPlayer();
-
-        BigDecimal netWorth = player.getNetWorth(converter);
-        BigDecimal change = player.getNetWorthChangeSinceStart(converter);
-        BigDecimal percentChange = player.getNetWorthChangePercentSinceStart(converter);
+        BigDecimal netWorth = gameManager.getPlayerNetWorth();
+        BigDecimal change = gameManager.getPlayerNetWorthChangeSinceStart();
+        BigDecimal percentChange = gameManager.getPlayerNetWorthChangePercentSinceStart();
 
         String sign = change.compareTo(BigDecimal.ZERO) >= 0 ? "+" : "";
         String formattedPercent = String.format(Locale.of("no"), "%.1f", percentChange);
@@ -137,12 +135,12 @@ public class NetWorthCard extends Card {
     /**
      * Called when the game state has changed.
      * Adds a new data point to the chart, extends the x-axis and refreshes the display.
+     * The new point is read via the {@link GameManager} facade.
      */
     @Override
     public void onGameUpdated() {
         int nextPoint = series.getData().size() + 1;
-        double netWorth = gameManager.getPlayer().getNetWorth(
-                gameManager.getExchange().getCurrencyConverter()).doubleValue();
+        double netWorth = gameManager.getPlayerNetWorth().doubleValue();
         series.getData().add(new XYChart.Data<>(nextPoint, netWorth));
         xAxis.setUpperBound(nextPoint);
         xAxis.setTickUnit(Math.max(1, nextPoint / 8));

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/PortfolioValueCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/PortfolioValueCard.java
@@ -33,9 +33,7 @@ public class PortfolioValueCard extends Card {
 
         getChildren().addAll(titleLabel, valueLabel);
 
-        valueLabel.setText(CurrencyFormatter.format(
-                gameManager.getPlayer().getPortfolio().getNetWorth(
-                        gameManager.getExchange().getCurrencyConverter())));
+        valueLabel.setText(CurrencyFormatter.format(gameManager.getPortfolioValue()));
     }
 
     /**
@@ -48,12 +46,10 @@ public class PortfolioValueCard extends Card {
 
     /**
      * Called when the game state has changed.
-     * Refreshes the displayed portfolio value.
+     * Refreshes the displayed portfolio value via the {@link GameManager} facade.
      */
     @Override
     public void onGameUpdated() {
-        valueLabel.setText(CurrencyFormatter.format(
-                gameManager.getPlayer().getPortfolio().getNetWorth(
-                        gameManager.getExchange().getCurrencyConverter())));
+        valueLabel.setText(CurrencyFormatter.format(gameManager.getPortfolioValue()));
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/StatusCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/StatusCard.java
@@ -32,30 +32,25 @@ public class StatusCard extends Card {
 
         getChildren().addAll(titleLabel, valueLabel);
 
-        valueLabel.setText(LanguageManager.get(
-                gameManager.getPlayer().getStatus(
-                        gameManager.getExchange().getCurrencyConverter()).getI18nKey()));
+        valueLabel.setText(LanguageManager.get(gameManager.getPlayerStatus().getI18nKey()));
     }
 
     /**
      * Updates all text elements to the current language.
+     * Reads the status from {@link GameManager} via the facade.
      */
     @Override
     protected void onLanguageChanged() {
         titleLabel.setText(LanguageManager.get("dashboard.status"));
-        valueLabel.setText(LanguageManager.get(
-                gameManager.getPlayer().getStatus(
-                        gameManager.getExchange().getCurrencyConverter()).getI18nKey()));
+        valueLabel.setText(LanguageManager.get(gameManager.getPlayerStatus().getI18nKey()));
     }
 
     /**
      * Called when the game state has changed.
-     * Refreshes the displayed status level.
+     * Refreshes the displayed status level via the {@link GameManager} facade.
      */
     @Override
     public void onGameUpdated() {
-        valueLabel.setText(LanguageManager.get(
-                gameManager.getPlayer().getStatus(
-                        gameManager.getExchange().getCurrencyConverter()).getI18nKey()));
+        valueLabel.setText(LanguageManager.get(gameManager.getPlayerStatus().getI18nKey()));
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/WeeklyChangeCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/WeeklyChangeCard.java
@@ -43,19 +43,17 @@ public class WeeklyChangeCard extends Card {
 
     /**
      * Updates the displayed week change based on the current and previous net worth.
-     * Shows a dash if no week has been advanced yet.
+     * Shows a dash if no week has been advanced yet. Reads derived values from
+     * {@link GameManager} via facade methods.
      */
     private void updateDisplay() {
-        var converter = gameManager.getExchange().getCurrencyConverter();
-        var player = gameManager.getPlayer();
-
-        BigDecimal change = player.getWeeklyNetWorthChange(converter);
+        BigDecimal change = gameManager.getPlayerWeeklyNetWorthChange();
         if (change == null) {
             changeLabel.setText("–");
             return;
         }
 
-        BigDecimal percentChange = player.getWeeklyNetWorthChangePercent(converter);
+        BigDecimal percentChange = gameManager.getPlayerWeeklyNetWorthChangePercent();
 
         String arrow = change.compareTo(BigDecimal.ZERO) >= 0 ? "↗" : "↘";
         String sign = change.compareTo(BigDecimal.ZERO) >= 0 ? "+" : "";

--- a/src/test/java/edu/ntnu/idatt2003/millions/manager/GameManagerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/manager/GameManagerTest.java
@@ -1,0 +1,363 @@
+package edu.ntnu.idatt2003.millions.manager;
+
+import edu.ntnu.idatt2003.millions.file.game.JsonGameFileHandler;
+import edu.ntnu.idatt2003.millions.model.currency.FixedRateCurrencyConverter;
+import edu.ntnu.idatt2003.millions.model.exchange.Exchange;
+import edu.ntnu.idatt2003.millions.model.player.Player;
+import edu.ntnu.idatt2003.millions.model.player.PlayerStatusLevel;
+import edu.ntnu.idatt2003.millions.model.stock.Share;
+import edu.ntnu.idatt2003.millions.model.stock.Stock;
+import edu.ntnu.idatt2003.millions.model.transaction.Transaction;
+import edu.ntnu.idatt2003.millions.observer.GameObserver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.math.BigDecimal;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Currency;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for the facade methods on {@link GameManager}.
+ * <p>
+ * This test class verifies that the facade methods on GameManager correctly
+ * delegate to the underlying domain objects ({@link Player}, Portfolio,
+ * {@link Exchange}) and return the expected derived values.
+ * </p>
+ * <p>
+ * Game state is set up by saving a known {@link Player} and {@link Exchange}
+ * to a temporary file, then loading it via {@link GameManager#loadGame},
+ * since the public {@code createNewGame} entry point is not yet implemented.
+ * </p>
+ * <p>
+ * All tests follow the AAA pattern.
+ * </p>
+ */
+class GameManagerTest {
+
+    private static final BigDecimal STARTING_MONEY = new BigDecimal("10000.00");
+    private static final BigDecimal STOCK_PRICE = new BigDecimal("100.00");
+    private static final BigDecimal QUANTITY = new BigDecimal("5");
+    private static final BigDecimal PURCHASE_COMMISSION = new BigDecimal("2.50000");
+    private static final BigDecimal SALE_COMMISSION = new BigDecimal("5.0000");
+    private static final BigDecimal EXPECTED_PORTFOLIO_VALUE = new BigDecimal("495.0000");
+    private static final BigDecimal EXPECTED_NET_WORTH_AFTER_PURCHASE = new BigDecimal("9992.50000");
+
+    private GameManager gameManager;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setUp() {
+        Stock stock = new Stock("EQNR", "Equinor ASA",
+                new ArrayList<>(List.of(STOCK_PRICE)),
+                Currency.getInstance("NOK"));
+        Exchange exchange = new Exchange("NYSE",
+                new ArrayList<>(List.of(stock)),
+                new FixedRateCurrencyConverter());
+        Player player = new Player("Dara", STARTING_MONEY);
+
+        Path file = tempDir.resolve("save.json");
+        new JsonGameFileHandler().saveGame(player, exchange, file.toFile());
+
+        gameManager = new GameManager();
+        gameManager.loadGame(file.toFile());
+    }
+
+    @Nested
+    @DisplayName("addObserver()")
+    class AddObserver {
+
+        @Test
+        @DisplayName("Should throw exception when observer is null")
+        void throwsExceptionWhenObserverIsNull() {
+            // Act & Assert
+            assertThrows(NullPointerException.class, () ->
+                    gameManager.addObserver(null));
+        }
+    }
+
+    @Nested
+    @DisplayName("saveGame()")
+    class SaveGame {
+
+        @Test
+        @DisplayName("Should throw exception when file is null")
+        void throwsExceptionWhenFileIsNull() {
+            // Act & Assert
+            assertThrows(NullPointerException.class, () ->
+                    gameManager.saveGame(null));
+        }
+
+        @Test
+        @DisplayName("Should throw exception when no active game exists")
+        void throwsExceptionWhenNoActiveGameExists() {
+            // Arrange
+            GameManager emptyGameManager = new GameManager();
+            File file = tempDir.resolve("empty-save.json").toFile();
+            // Act & Assert
+            assertThrows(IllegalStateException.class, () ->
+                    emptyGameManager.saveGame(file));
+        }
+
+        @Test
+        @DisplayName("Should save an active game to file")
+        void savesActiveGameToFile() {
+            // Arrange
+            File file = tempDir.resolve("saved-game.json").toFile();
+            // Act
+            gameManager.saveGame(file);
+            // Assert
+            assertTrue(file.isFile());
+            assertTrue(file.length() > 0);
+        }
+    }
+
+    @Nested
+    @DisplayName("loadGame()")
+    class LoadGame {
+
+        @Test
+        @DisplayName("Should throw exception when file is null")
+        void throwsExceptionWhenFileIsNull() {
+            // Act & Assert
+            assertThrows(NullPointerException.class, () ->
+                    gameManager.loadGame(null));
+        }
+
+        @Test
+        @DisplayName("Should load player and exchange from file")
+        void loadsPlayerAndExchangeFromFile() {
+            // Act & Assert
+            assertEquals("Dara", gameManager.getPlayer().getName());
+            assertEquals("NYSE", gameManager.getExchange().getName());
+            assertTrue(gameManager.getExchange().hasStock("EQNR"));
+            assertNotNull(gameManager.getExchange().getCurrencyConverter());
+        }
+    }
+
+    @Nested
+    @DisplayName("buy()")
+    class Buy {
+
+        @Test
+        @DisplayName("Should buy shares and notify observers")
+        void buysSharesAndNotifiesObservers() {
+            // Arrange
+            CountingObserver observer = new CountingObserver();
+            gameManager.addObserver(observer);
+            // Act
+            Transaction transaction = gameManager.buy("EQNR", QUANTITY);
+            // Assert
+            assertNotNull(transaction);
+            assertEquals(1, gameManager.getPlayer().getPortfolio().getShares("EQNR").size());
+            assertEquals(1, observer.updateCount);
+            assertEquals(0, STARTING_MONEY.subtract(STOCK_PRICE.multiply(QUANTITY))
+                    .subtract(PURCHASE_COMMISSION)
+                    .compareTo(gameManager.getPlayer().getMoney()));
+        }
+    }
+
+    @Nested
+    @DisplayName("sell()")
+    class Sell {
+
+        @Test
+        @DisplayName("Should sell share and notify observers")
+        void sellsShareAndNotifiesObservers() {
+            // Arrange
+            gameManager.buy("EQNR", QUANTITY);
+            Share share = gameManager.getPlayer().getPortfolio().getShares("EQNR").getFirst();
+            CountingObserver observer = new CountingObserver();
+            gameManager.addObserver(observer);
+            // Act
+            Transaction transaction = gameManager.sell(share);
+            // Assert
+            assertNotNull(transaction);
+            assertTrue(gameManager.getPlayer().getPortfolio().getShares("EQNR").isEmpty());
+            assertEquals(1, observer.updateCount);
+            assertEquals(0, STARTING_MONEY.subtract(PURCHASE_COMMISSION)
+                    .subtract(SALE_COMMISSION)
+                    .compareTo(gameManager.getPlayer().getMoney()));
+        }
+    }
+
+    @Nested
+    @DisplayName("advanceWeek()")
+    class AdvanceWeek {
+
+        @Test
+        @DisplayName("Should advance exchange week, record previous net worth and notify observers")
+        void advancesWeekRecordsPreviousNetWorthAndNotifiesObservers() {
+            // Arrange
+            CountingObserver observer = new CountingObserver();
+            gameManager.addObserver(observer);
+            // Act
+            gameManager.advanceWeek();
+            // Assert
+            assertEquals(2, gameManager.getExchange().getWeek());
+            assertEquals(0, STARTING_MONEY.compareTo(gameManager.getPreviousNetWorth()));
+            assertEquals(2, gameManager.getPlayer().getNetWorthHistory().size());
+            assertEquals(1, observer.updateCount);
+        }
+    }
+
+    @Nested
+    @DisplayName("getPlayerNetWorth()")
+    class GetPlayerNetWorth {
+
+        @Test
+        @DisplayName("Should return starting money for fresh player with empty portfolio")
+        void returnsStartingMoneyForFreshPlayer() {
+            // Act
+            BigDecimal netWorth = gameManager.getPlayerNetWorth();
+            // Assert
+            assertEquals(0, STARTING_MONEY.compareTo(netWorth));
+        }
+
+        @Test
+        @DisplayName("Should return same total when shares are bought at current price")
+        void returnsSameTotalAfterPurchaseAtCurrentPrice() {
+            // Arrange
+            gameManager.buy("EQNR", QUANTITY);
+            // Act
+            BigDecimal netWorth = gameManager.getPlayerNetWorth();
+            // Assert: cash after purchase plus portfolio liquidation value
+            assertEquals(0, EXPECTED_NET_WORTH_AFTER_PURCHASE.compareTo(netWorth));
+        }
+    }
+
+    @Nested
+    @DisplayName("getPlayerNetWorthChangeSinceStart()")
+    class GetPlayerNetWorthChangeSinceStart {
+
+        @Test
+        @DisplayName("Should return zero for fresh player")
+        void returnsZeroForFreshPlayer() {
+            // Act
+            BigDecimal change = gameManager.getPlayerNetWorthChangeSinceStart();
+            // Assert
+            assertEquals(0, BigDecimal.ZERO.compareTo(change));
+        }
+    }
+
+    @Nested
+    @DisplayName("getPlayerNetWorthChangePercentSinceStart()")
+    class GetPlayerNetWorthChangePercentSinceStart {
+
+        @Test
+        @DisplayName("Should return zero for fresh player")
+        void returnsZeroForFreshPlayer() {
+            // Act
+            BigDecimal percent = gameManager.getPlayerNetWorthChangePercentSinceStart();
+            // Assert
+            assertEquals(0, BigDecimal.ZERO.compareTo(percent));
+        }
+    }
+
+    @Nested
+    @DisplayName("getPlayerWeeklyNetWorthChange()")
+    class GetPlayerWeeklyNetWorthChange {
+
+        @Test
+        @DisplayName("Should return null before the first week advance")
+        void returnsNullBeforeFirstAdvance() {
+            // Act
+            BigDecimal change = gameManager.getPlayerWeeklyNetWorthChange();
+            // Assert
+            assertNull(change);
+        }
+
+        @Test
+        @DisplayName("Should return non-null value after a week is advanced")
+        void returnsNonNullAfterAdvance() {
+            // Arrange
+            gameManager.advanceWeek();
+            // Act
+            BigDecimal change = gameManager.getPlayerWeeklyNetWorthChange();
+            // Assert
+            assertNotNull(change);
+        }
+    }
+
+    @Nested
+    @DisplayName("getPlayerWeeklyNetWorthChangePercent()")
+    class GetPlayerWeeklyNetWorthChangePercent {
+
+        @Test
+        @DisplayName("Should return null before the first week advance")
+        void returnsNullBeforeFirstAdvance() {
+            // Act
+            BigDecimal percent = gameManager.getPlayerWeeklyNetWorthChangePercent();
+            // Assert
+            assertNull(percent);
+        }
+
+        @Test
+        @DisplayName("Should return non-null value after a week is advanced")
+        void returnsNonNullAfterAdvance() {
+            // Arrange
+            gameManager.advanceWeek();
+            // Act
+            BigDecimal percent = gameManager.getPlayerWeeklyNetWorthChangePercent();
+            // Assert
+            assertNotNull(percent);
+        }
+    }
+
+    @Nested
+    @DisplayName("getPlayerStatus()")
+    class GetPlayerStatus {
+
+        @Test
+        @DisplayName("Should return NOVICE for fresh player")
+        void returnsNoviceForFreshPlayer() {
+            // Act
+            PlayerStatusLevel status = gameManager.getPlayerStatus();
+            // Assert
+            assertEquals(PlayerStatusLevel.NOVICE, status);
+        }
+    }
+
+    @Nested
+    @DisplayName("getPortfolioValue()")
+    class GetPortfolioValue {
+
+        @Test
+        @DisplayName("Should return zero for empty portfolio")
+        void returnsZeroForEmptyPortfolio() {
+            // Act
+            BigDecimal value = gameManager.getPortfolioValue();
+            // Assert
+            assertEquals(0, BigDecimal.ZERO.compareTo(value));
+        }
+
+        @Test
+        @DisplayName("Should return shares times price after purchase")
+        void returnsSharesTimesPriceAfterPurchase() {
+            // Arrange
+            gameManager.buy("EQNR", QUANTITY);
+            // Act
+            BigDecimal value = gameManager.getPortfolioValue();
+            // Assert: 5 shares * 100 NOK minus 1% sale commission
+            assertEquals(0, EXPECTED_PORTFOLIO_VALUE.compareTo(value));
+        }
+    }
+
+    private static class CountingObserver implements GameObserver {
+        private int updateCount;
+
+        @Override
+        public void onGameUpdated() {
+            updateCount++;
+        }
+    }
+}


### PR DESCRIPTION
Added 7 facade methods in GameManager for player net worth, weekly net worth changes, portfolio value and player status. Dashboard portfolio card now erads these derived values through GameManager instead of compisng Player, Exchange and CurrencyConverter directly.
Following separation of concerncs by keeping UI components focused on presentation while GameManager provieds a stable service layer.

**Changes**
- Added facade query methods to GameManager
- Updated networth, weekly change, portfolio value and status cards to use the facade.
- Added unit test for GameManager coverage for facade methods, save/loads, buy/sell, week advancement and observer notifications.