### PR TITLE
feat: implement GameManager.createNewGame

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
@@ -95,14 +95,14 @@ public class StartController {
     }
 
     /**
-     * Opens a file chooser for selecting a stock data file (CSV or JSON).
+     * Opens a file chooser for selecting a stock data file (CSV).
      * If a file is chosen, the path is shown in the view.
      */
     private void handleBrowseStockFile() {
         FileChooser chooser = new FileChooser();
         chooser.setTitle("Select stock file");
         chooser.getExtensionFilters().add(
-                new FileChooser.ExtensionFilter("Data files", "*.csv", "*.json"));
+                new FileChooser.ExtensionFilter("Data files", "*.csv"));
         File file = chooser.showOpenDialog(stage);
         if (file != null) {
             view.setStockFilePath(file.getAbsolutePath());

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
@@ -146,7 +146,7 @@ public class StartController {
             if (stockFilePath.isBlank()) {
                 gameManager.createNewGame(name, parsedCapital);
             } else {
-                File stockFile = requireFilePath(stockFilePath, "Stock file must be selected");
+                File stockFile = requireCsvFilePath(stockFilePath);
                 gameManager.createNewGame(name, parsedCapital, stockFile);
             }
             showMainView();
@@ -188,6 +188,24 @@ public class StartController {
             throw new IllegalArgumentException(message);
         }
         return new File(filePath);
+    }
+
+    /**
+     * Validates a custom stock file path and requires it to point to a CSV file.
+     *
+     * <p>The method is package-private so controller tests can verify stock file
+     * validation without starting JavaFX.</p>
+     *
+     * @param filePath the stock file path selected by the user
+     * @return a CSV file representing the validated path
+     * @throws IllegalArgumentException if the path is missing or does not end with {@code .csv}
+     */
+    static File requireCsvFilePath(String filePath) {
+        File file = requireFilePath(filePath, "Stock file must be selected");
+        if (!file.getName().toLowerCase().endsWith(".csv")) {
+            throw new IllegalArgumentException("Stock file must be a CSV file");
+        }
+        return file;
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
@@ -140,12 +140,10 @@ public class StartController {
             if (name.isBlank()) {
                 throw new IllegalArgumentException("Player name cannot be blank");
             }
-            if (stockFilePath.isBlank()) {
-                throw new IllegalArgumentException("Stock file must be selected");
-            }
 
             BigDecimal parsedCapital = parseCapital(capital);
-            gameManager.createNewGame(name, parsedCapital, new File(stockFilePath));
+            File stockFile = requireFilePath(stockFilePath, "Stock file must be selected");
+            gameManager.createNewGame(name, parsedCapital, stockFile);
             showMainView();
         } catch (IllegalArgumentException exception) {
             showError(exception.getMessage());
@@ -170,6 +168,24 @@ public class StartController {
     }
 
     /**
+     * Validates a file path from UI input and converts it to a {@link File}.
+     *
+     * <p>The method is package-private so controller tests can verify file path
+     * validation without starting JavaFX.</p>
+     *
+     * @param filePath the file path text entered or selected by the user
+     * @param message  the exception message used when the path is missing
+     * @return a file representing the validated path
+     * @throws IllegalArgumentException if the path is null or blank
+     */
+    File requireFilePath(String filePath, String message) {
+        if (filePath == null || filePath.isBlank()) {
+            throw new IllegalArgumentException(message);
+        }
+        return new File(filePath);
+    }
+
+    /**
      * Validates input, loads an existing saved game through {@link GameManager},
      * and shows the main view.
      *
@@ -179,12 +195,8 @@ public class StartController {
     void handleLoadGame() {
         try {
             String saveFilePath = view.getSaveFilePath();
-
-            if (saveFilePath.isBlank()) {
-                throw new IllegalArgumentException("Save file must be selected");
-            }
-
-            gameManager.loadGame(new File(saveFilePath));
+            File saveFile = requireFilePath(saveFilePath, "Save file must be selected");
+            gameManager.loadGame(saveFile);
             showMainView();
         } catch (RuntimeException exception) {
             showError(exception.getMessage());

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
@@ -26,8 +26,8 @@ public class StartController {
      * Constructs a new StartController with a default {@link GameManager}.
      *
      * <p>This constructor is used by the application startup flow. It delegates
-     * to {@link #StartController(Stage, GameManager)} so tests and alternate
-     * startup paths can inject their own game manager.</p>
+     * to {@link #StartController(Stage, GameManager)} so alternate startup paths
+     * can inject their own game manager.</p>
      *
      * @param stage the primary application stage
      * @throws NullPointerException if stage is null
@@ -39,7 +39,7 @@ public class StartController {
     /**
      * Constructs a new StartController with the given {@link GameManager} and binds all UI events.
      *
-     * <p>Injecting the manager keeps the controller testable while preserving
+     * <p>Injecting the manager keeps the controller flexible while preserving
      * the normal production flow through {@link #StartController(Stage)}.</p>
      *
      * @param stage       the primary application stage
@@ -47,10 +47,27 @@ public class StartController {
      * @throws NullPointerException if stage or game manager is null
      */
     public StartController(Stage stage, GameManager gameManager) {
+        this(stage, gameManager, new StartView());
+    }
+
+    /**
+     * Constructs a new StartController with injected dependencies and binds all UI events.
+     *
+     * <p>This constructor is package-private so controller tests in the same package
+     * can inject a controlled {@link StartView} while production code uses the public
+     * constructors.</p>
+     *
+     * @param stage       the primary application stage
+     * @param gameManager the game manager used to create or load game state
+     * @param view        the start view that exposes user input and controls
+     * @throws NullPointerException if stage, game manager, or view is null
+     */
+    StartController(Stage stage, GameManager gameManager, StartView view) {
         Objects.requireNonNull(stage, "Stage cannot be null");
         Objects.requireNonNull(gameManager, "GameManager cannot be null");
+        Objects.requireNonNull(view, "StartView cannot be null");
         this.stage = stage;
-        this.view = new StartView();
+        this.view = view;
         this.gameManager = gameManager;
         bindEvents();
     }

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
@@ -160,7 +160,7 @@ public class StartController {
      * @return the parsed starting capital
      * @throws IllegalArgumentException if the capital is null, blank, or not a valid decimal number
      */
-    BigDecimal parseCapital(String capital) {
+    static BigDecimal parseCapital(String capital) {
         if (capital == null || capital.isBlank()) {
             throw new IllegalArgumentException("Starting capital cannot be blank");
         }
@@ -178,7 +178,7 @@ public class StartController {
      * @return a file representing the validated path
      * @throws IllegalArgumentException if the path is null or blank
      */
-    File requireFilePath(String filePath, String message) {
+    static File requireFilePath(String filePath, String message) {
         if (filePath == null || filePath.isBlank()) {
             throw new IllegalArgumentException(message);
         }

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
@@ -5,6 +5,7 @@ import edu.ntnu.idatt2003.millions.view.StartView;
 import java.io.File;
 import java.io.UncheckedIOException;
 import java.math.BigDecimal;
+import java.util.Currency;
 import java.util.Objects;
 import javafx.scene.control.Alert;
 import javafx.stage.FileChooser;
@@ -152,7 +153,8 @@ public class StartController {
                 gameManager.createNewGame(name, parsedCapital);
             } else {
                 File stockFile = StartInputValidator.requireCsvFilePath(stockFilePath);
-                gameManager.createNewGame(name, parsedCapital, stockFile);
+                Currency currency = StartInputValidator.requireCurrency(view.getSelectedCurrency());
+                gameManager.createNewGame(name, parsedCapital, stockFile, currency);
             }
             showMainView();
         });

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
@@ -21,6 +21,7 @@ public class StartController {
     private final Stage stage;
     private final StartView view;
     private final GameManager gameManager;
+    private final Runnable showMainViewAction;
 
     /**
      * Constructs a new StartController with a default {@link GameManager}.
@@ -47,28 +48,31 @@ public class StartController {
      * @throws NullPointerException if stage or game manager is null
      */
     public StartController(Stage stage, GameManager gameManager) {
-        this(stage, gameManager, new StartView());
+        this(stage, gameManager, new StartView(), () -> new MainController(stage, gameManager).show());
     }
 
     /**
      * Constructs a new StartController with injected dependencies and binds all UI events.
      *
      * <p>This constructor is package-private so controller tests in the same package
-     * can inject a controlled {@link StartView} while production code uses the public
-     * constructors.</p>
+     * can inject a controlled {@link StartView} and navigation action while production
+     * code uses the public constructors.</p>
      *
-     * @param stage       the primary application stage
-     * @param gameManager the game manager used to create or load game state
-     * @param view        the start view that exposes user input and controls
-     * @throws NullPointerException if stage, game manager, or view is null
+     * @param stage              the primary application stage
+     * @param gameManager        the game manager used to create or load game state
+     * @param view               the start view that exposes user input and controls
+     * @param showMainViewAction the action used to navigate to the main view
+     * @throws NullPointerException if stage, game manager, view, or navigation action is null
      */
-    StartController(Stage stage, GameManager gameManager, StartView view) {
+    StartController(Stage stage, GameManager gameManager, StartView view, Runnable showMainViewAction) {
         Objects.requireNonNull(stage, "Stage cannot be null");
         Objects.requireNonNull(gameManager, "GameManager cannot be null");
         Objects.requireNonNull(view, "StartView cannot be null");
+        Objects.requireNonNull(showMainViewAction, "Show main view action cannot be null");
         this.stage = stage;
         this.view = view;
         this.gameManager = gameManager;
+        this.showMainViewAction = showMainViewAction;
         bindEvents();
     }
 
@@ -177,7 +181,7 @@ public class StartController {
      * Shows the main view using the active {@link GameManager}.
      */
     private void showMainView() {
-        new MainController(stage, gameManager).show();
+        showMainViewAction.run();
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
@@ -1,12 +1,14 @@
 package edu.ntnu.idatt2003.millions.controller;
 
 import edu.ntnu.idatt2003.millions.manager.GameManager;
+import edu.ntnu.idatt2003.millions.view.StartScreenInputs;
 import edu.ntnu.idatt2003.millions.view.StartView;
 import java.io.File;
 import java.io.UncheckedIOException;
 import java.math.BigDecimal;
 import java.util.Currency;
 import java.util.Objects;
+import java.util.function.Consumer;
 import javafx.scene.control.Alert;
 import javafx.stage.FileChooser;
 import javafx.stage.Stage;
@@ -22,7 +24,7 @@ import javafx.stage.Stage;
  * so the controller keeps a single, consistent validation strategy and
  * stays free of domain rules.</p>
  *
- * <p>Errors from the start flow are translated to user-facing dialogs by
+ * <p>Errors from the start flow are translated to user-facing messages by
  * a shared error-handling helper that catches the concrete exception types
  * the flow can legitimately produce (input validation, missing game state
  * and file I/O), while letting programming errors surface as crashes.</p>
@@ -31,8 +33,10 @@ public class StartController {
 
     private final Stage stage;
     private final StartView view;
+    private final StartScreenInputs inputs;
     private final GameManager gameManager;
     private final Runnable showMainViewAction;
+    private final Consumer<String> errorSink;
 
     /**
      * Constructs a new StartController with a default {@link GameManager}.
@@ -49,42 +53,71 @@ public class StartController {
     }
 
     /**
-     * Constructs a new StartController with the given {@link GameManager} and binds all UI events.
+     * Constructs a new StartController with the given {@link GameManager}.
      *
      * <p>Injecting the manager keeps the controller flexible while preserving
-     * the normal production flow through {@link #StartController(Stage)}.</p>
+     * the normal production flow through {@link #StartController(Stage)}.
+     * Event bindings are deferred to {@link #show()}.</p>
      *
      * @param stage       the primary application stage
      * @param gameManager the game manager used to create or load game state
      * @throws NullPointerException if stage or game manager is null
      */
     public StartController(Stage stage, GameManager gameManager) {
-        this(stage, gameManager, new StartView(), () -> new MainController(stage, gameManager).show());
+        this(stage, gameManager, new StartView(),
+                () -> new MainController(stage, gameManager).show(),
+                StartController::showAlert);
     }
 
     /**
-     * Constructs a new StartController with injected dependencies and binds all UI events.
-     *
-     * <p>This constructor is package-private so controller tests in the same package
-     * can inject a controlled {@link StartView} and navigation action while production
-     * code uses the public constructors.</p>
+     * Full dependency injection constructor used by production wiring and by
+     * controller tests that need access to the concrete {@link StartView}.
+     * Event bindings are deferred to {@link #show()}.
      *
      * @param stage              the primary application stage
      * @param gameManager        the game manager used to create or load game state
      * @param view               the start view that exposes user input and controls
      * @param showMainViewAction the action used to navigate to the main view
-     * @throws NullPointerException if stage, game manager, view, or navigation action is null
+     * @param errorSink          the consumer that displays user-facing error messages
+     * @throws NullPointerException if any argument is null
      */
-    StartController(Stage stage, GameManager gameManager, StartView view, Runnable showMainViewAction) {
-        Objects.requireNonNull(stage, "Stage cannot be null");
-        Objects.requireNonNull(gameManager, "GameManager cannot be null");
-        Objects.requireNonNull(view, "StartView cannot be null");
-        Objects.requireNonNull(showMainViewAction, "Show main view action cannot be null");
-        this.stage = stage;
-        this.view = view;
-        this.gameManager = gameManager;
-        this.showMainViewAction = showMainViewAction;
-        bindEvents();
+    StartController(Stage stage,
+                    GameManager gameManager,
+                    StartView view,
+                    Runnable showMainViewAction,
+                    Consumer<String> errorSink) {
+        this.stage = Objects.requireNonNull(stage, "Stage cannot be null");
+        this.gameManager = Objects.requireNonNull(gameManager, "GameManager cannot be null");
+        this.view = Objects.requireNonNull(view, "StartView cannot be null");
+        this.inputs = view;
+        this.showMainViewAction = Objects.requireNonNull(showMainViewAction, "Show main view action cannot be null");
+        this.errorSink = Objects.requireNonNull(errorSink, "Error sink cannot be null");
+    }
+
+    /**
+     * Test-only seam that constructs the controller without requiring a
+     * {@link Stage} or a fully built {@link StartView}. The controller
+     * reads user input. reports errors to {@code errorSink} and navigates
+     * through {@code showMainViewAction}.
+     * {@link #show()} and the file-chooser handlers are not safe to call
+     * on instances created through this constructor.
+     *
+     * @param gameManager        the game manager used to create or load game state
+     * @param inputs             the input seam the start flow reads from
+     * @param showMainViewAction the action used to navigate to the main view
+     * @param errorSink          the consumer that receives user-facing error messages
+     * @throws NullPointerException if any argument is null
+     */
+    StartController(GameManager gameManager,
+                    StartScreenInputs inputs,
+                    Runnable showMainViewAction,
+                    Consumer<String> errorSink) {
+        this.stage = null;
+        this.view = null;
+        this.gameManager = Objects.requireNonNull(gameManager, "GameManager cannot be null");
+        this.inputs = Objects.requireNonNull(inputs, "Inputs cannot be null");
+        this.showMainViewAction = Objects.requireNonNull(showMainViewAction, "Show main view action cannot be null");
+        this.errorSink = Objects.requireNonNull(errorSink, "Error sink cannot be null");
     }
 
     /**
@@ -98,7 +131,7 @@ public class StartController {
         view.getDropZone().setOnDragDropped(e -> {
             var db = e.getDragboard();
             if (db.hasFiles()) {
-                view.setStockFilePath(db.getFiles().getFirst().getAbsolutePath());
+                inputs.setStockFilePath(db.getFiles().getFirst().getAbsolutePath());
                 e.setDropCompleted(true);
             }
             e.consume();
@@ -116,7 +149,7 @@ public class StartController {
                 new FileChooser.ExtensionFilter("Data files", "*.csv"));
         File file = chooser.showOpenDialog(stage);
         if (file != null) {
-            view.setStockFilePath(file.getAbsolutePath());
+            inputs.setStockFilePath(file.getAbsolutePath());
         }
     }
 
@@ -131,7 +164,7 @@ public class StartController {
                 new FileChooser.ExtensionFilter("Save files", "*.json"));
         File file = chooser.showOpenDialog(stage);
         if (file != null) {
-            view.setSaveFilePath(file.getAbsolutePath());
+            inputs.setSaveFilePath(file.getAbsolutePath());
         }
     }
 
@@ -145,15 +178,15 @@ public class StartController {
      */
     void handleStartGame() {
         runOrShowError(() -> {
-            String name = StartInputValidator.requireName(view.getName());
-            BigDecimal parsedCapital = StartInputValidator.parseCapital(view.getCapital());
-            String stockFilePath = view.getStockFilePath();
+            String name = StartInputValidator.requireName(inputs.getName());
+            BigDecimal parsedCapital = StartInputValidator.parseCapital(inputs.getCapital());
+            String stockFilePath = inputs.getStockFilePath();
 
             if (stockFilePath.isBlank()) {
                 gameManager.createNewGame(name, parsedCapital);
             } else {
                 File stockFile = StartInputValidator.requireCsvFilePath(stockFilePath);
-                Currency currency = StartInputValidator.requireCurrency(view.getSelectedCurrency());
+                Currency currency = StartInputValidator.requireCurrency(inputs.getSelectedCurrency());
                 gameManager.createNewGame(name, parsedCapital, stockFile, currency);
             }
             showMainView();
@@ -169,7 +202,7 @@ public class StartController {
      */
     void handleLoadGame() {
         runOrShowError(() -> {
-            String saveFilePath = view.getSaveFilePath();
+            String saveFilePath = inputs.getSaveFilePath();
             File saveFile = StartInputValidator.requireFilePath(saveFilePath, "Save file must be selected");
             gameManager.loadGame(saveFile);
             showMainView();
@@ -189,7 +222,7 @@ public class StartController {
         try {
             action.run();
         } catch (IllegalArgumentException | IllegalStateException | UncheckedIOException exception) {
-            showError(exception.getMessage());
+            errorSink.accept(exception.getMessage());
         }
     }
 
@@ -201,11 +234,13 @@ public class StartController {
     }
 
     /**
-     * Shows an error dialog with a user-facing message.
+     * Default error sink used in production. Displays the message in a JavaFX
+     * {@link Alert} dialog. Tests inject a different consumer to avoid
+     * starting the JavaFX toolkit.
      *
      * @param message the error message to show
      */
-    private void showError(String message) {
+    private static void showAlert(String message) {
         Alert alert = new Alert(Alert.AlertType.ERROR);
         alert.setTitle("Could not open game");
         alert.setHeaderText(null);
@@ -214,9 +249,10 @@ public class StartController {
     }
 
     /**
-     * Displays the start screen on the primary stage.
+     * Displays the start screen on the primary stage and binds UI events.
      */
     public void show() {
+        bindEvents();
         stage.setTitle("Millions");
         stage.setScene(view.getScene());
         stage.show();

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
@@ -121,6 +121,13 @@ public class StartController {
     }
 
     /**
+     * Shows the main view using the active {@link GameManager}.
+     */
+    private void showMainView() {
+        new MainController(stage, gameManager).show();
+    }
+
+    /**
      * Displays the start screen on the primary stage.
      */
     public void show() {

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
@@ -87,27 +87,29 @@ public class StartController {
     /**
      * Validates input, starts a new game session through {@link GameManager},
      * and shows the main view.
-     *
-     * @throws IllegalArgumentException if name, capital, or stock file path is blank
      */
     private void handleStartGame() {
-        String name = view.getName();
-        String capital = view.getCapital();
-        String stockFilePath = view.getStockFilePath();
+        try {
+            String name = view.getName();
+            String capital = view.getCapital();
+            String stockFilePath = view.getStockFilePath();
 
-        if (name.isBlank()) {
-            throw new IllegalArgumentException("Player name cannot be blank");
-        }
-        if (capital.isBlank()) {
-            throw new IllegalArgumentException("Starting capital cannot be blank");
-        }
-        if (stockFilePath.isBlank()) {
-            throw new IllegalArgumentException("Stock file must be selected");
-        }
+            if (name.isBlank()) {
+                throw new IllegalArgumentException("Player name cannot be blank");
+            }
+            if (capital.isBlank()) {
+                throw new IllegalArgumentException("Starting capital cannot be blank");
+            }
+            if (stockFilePath.isBlank()) {
+                throw new IllegalArgumentException("Stock file must be selected");
+            }
 
-        BigDecimal parsedCapital = new BigDecimal(capital);
-        gameManager.createNewGame(name, parsedCapital, new File(stockFilePath));
-        showMainView();
+            BigDecimal parsedCapital = new BigDecimal(capital);
+            gameManager.createNewGame(name, parsedCapital, new File(stockFilePath));
+            showMainView();
+        } catch (IllegalArgumentException exception) {
+            showError(exception.getMessage());
+        }
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
@@ -110,7 +110,8 @@ public class StartController {
     }
 
     /**
-     * Validates input and loads an existing saved game.
+     * Validates input, loads an existing saved game through {@link GameManager},
+     * and shows the main view.
      *
      * @throws IllegalArgumentException if no save file has been selected
      */
@@ -121,7 +122,8 @@ public class StartController {
             throw new IllegalArgumentException("Save file must be selected");
         }
 
-        // TODO: load GameState, create MainController from state
+        gameManager.loadGame(new File(saveFilePath));
+        showMainView();
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
@@ -3,6 +3,7 @@ package edu.ntnu.idatt2003.millions.controller;
 import edu.ntnu.idatt2003.millions.manager.GameManager;
 import edu.ntnu.idatt2003.millions.view.StartView;
 import java.io.File;
+import java.io.UncheckedIOException;
 import java.math.BigDecimal;
 import java.util.Objects;
 import javafx.scene.control.Alert;
@@ -19,6 +20,11 @@ import javafx.stage.Stage;
  * <p>All UI-input validation is delegated to {@link StartInputValidator}
  * so the controller keeps a single, consistent validation strategy and
  * stays free of domain rules.</p>
+ *
+ * <p>Errors from the start flow are translated to user-facing dialogs by
+ * a shared error-handling helper that catches the concrete exception types
+ * the flow can legitimately produce (input validation, missing game state
+ * and file I/O), while letting programming errors surface as crashes.</p>
  */
 public class StartController {
 
@@ -137,7 +143,7 @@ public class StartController {
      * to call the handler without simulating a JavaFX button click.</p>
      */
     void handleStartGame() {
-        try {
+        runOrShowError(() -> {
             String name = StartInputValidator.requireName(view.getName());
             BigDecimal parsedCapital = StartInputValidator.parseCapital(view.getCapital());
             String stockFilePath = view.getStockFilePath();
@@ -149,9 +155,7 @@ public class StartController {
                 gameManager.createNewGame(name, parsedCapital, stockFile);
             }
             showMainView();
-        } catch (IllegalArgumentException exception) {
-            showError(exception.getMessage());
-        }
+        });
     }
 
     /**
@@ -162,12 +166,27 @@ public class StartController {
      * to call the handler without simulating a JavaFX button click.</p>
      */
     void handleLoadGame() {
-        try {
+        runOrShowError(() -> {
             String saveFilePath = view.getSaveFilePath();
             File saveFile = StartInputValidator.requireFilePath(saveFilePath, "Save file must be selected");
             gameManager.loadGame(saveFile);
             showMainView();
-        } catch (RuntimeException exception) {
+        });
+    }
+
+    /**
+     * Runs the given action and translates expected game errors to a user-facing
+     * error dialog. Catches the specific exception types that the start flow can
+     * legitimately produce: input validation failures, missing game state, and
+     * file I/O errors. Programming errors such as {@link NullPointerException}
+     * are intentionally not caught so they surface during development.
+     *
+     * @param action the start-flow action to execute
+     */
+    private void runOrShowError(Runnable action) {
+        try {
+            action.run();
+        } catch (IllegalArgumentException | IllegalStateException | UncheckedIOException exception) {
             showError(exception.getMessage());
         }
     }

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
@@ -140,19 +140,33 @@ public class StartController {
             if (name.isBlank()) {
                 throw new IllegalArgumentException("Player name cannot be blank");
             }
-            if (capital.isBlank()) {
-                throw new IllegalArgumentException("Starting capital cannot be blank");
-            }
             if (stockFilePath.isBlank()) {
                 throw new IllegalArgumentException("Stock file must be selected");
             }
 
-            BigDecimal parsedCapital = new BigDecimal(capital);
+            BigDecimal parsedCapital = parseCapital(capital);
             gameManager.createNewGame(name, parsedCapital, new File(stockFilePath));
             showMainView();
         } catch (IllegalArgumentException exception) {
             showError(exception.getMessage());
         }
+    }
+
+    /**
+     * Parses starting capital from UI input.
+     *
+     * <p>The method is package-private so controller tests can verify the
+     * validation and parsing logic without starting JavaFX.</p>
+     *
+     * @param capital the capital text entered by the user
+     * @return the parsed starting capital
+     * @throws IllegalArgumentException if the capital is null, blank, or not a valid decimal number
+     */
+    BigDecimal parseCapital(String capital) {
+        if (capital == null || capital.isBlank()) {
+            throw new IllegalArgumentException("Starting capital cannot be blank");
+        }
+        return new BigDecimal(capital);
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
@@ -1,5 +1,6 @@
 package edu.ntnu.idatt2003.millions.controller;
 
+import edu.ntnu.idatt2003.millions.manager.GameManager;
 import edu.ntnu.idatt2003.millions.view.StartView;
 import java.io.File;
 import java.util.Objects;
@@ -17,9 +18,10 @@ public class StartController {
 
     private final Stage stage;
     private final StartView view;
+    private final GameManager gameManager;
 
     /**
-     * Constructs a new StartController and binds all UI events.
+     * Constructs a new StartController with a {@link GameManager} and binds all UI events.
      *
      * @param stage the primary application stage
      * @throws NullPointerException if stage is null
@@ -28,6 +30,7 @@ public class StartController {
         Objects.requireNonNull(stage, "Stage cannot be null");
         this.stage = stage;
         this.view = new StartView();
+        this.gameManager = new GameManager();
         bindEvents();
     }
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
@@ -142,70 +142,17 @@ public class StartController {
                 throw new IllegalArgumentException("Player name cannot be blank");
             }
 
-            BigDecimal parsedCapital = parseCapital(capital);
+            BigDecimal parsedCapital = StartInputValidator.parseCapital(capital);
             if (stockFilePath.isBlank()) {
                 gameManager.createNewGame(name, parsedCapital);
             } else {
-                File stockFile = requireCsvFilePath(stockFilePath);
+                File stockFile = StartInputValidator.requireCsvFilePath(stockFilePath);
                 gameManager.createNewGame(name, parsedCapital, stockFile);
             }
             showMainView();
         } catch (IllegalArgumentException exception) {
             showError(exception.getMessage());
         }
-    }
-
-    /**
-     * Parses starting capital from UI input.
-     *
-     * <p>The method is package-private so controller tests can verify the
-     * validation and parsing logic without starting JavaFX.</p>
-     *
-     * @param capital the capital text entered by the user
-     * @return the parsed starting capital
-     * @throws IllegalArgumentException if the capital is null, blank, or not a valid decimal number
-     */
-    static BigDecimal parseCapital(String capital) {
-        if (capital == null || capital.isBlank()) {
-            throw new IllegalArgumentException("Starting capital cannot be blank");
-        }
-        return new BigDecimal(capital);
-    }
-
-    /**
-     * Validates a file path from UI input and converts it to a {@link File}.
-     *
-     * <p>The method is package-private so controller tests can verify file path
-     * validation without starting JavaFX.</p>
-     *
-     * @param filePath the file path text entered or selected by the user
-     * @param message  the exception message used when the path is missing
-     * @return a file representing the validated path
-     * @throws IllegalArgumentException if the path is null or blank
-     */
-    static File requireFilePath(String filePath, String message) {
-        if (filePath == null || filePath.isBlank()) {
-            throw new IllegalArgumentException(message);
-        }
-        return new File(filePath);
-    }
-
-    /**
-     * Validates a custom stock file path and requires it to point to a CSV file.
-     *
-     * <p>The method is package-private so controller tests can verify stock file
-     * validation without starting JavaFX.</p>
-     *
-     * @param filePath the stock file path selected by the user
-     * @return a CSV file representing the validated path
-     * @throws IllegalArgumentException if the path is missing or does not end with {@code .csv}
-     */
-    static File requireCsvFilePath(String filePath) {
-        File file = requireFilePath(filePath, "Stock file must be selected");
-        if (!file.getName().toLowerCase().endsWith(".csv")) {
-            throw new IllegalArgumentException("Stock file must be a CSV file");
-        }
-        return file;
     }
 
     /**
@@ -218,7 +165,7 @@ public class StartController {
     void handleLoadGame() {
         try {
             String saveFilePath = view.getSaveFilePath();
-            File saveFile = requireFilePath(saveFilePath, "Save file must be selected");
+            File saveFile = StartInputValidator.requireFilePath(saveFilePath, "Save file must be selected");
             gameManager.loadGame(saveFile);
             showMainView();
         } catch (RuntimeException exception) {

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
@@ -14,7 +14,11 @@ import javafx.stage.Stage;
  *
  * <p>Handles user interactions on the start screen, including
  * file selection for stock data and saved games, as well as
- * starting or loading a game session.
+ * starting or loading a game session.</p>
+ *
+ * <p>All UI-input validation is delegated to {@link StartInputValidator}
+ * so the controller keeps a single, consistent validation strategy and
+ * stays free of domain rules.</p>
  */
 public class StartController {
 
@@ -134,15 +138,10 @@ public class StartController {
      */
     void handleStartGame() {
         try {
-            String name = view.getName();
-            String capital = view.getCapital();
+            String name = StartInputValidator.requireName(view.getName());
+            BigDecimal parsedCapital = StartInputValidator.parseCapital(view.getCapital());
             String stockFilePath = view.getStockFilePath();
 
-            if (name.isBlank()) {
-                throw new IllegalArgumentException("Player name cannot be blank");
-            }
-
-            BigDecimal parsedCapital = StartInputValidator.parseCapital(capital);
             if (stockFilePath.isBlank()) {
                 gameManager.createNewGame(name, parsedCapital);
             } else {

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
@@ -5,6 +5,7 @@ import edu.ntnu.idatt2003.millions.view.StartView;
 import java.io.File;
 import java.math.BigDecimal;
 import java.util.Objects;
+import javafx.scene.control.Alert;
 import javafx.stage.FileChooser;
 import javafx.stage.Stage;
 
@@ -131,6 +132,19 @@ public class StartController {
      */
     private void showMainView() {
         new MainController(stage, gameManager).show();
+    }
+
+    /**
+     * Shows an error dialog with a user-facing message.
+     *
+     * @param message the error message to show
+     */
+    private void showError(String message) {
+        Alert alert = new Alert(Alert.AlertType.ERROR);
+        alert.setTitle("Could not start game");
+        alert.setHeaderText(null);
+        alert.setContentText(message);
+        alert.showAndWait();
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
@@ -23,16 +23,35 @@ public class StartController {
     private final GameManager gameManager;
 
     /**
-     * Constructs a new StartController with a {@link GameManager} and binds all UI events.
+     * Constructs a new StartController with a default {@link GameManager}.
+     *
+     * <p>This constructor is used by the application startup flow. It delegates
+     * to {@link #StartController(Stage, GameManager)} so tests and alternate
+     * startup paths can inject their own game manager.</p>
      *
      * @param stage the primary application stage
      * @throws NullPointerException if stage is null
      */
     public StartController(Stage stage) {
+        this(stage, new GameManager());
+    }
+
+    /**
+     * Constructs a new StartController with the given {@link GameManager} and binds all UI events.
+     *
+     * <p>Injecting the manager keeps the controller testable while preserving
+     * the normal production flow through {@link #StartController(Stage)}.</p>
+     *
+     * @param stage       the primary application stage
+     * @param gameManager the game manager used to create or load game state
+     * @throws NullPointerException if stage or game manager is null
+     */
+    public StartController(Stage stage, GameManager gameManager) {
         Objects.requireNonNull(stage, "Stage cannot be null");
+        Objects.requireNonNull(gameManager, "GameManager cannot be null");
         this.stage = stage;
         this.view = new StartView();
-        this.gameManager = new GameManager();
+        this.gameManager = gameManager;
         bindEvents();
     }
 
@@ -145,7 +164,7 @@ public class StartController {
      */
     private void showError(String message) {
         Alert alert = new Alert(Alert.AlertType.ERROR);
-        alert.setTitle("Could not start game");
+        alert.setTitle("Could not open game");
         alert.setHeaderText(null);
         alert.setContentText(message);
         alert.showAndWait();

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
@@ -123,8 +123,11 @@ public class StartController {
     /**
      * Validates input, starts a new game session through {@link GameManager},
      * and shows the main view.
+     *
+     * <p>Package-private visibility allows controller tests in this package
+     * to call the handler without simulating a JavaFX button click.</p>
      */
-    private void handleStartGame() {
+    void handleStartGame() {
         try {
             String name = view.getName();
             String capital = view.getCapital();
@@ -151,8 +154,11 @@ public class StartController {
     /**
      * Validates input, loads an existing saved game through {@link GameManager},
      * and shows the main view.
+     *
+     * <p>Package-private visibility allows controller tests in this package
+     * to call the handler without simulating a JavaFX button click.</p>
      */
-    private void handleLoadGame() {
+    void handleLoadGame() {
         try {
             String saveFilePath = view.getSaveFilePath();
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
@@ -3,6 +3,7 @@ package edu.ntnu.idatt2003.millions.controller;
 import edu.ntnu.idatt2003.millions.manager.GameManager;
 import edu.ntnu.idatt2003.millions.view.StartView;
 import java.io.File;
+import java.math.BigDecimal;
 import java.util.Objects;
 import javafx.stage.FileChooser;
 import javafx.stage.Stage;
@@ -83,7 +84,8 @@ public class StartController {
     }
 
     /**
-     * Validates input and starts a new game session.
+     * Validates input, starts a new game session through {@link GameManager},
+     * and shows the main view.
      *
      * @throws IllegalArgumentException if name, capital, or stock file path is blank
      */
@@ -102,7 +104,9 @@ public class StartController {
             throw new IllegalArgumentException("Stock file must be selected");
         }
 
-        // TODO: parse capital, load exchange from file, create Player, start MainController
+        BigDecimal parsedCapital = new BigDecimal(capital);
+        gameManager.createNewGame(name, parsedCapital, new File(stockFilePath));
+        showMainView();
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
@@ -126,7 +126,8 @@ public class StartController {
 
     /**
      * Validates input, starts a new game session through {@link GameManager},
-     * and shows the main view.
+     * and shows the main view. A custom stock file is optional; if none is
+     * selected, the default stock data is used.
      *
      * <p>Package-private visibility allows controller tests in this package
      * to call the handler without simulating a JavaFX button click.</p>
@@ -142,8 +143,12 @@ public class StartController {
             }
 
             BigDecimal parsedCapital = parseCapital(capital);
-            File stockFile = requireFilePath(stockFilePath, "Stock file must be selected");
-            gameManager.createNewGame(name, parsedCapital, stockFile);
+            if (stockFilePath.isBlank()) {
+                gameManager.createNewGame(name, parsedCapital);
+            } else {
+                File stockFile = requireFilePath(stockFilePath, "Stock file must be selected");
+                gameManager.createNewGame(name, parsedCapital, stockFile);
+            }
             showMainView();
         } catch (IllegalArgumentException exception) {
             showError(exception.getMessage());

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
@@ -115,18 +115,20 @@ public class StartController {
     /**
      * Validates input, loads an existing saved game through {@link GameManager},
      * and shows the main view.
-     *
-     * @throws IllegalArgumentException if no save file has been selected
      */
     private void handleLoadGame() {
-        String saveFilePath = view.getSaveFilePath();
+        try {
+            String saveFilePath = view.getSaveFilePath();
 
-        if (saveFilePath.isBlank()) {
-            throw new IllegalArgumentException("Save file must be selected");
+            if (saveFilePath.isBlank()) {
+                throw new IllegalArgumentException("Save file must be selected");
+            }
+
+            gameManager.loadGame(new File(saveFilePath));
+            showMainView();
+        } catch (RuntimeException exception) {
+            showError(exception.getMessage());
         }
-
-        gameManager.loadGame(new File(saveFilePath));
-        showMainView();
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/StartInputValidator.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/StartInputValidator.java
@@ -1,0 +1,61 @@
+package edu.ntnu.idatt2003.millions.controller;
+
+import java.io.File;
+import java.math.BigDecimal;
+
+/**
+ * Validates and converts input from the start screen.
+ *
+ * <p>This utility keeps simple UI-input validation out of {@link StartController}
+ * while staying in the controller layer. It does not contain domain business rules.</p>
+ */
+final class StartInputValidator {
+
+    private StartInputValidator() {
+        // Utility class - should not be instantiated
+    }
+
+    /**
+     * Parses starting capital from UI input.
+     *
+     * @param capital the capital text entered by the user
+     * @return the parsed starting capital
+     * @throws IllegalArgumentException if the capital is null, blank, or not a valid decimal number
+     */
+    static BigDecimal parseCapital(String capital) {
+        if (capital == null || capital.isBlank()) {
+            throw new IllegalArgumentException("Starting capital cannot be blank");
+        }
+        return new BigDecimal(capital);
+    }
+
+    /**
+     * Validates a file path from UI input and converts it to a {@link File}.
+     *
+     * @param filePath the file path text entered or selected by the user
+     * @param message  the exception message used when the path is missing
+     * @return a file representing the validated path
+     * @throws IllegalArgumentException if the path is null or blank
+     */
+    static File requireFilePath(String filePath, String message) {
+        if (filePath == null || filePath.isBlank()) {
+            throw new IllegalArgumentException(message);
+        }
+        return new File(filePath);
+    }
+
+    /**
+     * Validates a custom stock file path and requires it to point to a CSV file.
+     *
+     * @param filePath the stock file path selected by the user
+     * @return a CSV file representing the validated path
+     * @throws IllegalArgumentException if the path is missing or does not end with {@code .csv}
+     */
+    static File requireCsvFilePath(String filePath) {
+        File file = requireFilePath(filePath, "Stock file must be selected");
+        if (!file.getName().toLowerCase().endsWith(".csv")) {
+            throw new IllegalArgumentException("Stock file must be a CSV file");
+        }
+        return file;
+    }
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/StartInputValidator.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/StartInputValidator.java
@@ -38,13 +38,19 @@ final class StartInputValidator {
      *
      * @param capital the capital text entered by the user
      * @return the parsed starting capital
-     * @throws IllegalArgumentException if the capital is null, blank, or not a valid decimal number
+     * @throws IllegalArgumentException if the capital is null, blank, not a valid
+     *                                  decimal number, or not strictly greater
+     *                                  than zero
      */
     static BigDecimal parseCapital(String capital) {
         if (capital == null || capital.isBlank()) {
             throw new IllegalArgumentException("Starting capital cannot be blank");
         }
-        return new BigDecimal(capital);
+        BigDecimal parsed = new BigDecimal(capital);
+        if (parsed.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("Starting capital must be greater than zero");
+        }
+        return parsed;
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/StartInputValidator.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/StartInputValidator.java
@@ -2,6 +2,7 @@ package edu.ntnu.idatt2003.millions.controller;
 
 import java.io.File;
 import java.math.BigDecimal;
+import java.util.Currency;
 
 /**
  * Validates and converts input from the start screen.
@@ -59,6 +60,20 @@ final class StartInputValidator {
             throw new IllegalArgumentException(message);
         }
         return new File(filePath);
+    }
+
+    /**
+     * Validates that a currency has been selected.
+     *
+     * @param currency the currency selected in the UI
+     * @return the validated currency
+     * @throws IllegalArgumentException if the currency is null
+     */
+    static Currency requireCurrency(Currency currency) {
+        if (currency == null) {
+            throw new IllegalArgumentException("Currency must be selected");
+        }
+        return currency;
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/StartInputValidator.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/StartInputValidator.java
@@ -8,11 +8,28 @@ import java.math.BigDecimal;
  *
  * <p>This utility keeps simple UI-input validation out of {@link StartController}
  * while staying in the controller layer. It does not contain domain business rules.</p>
+ *
+ * <p>Provides validators for player name, starting capital and file paths,
+ * including a CSV-specific check for stock data files.</p>
  */
 final class StartInputValidator {
 
     private StartInputValidator() {
         // Utility class - should not be instantiated
+    }
+
+    /**
+     * Validates a player name from UI input.
+     *
+     * @param name the player name entered by the user
+     * @return the trimmed player name
+     * @throws IllegalArgumentException if the name is null or blank
+     */
+    static String requireName(String name) {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("Player name cannot be blank");
+        }
+        return name.trim();
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/StartInputValidator.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/StartInputValidator.java
@@ -19,7 +19,7 @@ final class StartInputValidator {
         // Utility class - should not be instantiated
     }
 
-    /**
+     /**
      * Validates a player name from UI input.
      *
      * @param name the player name entered by the user

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/stock/CsvStockFileHandler.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/stock/CsvStockFileHandler.java
@@ -5,8 +5,11 @@ import edu.ntnu.idatt2003.millions.model.stock.Stock;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -20,6 +23,9 @@ import java.util.Objects;
  * <p>Each line in the file represents a stock on the form:
  * {@code symbol,name,price}. Lines starting with {@code #} and
  * blank lines are ignored.</p>
+ *
+ * <p>Both file paths and arbitrary input streams are supported as input,
+ * which lets callers parse classpath resources without writing them to disk.</p>
  */
 public class CsvStockFileHandler implements StockFileHandler {
 
@@ -68,18 +74,49 @@ public class CsvStockFileHandler implements StockFileHandler {
         Objects.requireNonNull(path, "Path cannot be null");
 
         try (BufferedReader reader = Files.newBufferedReader(path)) {
-            return reader.lines()
-                    .filter(line -> !line.isBlank() && !line.startsWith(COMMENT_PREFIX))
-                    .map(line -> line.split(DELIMITER))
-                    .filter(fields -> fields.length == EXPECTED_FIELDS)
-                    .map(fields -> new Stock(
-                            fields[SYMBOL_INDEX].trim(),
-                            fields[NAME_INDEX].trim(),
-                            new ArrayList<>(List.of(new BigDecimal(fields[PRICE_INDEX].trim())))))
-                    .toList();
+            return parse(reader);
         } catch (IOException e) {
             throw new UncheckedIOException("Could not read file: " + path, e);
         }
+    }
+
+    /**
+     * Reads stock data from a CSV input stream. Lines starting with {@code #}
+     * and blank lines are skipped. Lines with invalid format are also skipped.
+     * The caller retains ownership of the stream and is responsible for
+     * closing it.
+     *
+     * @param inputStream the input stream to read from
+     * @return a list of stocks parsed from the stream
+     * @throws NullPointerException if inputStream is null
+     * @throws UncheckedIOException if the stream cannot be read
+     */
+    @Override
+    public List<Stock> readStocks(InputStream inputStream) {
+        Objects.requireNonNull(inputStream, "Input stream cannot be null");
+
+        BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
+        return parse(reader);
+    }
+
+    /**
+     * Parses CSV stock data from the given reader. Lines starting with
+     * {@code #} and blank lines are skipped, as are lines that do not have
+     * the expected number of fields.
+     *
+     * @param reader the buffered reader to parse from
+     * @return a list of stocks parsed from the reader
+     */
+    private List<Stock> parse(BufferedReader reader) {
+        return reader.lines()
+                .filter(line -> !line.isBlank() && !line.startsWith(COMMENT_PREFIX))
+                .map(line -> line.split(DELIMITER))
+                .filter(fields -> fields.length == EXPECTED_FIELDS)
+                .map(fields -> new Stock(
+                        fields[SYMBOL_INDEX].trim(),
+                        fields[NAME_INDEX].trim(),
+                        new ArrayList<>(List.of(new BigDecimal(fields[PRICE_INDEX].trim())))))
+                .toList();
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/stock/CsvStockFileHandler.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/stock/CsvStockFileHandler.java
@@ -13,6 +13,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Currency;
 import java.util.List;
 import java.util.Objects;
 
@@ -28,6 +29,13 @@ import java.util.Objects;
  * which lets callers parse classpath resources without writing them to disk.</p>
  */
 public class CsvStockFileHandler implements StockFileHandler {
+
+    /**
+     * Default currency assigned to parsed stocks when no currency is supplied
+     * by the caller. Used by the no-currency overloads to preserve previous
+     * behaviour.
+     */
+    private static final Currency DEFAULT_CURRENCY = Currency.getInstance("USD");
 
     /**
      * Delimiter used to separate fields in the CSV file.
@@ -71,10 +79,27 @@ public class CsvStockFileHandler implements StockFileHandler {
      */
     @Override
     public List<Stock> readStocks(Path path) {
+        return readStocks(path, DEFAULT_CURRENCY);
+    }
+
+    /**
+     * Reads stock data from a CSV file at the given path and tags every
+     * parsed stock with the supplied currency. Lines starting with {@code #}
+     * and blank lines are skipped. Lines with invalid format are also skipped.
+     *
+     * @param path     the path to the CSV file to read from
+     * @param currency the currency to assign to every parsed stock
+     * @return a list of stocks parsed from the file
+     * @throws NullPointerException if path or currency is null
+     * @throws UncheckedIOException if the file cannot be read
+     */
+    @Override
+    public List<Stock> readStocks(Path path, Currency currency) {
         Objects.requireNonNull(path, "Path cannot be null");
+        Objects.requireNonNull(currency, "Currency cannot be null");
 
         try (BufferedReader reader = Files.newBufferedReader(path)) {
-            return parse(reader);
+            return parse(reader, currency);
         } catch (IOException e) {
             throw new UncheckedIOException("Could not read file: " + path, e);
         }
@@ -93,21 +118,40 @@ public class CsvStockFileHandler implements StockFileHandler {
      */
     @Override
     public List<Stock> readStocks(InputStream inputStream) {
-        Objects.requireNonNull(inputStream, "Input stream cannot be null");
-
-        BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
-        return parse(reader);
+        return readStocks(inputStream, DEFAULT_CURRENCY);
     }
 
     /**
-     * Parses CSV stock data from the given reader. Lines starting with
-     * {@code #} and blank lines are skipped, as are lines that do not have
-     * the expected number of fields.
+     * Reads stock data from a CSV input stream and tags every parsed stock
+     * with the supplied currency. Lines starting with {@code #} and blank
+     * lines are skipped. Lines with invalid format are also skipped. The
+     * caller retains ownership of the stream and is responsible for closing it.
      *
-     * @param reader the buffered reader to parse from
+     * @param inputStream the input stream to read from
+     * @param currency    the currency to assign to every parsed stock
+     * @return a list of stocks parsed from the stream
+     * @throws NullPointerException if inputStream or currency is null
+     */
+    @Override
+    public List<Stock> readStocks(InputStream inputStream, Currency currency) {
+        Objects.requireNonNull(inputStream, "Input stream cannot be null");
+        Objects.requireNonNull(currency, "Currency cannot be null");
+
+        BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
+        return parse(reader, currency);
+    }
+
+    /**
+     * Parses CSV stock data from the given reader and tags every produced
+     * stock with the supplied currency. Lines starting with {@code #} and
+     * blank lines are skipped, as are lines that do not have the expected
+     * number of fields.
+     *
+     * @param reader   the buffered reader to parse from
+     * @param currency the currency to assign to every parsed stock
      * @return a list of stocks parsed from the reader
      */
-    private List<Stock> parse(BufferedReader reader) {
+    private List<Stock> parse(BufferedReader reader, Currency currency) {
         return reader.lines()
                 .filter(line -> !line.isBlank() && !line.startsWith(COMMENT_PREFIX))
                 .map(line -> line.split(DELIMITER))
@@ -115,7 +159,8 @@ public class CsvStockFileHandler implements StockFileHandler {
                 .map(fields -> new Stock(
                         fields[SYMBOL_INDEX].trim(),
                         fields[NAME_INDEX].trim(),
-                        new ArrayList<>(List.of(new BigDecimal(fields[PRICE_INDEX].trim())))))
+                        new ArrayList<>(List.of(new BigDecimal(fields[PRICE_INDEX].trim()))),
+                        currency))
                 .toList();
     }
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/stock/StockFileHandler.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/stock/StockFileHandler.java
@@ -2,6 +2,7 @@ package edu.ntnu.idatt2003.millions.file.stock;
 
 import edu.ntnu.idatt2003.millions.model.stock.Stock;
 
+import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -9,6 +10,10 @@ import java.util.List;
  * Interface for reading and writing stock data to and from files.
  * Implementations of this interface handle a specific file format,
  * making it easy to add support for new formats in the future.
+ *
+ * <p>Reading is exposed for both file paths and arbitrary input streams,
+ * which lets callers parse classpath resources or in-memory data without
+ * routing them through the filesystem.</p>
  */
 public interface StockFileHandler {
 
@@ -19,6 +24,17 @@ public interface StockFileHandler {
      * @return a list of stocks parsed from the file
      */
     List<Stock> readStocks(Path path);
+
+    /**
+     * Reads stock data from the given input stream. Useful for parsing
+     * classpath resources or in-memory data without writing to disk.
+     * The caller retains ownership of the stream and is responsible for
+     * closing it.
+     *
+     * @param inputStream the input stream to read from
+     * @return a list of stocks parsed from the stream
+     */
+    List<Stock> readStocks(InputStream inputStream);
 
     /**
      * Writes stock data to the file at the given path.

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/stock/StockFileHandler.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/stock/StockFileHandler.java
@@ -4,6 +4,7 @@ import edu.ntnu.idatt2003.millions.model.stock.Stock;
 
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.util.Currency;
 import java.util.List;
 
 /**
@@ -18,7 +19,8 @@ import java.util.List;
 public interface StockFileHandler {
 
     /**
-     * Reads stock data from the file at the given path.
+     * Reads stock data from the file at the given path. Stocks are tagged
+     * with the implementation's default currency.
      *
      * @param path the path to the file to read from
      * @return a list of stocks parsed from the file
@@ -26,15 +28,37 @@ public interface StockFileHandler {
     List<Stock> readStocks(Path path);
 
     /**
+     * Reads stock data from the file at the given path and tags each stock
+     * with the supplied currency.
+     *
+     * @param path     the path to the file to read from
+     * @param currency the currency to assign to every parsed stock
+     * @return a list of stocks parsed from the file
+     */
+    List<Stock> readStocks(Path path, Currency currency);
+
+    /**
      * Reads stock data from the given input stream. Useful for parsing
      * classpath resources or in-memory data without writing to disk.
      * The caller retains ownership of the stream and is responsible for
-     * closing it.
+     * closing it. Stocks are tagged with the implementation's default
+     * currency.
      *
      * @param inputStream the input stream to read from
      * @return a list of stocks parsed from the stream
      */
     List<Stock> readStocks(InputStream inputStream);
+
+    /**
+     * Reads stock data from the given input stream and tags each stock
+     * with the supplied currency. The caller retains ownership of the
+     * stream and is responsible for closing it.
+     *
+     * @param inputStream the input stream to read from
+     * @param currency    the currency to assign to every parsed stock
+     * @return a list of stocks parsed from the stream
+     */
+    List<Stock> readStocks(InputStream inputStream, Currency currency);
 
     /**
      * Writes stock data to the file at the given path.

--- a/src/main/java/edu/ntnu/idatt2003/millions/manager/GameManager.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/manager/GameManager.java
@@ -39,6 +39,11 @@ import java.util.Objects;
  * and ensures that observers are notified consistently after every
  * state-changing operation.</p>
  *
+ * <p>Game creation validates player input before performing any file I/O,
+ * and only mutates the active game state once both the player and the
+ * exchange have been successfully constructed. This ensures that a failed
+ * {@code createNewGame} call leaves any previously active game intact.</p>
+ *
  * <p>Also exposes facade query methods for derived values such as net worth,
  * weekly change and player status. These methods let the view layer read
  * derived state without composing {@link Player} and {@link Exchange}
@@ -92,9 +97,11 @@ public class GameManager {
     /**
      * Creates a new game with the given player name and starting capital.
      *
-     * <p>Loads default stock data from {@link #DEFAULT_STOCK_RESOURCE}, creates
-     * a new {@link Player}, and instantiates an {@link Exchange}. Observers are
-     * notified once the new game state is active.</p>
+     * <p>Validates the player input first by constructing a {@link Player},
+     * then loads default stock data from {@link #DEFAULT_STOCK_RESOURCE} and
+     * instantiates an {@link Exchange}. The active game state is only mutated
+     * once both steps succeed, leaving any previous game intact on failure.
+     * Observers are notified once the new game state is active.</p>
      *
      * @param name    the name of the player
      * @param capital the starting capital for the player, in NOK
@@ -105,18 +112,21 @@ public class GameManager {
      * @throws UncheckedIOException     if the default stock data cannot be read
      */
     public void createNewGame(String name, BigDecimal capital) {
+        Player newPlayer = new Player(name, capital);
         List<Stock> stocks = loadDefaultStocks();
-        initializeNewGame(name, capital, stocks);
+        activate(newPlayer, stocks);
     }
 
     /**
      * Creates a new game with the given player name, starting capital,
      * and custom stock data file.
      *
-     * <p>Loads stocks from {@code stockFile} through a {@link StockFileHandler},
-     * creates a new {@link Player}, and instantiates an {@link Exchange} with a
-     * {@link FixedRateCurrencyConverter}. Observers are notified once the new
-     * game state is active.
+     * <p>Validates the player input first by constructing a {@link Player},
+     * then loads stocks from {@code stockFile} through a {@link StockFileHandler}
+     * and instantiates an {@link Exchange} with a {@link FixedRateCurrencyConverter}.
+     * The active game state is only mutated once both steps succeed, leaving any
+     * previous game intact on failure. Observers are notified once the new game
+     * state is active.</p>
      *
      * @param name      the name of the player
      * @param capital   the starting capital for the player, in NOK
@@ -127,21 +137,22 @@ public class GameManager {
      */
     public void createNewGame(String name, BigDecimal capital, File stockFile) {
         Objects.requireNonNull(stockFile, "Stock file cannot be null");
+        Player newPlayer = new Player(name, capital);
         StockFileHandler stockFileHandler = new CsvStockFileHandler();
         List<Stock> stocks = stockFileHandler.readStocks(stockFile.toPath());
-
-        initializeNewGame(name, capital, stocks);
+        activate(newPlayer, stocks);
     }
 
     /**
-     * Initializes the active game state from already loaded stocks.
+     * Activates a new game state once the player and stocks have been
+     * successfully constructed and loaded. Replaces the active player and
+     * exchange atomically and notifies observers.
      *
-     * @param name    the name of the player
-     * @param capital the starting capital for the player, in NOK
-     * @param stocks  the stocks to list on the exchange
+     * @param newPlayer the validated player instance
+     * @param stocks    the stocks to list on the exchange
      */
-    private void initializeNewGame(String name, BigDecimal capital, List<Stock> stocks) {
-        this.player = new Player(name, capital);
+    private void activate(Player newPlayer, List<Stock> stocks) {
+        this.player = newPlayer;
         this.exchange = new Exchange(DEFAULT_EXCHANGE_NAME, stocks, new FixedRateCurrencyConverter());
         notifyObservers();
     }

--- a/src/main/java/edu/ntnu/idatt2003/millions/manager/GameManager.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/manager/GameManager.java
@@ -20,9 +20,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.math.BigDecimal;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -159,6 +156,8 @@ public class GameManager {
 
     /**
      * Loads default stock data from the application resources.
+     * Streams the resource directly through the {@link StockFileHandler}
+     * so no intermediate file is written to disk.
      *
      * @return the default stocks for a new game
      * @throws IllegalStateException if the default stock data cannot be found
@@ -170,14 +169,7 @@ public class GameManager {
             if (inputStream == null) {
                 throw new IllegalStateException("Default stock data not found: " + DEFAULT_STOCK_RESOURCE);
             }
-
-            Path tempFile = Files.createTempFile("default-stocks", ".csv");
-            try {
-                Files.copy(inputStream, tempFile, StandardCopyOption.REPLACE_EXISTING);
-                return stockFileHandler.readStocks(tempFile);
-            } finally {
-                Files.deleteIfExists(tempFile);
-            }
+            return stockFileHandler.readStocks(inputStream);
         } catch (IOException e) {
             throw new UncheckedIOException("Could not read default stock data", e);
         }

--- a/src/main/java/edu/ntnu/idatt2003/millions/manager/GameManager.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/manager/GameManager.java
@@ -16,7 +16,13 @@ import edu.ntnu.idatt2003.millions.model.transaction.Transaction;
 import edu.ntnu.idatt2003.millions.observer.GameObserver;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.math.BigDecimal;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -41,6 +47,7 @@ import java.util.Objects;
 public class GameManager {
 
     private static final String DEFAULT_EXCHANGE_NAME = "MainExchange";
+    private static final String DEFAULT_STOCK_RESOURCE = "/data/sp500.csv";
 
     private Player player;
     private Exchange exchange;
@@ -83,8 +90,28 @@ public class GameManager {
     }
 
     /**
+     * Creates a new game with the given player name and starting capital.
+     *
+     * <p>Loads default stock data from {@link #DEFAULT_STOCK_RESOURCE}, creates
+     * a new {@link Player}, and instantiates an {@link Exchange}. Observers are
+     * notified once the new game state is active.</p>
+     *
+     * @param name    the name of the player
+     * @param capital the starting capital for the player, in NOK
+     * @throws NullPointerException     if name or capital is null
+     * @throws IllegalArgumentException if name is blank, capital is negative,
+     *                                  or the default stock file contains no stocks
+     * @throws IllegalStateException    if the default stock data cannot be found
+     * @throws UncheckedIOException     if the default stock data cannot be read
+     */
+    public void createNewGame(String name, BigDecimal capital) {
+        List<Stock> stocks = loadDefaultStocks();
+        initializeNewGame(name, capital, stocks);
+    }
+
+    /**
      * Creates a new game with the given player name, starting capital,
-     * and stock data file.
+     * and custom stock data file.
      *
      * <p>Loads stocks from {@code stockFile} through a {@link StockFileHandler},
      * creates a new {@link Player}, and instantiates an {@link Exchange} with a
@@ -103,9 +130,46 @@ public class GameManager {
         StockFileHandler stockFileHandler = new CsvStockFileHandler();
         List<Stock> stocks = stockFileHandler.readStocks(stockFile.toPath());
 
+        initializeNewGame(name, capital, stocks);
+    }
+
+    /**
+     * Initializes the active game state from already loaded stocks.
+     *
+     * @param name    the name of the player
+     * @param capital the starting capital for the player, in NOK
+     * @param stocks  the stocks to list on the exchange
+     */
+    private void initializeNewGame(String name, BigDecimal capital, List<Stock> stocks) {
         this.player = new Player(name, capital);
         this.exchange = new Exchange(DEFAULT_EXCHANGE_NAME, stocks, new FixedRateCurrencyConverter());
         notifyObservers();
+    }
+
+    /**
+     * Loads default stock data from the application resources.
+     *
+     * @return the default stocks for a new game
+     * @throws IllegalStateException if the default stock data cannot be found
+     * @throws UncheckedIOException  if the default stock data cannot be read
+     */
+    private List<Stock> loadDefaultStocks() {
+        StockFileHandler stockFileHandler = new CsvStockFileHandler();
+        try (InputStream inputStream = GameManager.class.getResourceAsStream(DEFAULT_STOCK_RESOURCE)) {
+            if (inputStream == null) {
+                throw new IllegalStateException("Default stock data not found: " + DEFAULT_STOCK_RESOURCE);
+            }
+
+            Path tempFile = Files.createTempFile("default-stocks", ".csv");
+            try {
+                Files.copy(inputStream, tempFile, StandardCopyOption.REPLACE_EXISTING);
+                return stockFileHandler.readStocks(tempFile);
+            } finally {
+                Files.deleteIfExists(tempFile);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Could not read default stock data", e);
+        }
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/manager/GameManager.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/manager/GameManager.java
@@ -21,35 +21,32 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Currency;
 import java.util.List;
 import java.util.Objects;
 
 /**
- * Manages the overall game lifecycle.
- * Responsible for creating new games, loading saved games,
- * saving the current game state, and advancing the game week.
- * Notifies registered {@link GameObserver}s when the game state changes.
- * Delegates file operations to {@link GameFileHandler}.
+ * Service-layer manager for the game lifecycle: creates new games, loads and
+ * saves game state, and advances the game week. Owns the active {@link Player}
+ * and {@link Exchange}, and notifies registered {@link GameObserver}s after
+ * every state-changing operation. Delegates persistence to {@link GameFileHandler}.
  *
- * <p>Acts as the application's Service Layer: owns the game state
- * ({@link Player}, {@link Exchange}), exposes a stable API to controllers,
- * and ensures that observers are notified consistently after every
- * state-changing operation.</p>
+ * <p>{@code createNewGame} validates player input before performing any file I/O
+ * and only swaps in the new state once the player and exchange are fully
+ * constructed, so failures leave the previous game intact. The four-argument
+ * overload accepts the {@link Currency} of the stock prices so the
+ * {@link Exchange} can convert to NOK through its {@link CurrencyConverter};
+ * the three-argument overload defaults to USD.</p>
  *
- * <p>Game creation validates player input before performing any file I/O,
- * and only mutates the active game state once both the player and the
- * exchange have been successfully constructed. This ensures that a failed
- * {@code createNewGame} call leaves any previously active game intact.</p>
- *
- * <p>Also exposes facade query methods for derived values such as net worth,
- * weekly change and player status. These methods let the view layer read
- * derived state without composing {@link Player} and {@link Exchange}
- * directly through {@link CurrencyConverter}.</p>
+ * <p>Also exposes facade query methods (net worth, weekly change, status,
+ * portfolio value) so views can read derived values without composing
+ * {@link Player} and {@link Exchange} through the converter themselves.</p>
  */
 public class GameManager {
 
     private static final String DEFAULT_EXCHANGE_NAME = "MainExchange";
     private static final String DEFAULT_STOCK_RESOURCE = "/data/sp500.csv";
+    private static final Currency DEFAULT_STOCK_CURRENCY = Currency.getInstance("USD");
 
     private Player player;
     private Exchange exchange;
@@ -115,28 +112,40 @@ public class GameManager {
     }
 
     /**
-     * Creates a new game with the given player name, starting capital,
-     * and custom stock data file.
+     * Convenience overload of {@link #createNewGame(String, BigDecimal, File, Currency)}
+     * that defaults the stock currency to USD.
      *
-     * <p>Validates the player input first by constructing a {@link Player},
-     * then loads stocks from {@code stockFile} through a {@link StockFileHandler}
-     * and instantiates an {@link Exchange} with a {@link FixedRateCurrencyConverter}.
-     * The active game state is only mutated once both steps succeed, leaving any
-     * previous game intact on failure. Observers are notified once the new game
-     * state is active.</p>
-     *
-     * @param name      the name of the player
-     * @param capital   the starting capital for the player, in NOK
-     * @param stockFile the file containing stock data to load
-     * @throws NullPointerException     if name, capital, or stock file is null
+     * @param name      the player name
+     * @param capital   the starting capital, in NOK
+     * @param stockFile the CSV file with stock data
+     * @throws NullPointerException     if any argument is null
      * @throws IllegalArgumentException if name is blank, capital is negative,
-     *                                  or the stock file contains no stocks
+     *                                  or the file contains no stocks
      */
     public void createNewGame(String name, BigDecimal capital, File stockFile) {
+        createNewGame(name, capital, stockFile, DEFAULT_STOCK_CURRENCY);
+    }
+
+    /**
+     * Creates a new game from the given stock file, tagging every parsed
+     * {@link Stock} with {@code currency} so the {@link Exchange} converts
+     * prices to NOK on every trade. See class-level Javadoc for validation
+     * order and observer semantics.
+     *
+     * @param name      the player name
+     * @param capital   the starting capital, in NOK
+     * @param stockFile the CSV file with stock data
+     * @param currency  the currency the stock prices are quoted in
+     * @throws NullPointerException     if any argument is null
+     * @throws IllegalArgumentException if name is blank, capital is negative,
+     *                                  or the file contains no stocks
+     */
+    public void createNewGame(String name, BigDecimal capital, File stockFile, Currency currency) {
         Objects.requireNonNull(stockFile, "Stock file cannot be null");
+        Objects.requireNonNull(currency, "Currency cannot be null");
         Player newPlayer = new Player(name, capital);
         StockFileHandler stockFileHandler = new CsvStockFileHandler();
-        List<Stock> stocks = stockFileHandler.readStocks(stockFile.toPath());
+        List<Stock> stocks = stockFileHandler.readStocks(stockFile.toPath(), currency);
         activate(newPlayer, stocks);
     }
 
@@ -169,7 +178,7 @@ public class GameManager {
             if (inputStream == null) {
                 throw new IllegalStateException("Default stock data not found: " + DEFAULT_STOCK_RESOURCE);
             }
-            return stockFileHandler.readStocks(inputStream);
+            return stockFileHandler.readStocks(inputStream, DEFAULT_STOCK_CURRENCY);
         } catch (IOException e) {
             throw new UncheckedIOException("Could not read default stock data", e);
         }

--- a/src/main/java/edu/ntnu/idatt2003/millions/manager/GameManager.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/manager/GameManager.java
@@ -3,12 +3,15 @@ package edu.ntnu.idatt2003.millions.manager;
 import edu.ntnu.idatt2003.millions.file.game.GameFileHandler;
 import edu.ntnu.idatt2003.millions.file.game.GameState;
 import edu.ntnu.idatt2003.millions.file.game.JsonGameFileHandler;
+import edu.ntnu.idatt2003.millions.file.stock.CsvStockFileHandler;
+import edu.ntnu.idatt2003.millions.file.stock.StockFileHandler;
 import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
 import edu.ntnu.idatt2003.millions.model.currency.FixedRateCurrencyConverter;
 import edu.ntnu.idatt2003.millions.model.exchange.Exchange;
 import edu.ntnu.idatt2003.millions.model.player.Player;
 import edu.ntnu.idatt2003.millions.model.player.PlayerStatusLevel;
 import edu.ntnu.idatt2003.millions.model.stock.Share;
+import edu.ntnu.idatt2003.millions.model.stock.Stock;
 import edu.ntnu.idatt2003.millions.model.transaction.Transaction;
 import edu.ntnu.idatt2003.millions.observer.GameObserver;
 
@@ -36,6 +39,8 @@ import java.util.Objects;
  * directly through {@link CurrencyConverter}.</p>
  */
 public class GameManager {
+
+    private static final String DEFAULT_EXCHANGE_NAME = "MainExchange";
 
     private Player player;
     private Exchange exchange;
@@ -81,20 +86,26 @@ public class GameManager {
      * Creates a new game with the given player name, starting capital,
      * and stock data file.
      *
-     * <p>Once implemented, this method will load stocks from {@code stockFile},
-     * create a new {@link Player} with the given name and capital, and instantiate
-     * an {@link Exchange} with a {@link FixedRateCurrencyConverter} so that
-     * subsequent transactions are converted to NOK against the player's balance.
+     * <p>Loads stocks from {@code stockFile} through a {@link StockFileHandler},
+     * creates a new {@link Player}, and instantiates an {@link Exchange} with a
+     * {@link FixedRateCurrencyConverter}. Observers are notified once the new
+     * game state is active.
      *
      * @param name      the name of the player
      * @param capital   the starting capital for the player, in NOK
      * @param stockFile the file containing stock data to load
+     * @throws NullPointerException     if name, capital, or stock file is null
+     * @throws IllegalArgumentException if name is blank, capital is negative,
+     *                                  or the stock file contains no stocks
      */
     public void createNewGame(String name, BigDecimal capital, File stockFile) {
-        // TODO: load stocks from stockFile and create Player.
-        // When implemented, instantiate the Exchange with a CurrencyConverter:
-        //   CurrencyConverter converter = new FixedRateCurrencyConverter();
-        //   this.exchange = new Exchange("MainExchange", stocks, converter);
+        Objects.requireNonNull(stockFile, "Stock file cannot be null");
+        StockFileHandler stockFileHandler = new CsvStockFileHandler();
+        List<Stock> stocks = stockFileHandler.readStocks(stockFile.toPath());
+
+        this.player = new Player(name, capital);
+        this.exchange = new Exchange(DEFAULT_EXCHANGE_NAME, stocks, new FixedRateCurrencyConverter());
+        notifyObservers();
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/player/Player.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/player/Player.java
@@ -31,14 +31,15 @@ public class Player {
      * @param name          the player's name
      * @param startingMoney the amount of money the player starts with
      * @throws NullPointerException     if the name or starting balance is null
-     * @throws IllegalArgumentException if the name is blank or the starting balance is negative
+     * @throws IllegalArgumentException if the name is blank or the starting balance
+     *                                  is not strictly greater than zero
      */
     public Player(String name, BigDecimal startingMoney) {
         Objects.requireNonNull(name, "Player name cannot be null");
         Objects.requireNonNull(startingMoney, "Starting money cannot be null");
         if (name.isBlank()) throw new IllegalArgumentException("Player name cannot be blank");
-        if (startingMoney.compareTo(BigDecimal.ZERO) < 0)
-            throw new IllegalArgumentException("Starting money cannot be negative");
+        if (startingMoney.compareTo(BigDecimal.ZERO) <= 0)
+            throw new IllegalArgumentException("Starting money must be greater than zero");
 
         this.name = name;
         this.startingMoney = startingMoney;

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/StartScreenInputs.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/StartScreenInputs.java
@@ -1,0 +1,64 @@
+package edu.ntnu.idatt2003.millions.view;
+
+import java.util.Currency;
+
+/**
+ * Read/write seam for the data the start screen exposes to its controller.
+ *
+ * <p>Implemented by {@link StartView} and lets {@code StartController} read
+ * user input and update path fields without depending on the concrete
+ * JavaFX view. Test doubles can implement this interface directly so the
+ * controller's start-flow logic can be unit tested without initialising
+ * the JavaFX toolkit.</p>
+ */
+public interface StartScreenInputs {
+
+    /**
+     * Returns the trimmed player name entered by the user.
+     *
+     * @return trimmed player name, never {@code null}
+     */
+    String getName();
+
+    /**
+     * Returns the trimmed starting capital entered by the user.
+     *
+     * @return trimmed starting capital, never {@code null}
+     */
+    String getCapital();
+
+    /**
+     * Returns the path to the stock data file selected by the user.
+     *
+     * @return stock file path, or empty string when none is selected
+     */
+    String getStockFilePath();
+
+    /**
+     * Returns the path to the save file selected by the user.
+     *
+     * @return save file path, or empty string when none is selected
+     */
+    String getSaveFilePath();
+
+    /**
+     * Returns the currency currently selected for the uploaded stock file.
+     *
+     * @return the selected currency, or {@code null} if none is selected
+     */
+    Currency getSelectedCurrency();
+
+    /**
+     * Updates the displayed stock file path.
+     *
+     * @param path the absolute file path; {@code null} or blank resets the field
+     */
+    void setStockFilePath(String path);
+
+    /**
+     * Updates the displayed save file path.
+     *
+     * @param path the absolute file path; {@code null} clears the field
+     */
+    void setSaveFilePath(String path);
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/StartView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/StartView.java
@@ -57,6 +57,7 @@ public class StartView {
     private final Label dropZoneOr;
     private final Button browseStockFileButton;
     private final Label stockFileNameLabel;
+    private final VBox dropZone;
     private final Button startButton;
 
     // Load game tab
@@ -87,6 +88,7 @@ public class StartView {
         browseStockFileButton = new Button();
         stockFileNameLabel = new Label();
         stockFileNameLabel.setVisible(false);
+        dropZone = buildDropZone();
         startButton = new Button();
 
         saveFileLabel = StyledText.PARAGRAPH_ONE();
@@ -186,7 +188,6 @@ public class StartView {
     private VBox createNewGameContent() {
         HBox nameRow = buildFormRow(nameLabel, nameField);
         HBox capitalRow = buildFormRow(capitalLabel, capitalField);
-        VBox dropZone = buildDropZone();
         HBox currencyRow = buildFormRow(currencyLabel, currencySelector);
 
         startButton.setMaxWidth(CARD_WIDTH);
@@ -345,10 +346,13 @@ public class StartView {
     }
 
     /**
-     * @return the drop zone node for drag-and-drop binding in controller
+     * Returns the drop zone node so the controller can bind drag-and-drop
+     * handlers without depending on the internal layout structure.
+     *
+     * @return the drop zone node
      */
     public VBox getDropZone() {
-        return (VBox) browseStockFileButton.getParent();
+        return dropZone;
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/StartView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/StartView.java
@@ -30,7 +30,7 @@ import java.util.Currency;
  * card with inline label-field rows, a drag-and-drop file zone,
  * and a currency selector that activates once a file is chosen.
  */
-public class StartView {
+public class StartView implements StartScreenInputs {
 
     private static final double SCENE_WIDTH = 900;
     private static final double SCENE_HEIGHT = 700;
@@ -61,6 +61,7 @@ public class StartView {
     private final Label stockFileNameLabel;
     private final VBox dropZone;
     private final Button startButton;
+    private String stockFilePath = "";
 
     // Load game tab
     private final StyledText saveFileLabel;
@@ -259,26 +260,31 @@ public class StartView {
 
     /**
      * Returns the path to the stock data file selected by the user.
+     * The path is stored independently of any UI label so changes to the
+     * drop-zone presentation do not affect the controller's contract.
      *
-     * @return stock file path, or empty string
+     * @return stock file path, or empty string when none is selected
      */
     public String getStockFilePath() {
-        return stockFileNameLabel.getText().trim();
+        return stockFilePath;
     }
 
     /**
-     * Returns the path to the save file selected by the user.
-     * Sets the stock file path, shows the filename in the drop zone,
-     * and enables the currency selector.
+     * Sets the stock file path. Updates the internal data field, mirrors the
+     * filename in the drop-zone label, and enables or disables the currency
+     * selector accordingly. The data field is the source of truth for
+     * {@link #getStockFilePath()}.
      *
      * @param path the absolute file path; {@code null} or blank resets the zone
      */
     public void setStockFilePath(String path) {
         if (path == null || path.isBlank()) {
+            this.stockFilePath = "";
             stockFileNameLabel.setText("");
             stockFileNameLabel.setVisible(false);
             currencySelector.setDisable(true);
         } else {
+            this.stockFilePath = path;
             stockFileNameLabel.setText(path);
             stockFileNameLabel.setVisible(true);
             currencySelector.setDisable(false);

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/StartView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/StartView.java
@@ -48,6 +48,7 @@ public class StartView {
     // New game tab
     private final StyledText nameLabel;
     private final StyledText capitalLabel;
+    private final StyledText fileLabel;
     private final StyledText currencyLabel;
     private final TextField nameField;
     private final TextField capitalField;
@@ -75,6 +76,7 @@ public class StartView {
         nameLabel = StyledText.PARAGRAPH_ONE();
         capitalLabel = StyledText.PARAGRAPH_ONE();
         currencyLabel = StyledText.PARAGRAPH_ONE();
+        fileLabel = StyledText.PARAGRAPH_ONE();
         nameField = new TextField();
         capitalField = new TextField();
         currencySelector = new CurrencySelector();
@@ -193,6 +195,7 @@ public class StartView {
                 FORM_SPACING,
                 nameRow,
                 capitalRow,
+                fileLabel,
                 dropZone,
                 currencyRow,
                 startButton
@@ -210,6 +213,7 @@ public class StartView {
     private VBox createLoadGameContent() {
         saveFileField.setEditable(false);
         saveFileField.setMaxWidth(CARD_WIDTH);
+        fileLabel.setMaxWidth(CARD_WIDTH);
         browseSaveFileButton.setMaxWidth(CARD_WIDTH);
         loadButton.setMaxWidth(CARD_WIDTH);
 
@@ -236,7 +240,7 @@ public class StartView {
         nameLabel.setText(LanguageManager.get("start.new.nameLabel"));
         capitalLabel.setText(LanguageManager.get("start.new.capitalLabel"));
         currencyLabel.setText(LanguageManager.get("start.new.currencyLabel"));
-
+        fileLabel.setText(LanguageManager.get("start.new.fileLabel"));
         dropZoneHint.setText(LanguageManager.get("start.new.dropZoneHint"));
         dropZoneOr.setText(LanguageManager.get("start.new.dropZoneOr"));
         browseStockFileButton.setText(LanguageManager.get("start.file.browse"));

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/StartView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/StartView.java
@@ -20,6 +20,8 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 
+import java.util.Currency;
+
 /**
  * Start view for the application.
  *
@@ -335,6 +337,17 @@ public class StartView {
      */
     public String getCapital() {
         return capitalField.getText().trim();
+    }
+
+    /**
+     * Returns the currency currently selected in the currency selector.
+     * Used when uploading custom stock data so the controller can pass the
+     * chosen currency to the {@code GameManager}.
+     *
+     * @return the selected currency, or {@code null} if none is selected
+     */
+    public Currency getSelectedCurrency() {
+        return currencySelector.getValue();
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/StartView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/StartView.java
@@ -297,12 +297,30 @@ public class StartView {
     }
 
     /**
+     * Sets the player name input field.
+     *
+     * @param name the player name to display; {@code null} clears the field
+     */
+    public void setName(String name) {
+        nameField.setText(name == null ? "" : name);
+    }
+
+    /**
      * Returns the trimmed player name entered by the user.
      *
      * @return trimmed player name
      */
     public String getName() {
         return nameField.getText().trim();
+    }
+
+    /**
+     * Sets the starting capital input field.
+     *
+     * @param capital the starting capital to display; {@code null} clears the field
+     */
+    public void setCapital(String capital) {
+        capitalField.setText(capital == null ? "" : capital);
     }
 
     /**

--- a/src/main/resources/css/style.css
+++ b/src/main/resources/css/style.css
@@ -530,4 +530,4 @@
 .tab-pane:focused .tab:selected {
     -fx-focus-color: transparent;
     -fx-faint-focus-color: transparent;
-}
+} }

--- a/src/main/resources/css/style.css
+++ b/src/main/resources/css/style.css
@@ -530,4 +530,4 @@
 .tab-pane:focused .tab:selected {
     -fx-focus-color: transparent;
     -fx-faint-focus-color: transparent;
-} }
+}

--- a/src/test/java/edu/ntnu/idatt2003/millions/controller/StartControllerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/controller/StartControllerTest.java
@@ -1,0 +1,102 @@
+package edu.ntnu.idatt2003.millions.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for validation helpers in {@link StartController}.
+ *
+ * <p>The tests cover controller input parsing without starting JavaFX.</p>
+ */
+class StartControllerTest {
+
+    @Nested
+    @DisplayName("parseCapital()")
+    class ParseCapital {
+
+        @Test
+        @DisplayName("Should return capital when input is valid")
+        void returnsCapitalWhenInputIsValid() {
+            // Arrange
+            String capital = "10000.00";
+            // Act
+            BigDecimal result = StartController.parseCapital(capital);
+            // Assert
+            assertEquals(0, new BigDecimal("10000.00").compareTo(result));
+        }
+
+        @Test
+        @DisplayName("Should throw exception when input is null")
+        void throwsExceptionWhenInputIsNull() {
+            // Act & Assert
+            assertThrows(IllegalArgumentException.class, () ->
+                    StartController.parseCapital(null));
+        }
+
+        @Test
+        @DisplayName("Should throw exception when input is blank")
+        void throwsExceptionWhenInputIsBlank() {
+            // Act & Assert
+            assertThrows(IllegalArgumentException.class, () ->
+                    StartController.parseCapital(" "));
+        }
+
+        @Test
+        @DisplayName("Should throw exception when input is not a valid number")
+        void throwsExceptionWhenInputIsNotValidNumber() {
+            // Act & Assert
+            assertThrows(NumberFormatException.class, () ->
+                    StartController.parseCapital("not-a-number"));
+        }
+    }
+
+    @Nested
+    @DisplayName("requireFilePath()")
+    class RequireFilePath {
+
+        @Test
+        @DisplayName("Should return file when path is valid")
+        void returnsFileWhenPathIsValid() {
+            // Arrange
+            String path = "stocks.csv";
+            // Act
+            File file = StartController.requireFilePath(path, "File must be selected");
+            // Assert
+            assertEquals(path, file.getPath());
+        }
+
+        @Test
+        @DisplayName("Should throw exception when path is null")
+        void throwsExceptionWhenPathIsNull() {
+            // Act & Assert
+            assertThrows(IllegalArgumentException.class, () ->
+                    StartController.requireFilePath(null, "File must be selected"));
+        }
+
+        @Test
+        @DisplayName("Should throw exception when path is blank")
+        void throwsExceptionWhenPathIsBlank() {
+            // Act & Assert
+            assertThrows(IllegalArgumentException.class, () ->
+                    StartController.requireFilePath(" ", "File must be selected"));
+        }
+
+        @Test
+        @DisplayName("Should use provided exception message when path is blank")
+        void usesProvidedExceptionMessageWhenPathIsBlank() {
+            // Arrange
+            String message = "Stock file must be selected";
+            // Act
+            IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+                    StartController.requireFilePath(" ", message));
+            // Assert
+            assertEquals(message, exception.getMessage());
+        }
+    }
+}

--- a/src/test/java/edu/ntnu/idatt2003/millions/controller/StartControllerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/controller/StartControllerTest.java
@@ -1,0 +1,303 @@
+package edu.ntnu.idatt2003.millions.controller;
+
+import edu.ntnu.idatt2003.millions.manager.GameManager;
+import edu.ntnu.idatt2003.millions.view.StartScreenInputs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.UncheckedIOException;
+import java.math.BigDecimal;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Currency;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link StartController}.
+ *
+ * <p>Uses the test seam constructor that takes a {@link StartScreenInputs}
+ * and a string {@link java.util.function.Consumer} so the start flow can be
+ * exercised without initialising the JavaFX toolkit. All tests follow the
+ * AAA pattern.</p>
+ */
+class StartControllerTest {
+
+    private StubInputs inputs;
+    private RecordingGameManager gameManager;
+    private List<String> errors;
+    private boolean showMainCalled;
+    private StartController controller;
+
+    @BeforeEach
+    void setUp() {
+        inputs = new StubInputs();
+        gameManager = new RecordingGameManager();
+        errors = new ArrayList<>();
+        showMainCalled = false;
+        controller = new StartController(
+                gameManager,
+                inputs,
+                () -> showMainCalled = true,
+                errors::add);
+    }
+
+    @Nested
+    @DisplayName("handleStartGame()")
+    class HandleStartGame {
+
+        @Test
+        @DisplayName("Should create new game with default stocks when no stock file is selected")
+        void createsNewGameWithDefaultStocksWhenNoFileSelected() {
+            // Arrange
+            inputs.name = "Dara";
+            inputs.capital = "10000.00";
+            inputs.stockFilePath = "";
+            // Act
+            controller.handleStartGame();
+            // Assert
+            assertEquals("Dara", gameManager.lastName);
+            assertEquals(0, new BigDecimal("10000.00").compareTo(gameManager.lastCapital));
+            assertNull(gameManager.lastStockFile);
+            assertNull(gameManager.lastCurrency);
+            assertTrue(showMainCalled);
+            assertTrue(errors.isEmpty());
+        }
+
+        @Test
+        @DisplayName("Should create new game with custom stock file and selected currency")
+        void createsNewGameWithCustomFileAndSelectedCurrency() {
+            // Arrange
+            inputs.name = "Dara";
+            inputs.capital = "10000.00";
+            inputs.stockFilePath = "/tmp/stocks.csv";
+            inputs.selectedCurrency = Currency.getInstance("EUR");
+            // Act
+            controller.handleStartGame();
+            // Assert
+            assertEquals("Dara", gameManager.lastName);
+            assertEquals(0, new BigDecimal("10000.00").compareTo(gameManager.lastCapital));
+            assertEquals(Path.of("/tmp/stocks.csv"), gameManager.lastStockFile.toPath());
+            assertEquals(Currency.getInstance("EUR"), gameManager.lastCurrency);
+            assertTrue(showMainCalled);
+            assertTrue(errors.isEmpty());
+        }
+
+        @Test
+        @DisplayName("Should report error and not navigate when player name is blank")
+        void reportsErrorWhenPlayerNameIsBlank() {
+            // Arrange
+            inputs.name = "";
+            inputs.capital = "10000.00";
+            // Act
+            controller.handleStartGame();
+            // Assert
+            assertEquals(1, errors.size());
+            assertEquals(0, gameManager.createNewGameCalls);
+            assertFalse(showMainCalled);
+        }
+
+        @Test
+        @DisplayName("Should report error and not navigate when capital is invalid")
+        void reportsErrorWhenCapitalIsInvalid() {
+            // Arrange: NumberFormatException extends IllegalArgumentException
+            // and is therefore caught and routed through the error sink.
+            inputs.name = "Dara";
+            inputs.capital = "not-a-number";
+            // Act
+            controller.handleStartGame();
+            // Assert
+            assertEquals(1, errors.size());
+            assertEquals(0, gameManager.createNewGameCalls);
+            assertFalse(showMainCalled);
+        }
+
+        @Test
+        @DisplayName("Should report error and not navigate when stock file is not csv")
+        void reportsErrorWhenStockFileIsNotCsv() {
+            // Arrange
+            inputs.name = "Dara";
+            inputs.capital = "10000.00";
+            inputs.stockFilePath = "/tmp/stocks.json";
+            inputs.selectedCurrency = Currency.getInstance("USD");
+            // Act
+            controller.handleStartGame();
+            // Assert
+            assertEquals(1, errors.size());
+            assertEquals(0, gameManager.createNewGameCalls);
+            assertFalse(showMainCalled);
+        }
+
+        @Test
+        @DisplayName("Should report error and not navigate when currency is not selected")
+        void reportsErrorWhenCurrencyIsNotSelected() {
+            // Arrange
+            inputs.name = "Dara";
+            inputs.capital = "10000.00";
+            inputs.stockFilePath = "/tmp/stocks.csv";
+            inputs.selectedCurrency = null;
+            // Act
+            controller.handleStartGame();
+            // Assert
+            assertEquals(1, errors.size());
+            assertEquals(0, gameManager.createNewGameCalls);
+            assertFalse(showMainCalled);
+        }
+
+        @Test
+        @DisplayName("Should report error and not navigate when game manager fails")
+        void reportsErrorWhenGameManagerFails() {
+            // Arrange
+            inputs.name = "Dara";
+            inputs.capital = "10000.00";
+            inputs.stockFilePath = "";
+            gameManager.failNextCreate = new IllegalStateException("default stock data missing");
+            // Act
+            controller.handleStartGame();
+            // Assert
+            assertEquals(1, errors.size());
+            assertEquals("default stock data missing", errors.getFirst());
+            assertFalse(showMainCalled);
+        }
+
+        @Test
+        @DisplayName("Should report error and not navigate when game manager throws UncheckedIOException")
+        void reportsErrorWhenGameManagerThrowsIoException() {
+            // Arrange
+            inputs.name = "Dara";
+            inputs.capital = "10000.00";
+            inputs.stockFilePath = "";
+            gameManager.failNextCreate =
+                    new UncheckedIOException("read failed", new java.io.IOException("disk error"));
+            // Act
+            controller.handleStartGame();
+            // Assert
+            assertEquals(1, errors.size());
+            assertFalse(showMainCalled);
+        }
+    }
+
+    @Nested
+    @DisplayName("handleLoadGame()")
+    class HandleLoadGame {
+
+        @Test
+        @DisplayName("Should load saved game and navigate")
+        void loadsSavedGameAndNavigates() {
+            // Arrange
+            inputs.saveFilePath = "/tmp/save.json";
+            // Act
+            controller.handleLoadGame();
+            // Assert
+            assertEquals(Path.of("/tmp/save.json"), gameManager.lastLoadedFile.toPath());
+            assertTrue(showMainCalled);
+            assertTrue(errors.isEmpty());
+        }
+
+        @Test
+        @DisplayName("Should report error and not navigate when save file is blank")
+        void reportsErrorWhenSaveFileIsBlank() {
+            // Arrange
+            inputs.saveFilePath = "";
+            // Act
+            controller.handleLoadGame();
+            // Assert
+            assertEquals(1, errors.size());
+            assertEquals(0, gameManager.loadGameCalls);
+            assertFalse(showMainCalled);
+        }
+
+        @Test
+        @DisplayName("Should report error and not navigate when game manager fails to load")
+        void reportsErrorWhenGameManagerFailsToLoad() {
+            // Arrange
+            inputs.saveFilePath = "/tmp/save.json";
+            gameManager.failNextLoad = new IllegalArgumentException("corrupt save file");
+            // Act
+            controller.handleLoadGame();
+            // Assert
+            assertEquals(1, errors.size());
+            assertEquals("corrupt save file", errors.getFirst());
+            assertFalse(showMainCalled);
+        }
+    }
+
+    /**
+     * In-memory implementation of {@link StartScreenInputs} for tests.
+     * Each field is set directly by the test before invoking the controller.
+     */
+    private static class StubInputs implements StartScreenInputs {
+        String name = "";
+        String capital = "";
+        String stockFilePath = "";
+        String saveFilePath = "";
+        Currency selectedCurrency = Currency.getInstance("USD");
+
+        @Override public String getName() { return name; }
+        @Override public String getCapital() { return capital; }
+        @Override public String getStockFilePath() { return stockFilePath; }
+        @Override public String getSaveFilePath() { return saveFilePath; }
+        @Override public Currency getSelectedCurrency() { return selectedCurrency; }
+        @Override public void setStockFilePath(String path) { this.stockFilePath = path == null ? "" : path; }
+        @Override public void setSaveFilePath(String path) { this.saveFilePath = path == null ? "" : path; }
+    }
+
+    /**
+     * Test double for {@link GameManager} that records the arguments passed
+     * to its mutating methods and lets tests trigger controlled failures.
+     */
+    private static class RecordingGameManager extends GameManager {
+        String lastName;
+        BigDecimal lastCapital;
+        File lastStockFile;
+        Currency lastCurrency;
+        File lastLoadedFile;
+        int createNewGameCalls;
+        int loadGameCalls;
+        RuntimeException failNextCreate;
+        RuntimeException failNextLoad;
+
+        @Override
+        public void createNewGame(String name, BigDecimal capital) {
+            createNewGameCalls++;
+            this.lastName = name;
+            this.lastCapital = capital;
+            this.lastStockFile = null;
+            this.lastCurrency = null;
+            throwPendingFailure();
+        }
+
+        @Override
+        public void createNewGame(String name, BigDecimal capital, File stockFile, Currency currency) {
+            createNewGameCalls++;
+            this.lastName = name;
+            this.lastCapital = capital;
+            this.lastStockFile = stockFile;
+            this.lastCurrency = currency;
+            throwPendingFailure();
+        }
+
+        @Override
+        public void loadGame(File file) {
+            loadGameCalls++;
+            this.lastLoadedFile = file;
+            if (failNextLoad != null) {
+                RuntimeException toThrow = failNextLoad;
+                failNextLoad = null;
+                throw toThrow;
+            }
+        }
+
+        private void throwPendingFailure() {
+            if (failNextCreate != null) {
+                RuntimeException toThrow = failNextCreate;
+                failNextCreate = null;
+                throw toThrow;
+            }
+        }
+    }
+}

--- a/src/test/java/edu/ntnu/idatt2003/millions/controller/StartInputValidatorTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/controller/StartInputValidatorTest.java
@@ -100,25 +100,19 @@ class StartInputValidatorTest {
         }
 
         @Test
-        @DisplayName("Should accept zero as a valid parse value")
-        void acceptsZero() {
-            // Arrange
-            String capital = "0";
-            // Act
-            BigDecimal result = StartInputValidator.parseCapital(capital);
-            // Assert
-            assertEquals(0, BigDecimal.ZERO.compareTo(result));
+        @DisplayName("Should throw exception when input is zero")
+        void throwsExceptionWhenInputIsZero() {
+            // Act & Assert
+            assertThrows(IllegalArgumentException.class, () ->
+                    StartInputValidator.parseCapital("0"));
         }
 
         @Test
-        @DisplayName("Should parse negative numbers without checking sign")
-        void parsesNegativeNumber() {
-            // Arrange: domain layer (Player) is responsible for rejecting negative capital
-            String capital = "-100";
-            // Act
-            BigDecimal result = StartInputValidator.parseCapital(capital);
-            // Assert
-            assertEquals(0, new BigDecimal("-100").compareTo(result));
+        @DisplayName("Should throw exception when input is negative")
+        void throwsExceptionWhenInputIsNegative() {
+            // Act & Assert
+            assertThrows(IllegalArgumentException.class, () ->
+                    StartInputValidator.parseCapital("-100"));
         }
     }
 

--- a/src/test/java/edu/ntnu/idatt2003/millions/controller/StartInputValidatorTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/controller/StartInputValidatorTest.java
@@ -17,6 +17,38 @@ import static org.junit.jupiter.api.Assertions.*;
 class StartInputValidatorTest {
 
     @Nested
+    @DisplayName("requireName()")
+    class RequireName {
+
+        @Test
+        @DisplayName("Should return trimmed name when input is valid")
+        void returnsTrimmedNameWhenInputIsValid() {
+            // Arrange
+            String name = "  Dara  ";
+            // Act
+            String result = StartInputValidator.requireName(name);
+            // Assert
+            assertEquals("Dara", result);
+        }
+
+        @Test
+        @DisplayName("Should throw exception when input is null")
+        void throwsExceptionWhenInputIsNull() {
+            // Act & Assert
+            assertThrows(IllegalArgumentException.class, () ->
+                    StartInputValidator.requireName(null));
+        }
+
+        @Test
+        @DisplayName("Should throw exception when input is blank")
+        void throwsExceptionWhenInputIsBlank() {
+            // Act & Assert
+            assertThrows(IllegalArgumentException.class, () ->
+                    StartInputValidator.requireName("   "));
+        }
+    }
+
+    @Nested
     @DisplayName("parseCapital()")
     class ParseCapital {
 

--- a/src/test/java/edu/ntnu/idatt2003/millions/controller/StartInputValidatorTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/controller/StartInputValidatorTest.java
@@ -10,11 +10,11 @@ import java.math.BigDecimal;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Unit tests for validation helpers in {@link StartController}.
+ * Unit tests for {@link StartInputValidator}.
  *
  * <p>The tests cover controller input parsing without starting JavaFX.</p>
  */
-class StartControllerTest {
+class StartInputValidatorTest {
 
     @Nested
     @DisplayName("parseCapital()")
@@ -26,7 +26,7 @@ class StartControllerTest {
             // Arrange
             String capital = "10000.00";
             // Act
-            BigDecimal result = StartController.parseCapital(capital);
+            BigDecimal result = StartInputValidator.parseCapital(capital);
             // Assert
             assertEquals(0, new BigDecimal("10000.00").compareTo(result));
         }
@@ -36,7 +36,7 @@ class StartControllerTest {
         void throwsExceptionWhenInputIsNull() {
             // Act & Assert
             assertThrows(IllegalArgumentException.class, () ->
-                    StartController.parseCapital(null));
+                    StartInputValidator.parseCapital(null));
         }
 
         @Test
@@ -44,7 +44,7 @@ class StartControllerTest {
         void throwsExceptionWhenInputIsBlank() {
             // Act & Assert
             assertThrows(IllegalArgumentException.class, () ->
-                    StartController.parseCapital(" "));
+                    StartInputValidator.parseCapital(" "));
         }
 
         @Test
@@ -52,7 +52,7 @@ class StartControllerTest {
         void throwsExceptionWhenInputIsNotValidNumber() {
             // Act & Assert
             assertThrows(NumberFormatException.class, () ->
-                    StartController.parseCapital("not-a-number"));
+                    StartInputValidator.parseCapital("not-a-number"));
         }
     }
 
@@ -66,7 +66,7 @@ class StartControllerTest {
             // Arrange
             String path = "stocks.csv";
             // Act
-            File file = StartController.requireFilePath(path, "File must be selected");
+            File file = StartInputValidator.requireFilePath(path, "File must be selected");
             // Assert
             assertEquals(path, file.getPath());
         }
@@ -76,7 +76,7 @@ class StartControllerTest {
         void throwsExceptionWhenPathIsNull() {
             // Act & Assert
             assertThrows(IllegalArgumentException.class, () ->
-                    StartController.requireFilePath(null, "File must be selected"));
+                    StartInputValidator.requireFilePath(null, "File must be selected"));
         }
 
         @Test
@@ -84,7 +84,7 @@ class StartControllerTest {
         void throwsExceptionWhenPathIsBlank() {
             // Act & Assert
             assertThrows(IllegalArgumentException.class, () ->
-                    StartController.requireFilePath(" ", "File must be selected"));
+                    StartInputValidator.requireFilePath(" ", "File must be selected"));
         }
 
         @Test
@@ -94,9 +94,60 @@ class StartControllerTest {
             String message = "Stock file must be selected";
             // Act
             IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
-                    StartController.requireFilePath(" ", message));
+                    StartInputValidator.requireFilePath(" ", message));
             // Assert
             assertEquals(message, exception.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("requireCsvFilePath()")
+    class RequireCsvFilePath {
+
+        @Test
+        @DisplayName("Should return file when path ends with csv")
+        void returnsFileWhenPathEndsWithCsv() {
+            // Arrange
+            String path = "stocks.csv";
+            // Act
+            File file = StartInputValidator.requireCsvFilePath(path);
+            // Assert
+            assertEquals(path, file.getPath());
+        }
+
+        @Test
+        @DisplayName("Should return file when path ends with uppercase CSV")
+        void returnsFileWhenPathEndsWithUppercaseCsv() {
+            // Arrange
+            String path = "stocks.CSV";
+            // Act
+            File file = StartInputValidator.requireCsvFilePath(path);
+            // Assert
+            assertEquals(path, file.getPath());
+        }
+
+        @Test
+        @DisplayName("Should throw exception when path is null")
+        void throwsExceptionWhenPathIsNull() {
+            // Act & Assert
+            assertThrows(IllegalArgumentException.class, () ->
+                    StartInputValidator.requireCsvFilePath(null));
+        }
+
+        @Test
+        @DisplayName("Should throw exception when path is blank")
+        void throwsExceptionWhenPathIsBlank() {
+            // Act & Assert
+            assertThrows(IllegalArgumentException.class, () ->
+                    StartInputValidator.requireCsvFilePath(" "));
+        }
+
+        @Test
+        @DisplayName("Should throw exception when path is not csv")
+        void throwsExceptionWhenPathIsNotCsv() {
+            // Act & Assert
+            assertThrows(IllegalArgumentException.class, () ->
+                    StartInputValidator.requireCsvFilePath("stocks.json"));
         }
     }
 }

--- a/src/test/java/edu/ntnu/idatt2003/millions/controller/StartInputValidatorTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/controller/StartInputValidatorTest.java
@@ -47,6 +47,17 @@ class StartInputValidatorTest {
             assertThrows(IllegalArgumentException.class, () ->
                     StartInputValidator.requireName("   "));
         }
+
+        @Test
+        @DisplayName("Should preserve internal whitespace when trimming")
+        void preservesInternalWhitespace() {
+            // Arrange
+            String name = "  John Doe  ";
+            // Act
+            String result = StartInputValidator.requireName(name);
+            // Assert
+            assertEquals("John Doe", result);
+        }
     }
 
     @Nested
@@ -86,6 +97,28 @@ class StartInputValidatorTest {
             // Act & Assert
             assertThrows(NumberFormatException.class, () ->
                     StartInputValidator.parseCapital("not-a-number"));
+        }
+
+        @Test
+        @DisplayName("Should accept zero as a valid parse value")
+        void acceptsZero() {
+            // Arrange
+            String capital = "0";
+            // Act
+            BigDecimal result = StartInputValidator.parseCapital(capital);
+            // Assert
+            assertEquals(0, BigDecimal.ZERO.compareTo(result));
+        }
+
+        @Test
+        @DisplayName("Should parse negative numbers without checking sign")
+        void parsesNegativeNumber() {
+            // Arrange: domain layer (Player) is responsible for rejecting negative capital
+            String capital = "-100";
+            // Act
+            BigDecimal result = StartInputValidator.parseCapital(capital);
+            // Assert
+            assertEquals(0, new BigDecimal("-100").compareTo(result));
         }
     }
 
@@ -205,6 +238,25 @@ class StartInputValidatorTest {
             // Act & Assert
             assertThrows(IllegalArgumentException.class, () ->
                     StartInputValidator.requireCsvFilePath("stocks.json"));
+        }
+
+        @Test
+        @DisplayName("Should throw exception when path has no extension")
+        void throwsExceptionWhenPathHasNoExtension() {
+            // Act & Assert
+            assertThrows(IllegalArgumentException.class, () ->
+                    StartInputValidator.requireCsvFilePath("stocks"));
+        }
+
+        @Test
+        @DisplayName("Should accept absolute paths with directory separators")
+        void acceptsAbsolutePathWithDirectorySeparators() {
+            // Arrange
+            String path = "/path/to/stocks.csv";
+            // Act
+            File file = StartInputValidator.requireCsvFilePath(path);
+            // Assert
+            assertEquals(path, file.getPath());
         }
     }
 }

--- a/src/test/java/edu/ntnu/idatt2003/millions/controller/StartInputValidatorTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/controller/StartInputValidatorTest.java
@@ -52,11 +52,11 @@ class StartInputValidatorTest {
         @DisplayName("Should preserve internal whitespace when trimming")
         void preservesInternalWhitespace() {
             // Arrange
-            String name = "  John Doe  ";
+            String name = "  Dara Alva  ";
             // Act
             String result = StartInputValidator.requireName(name);
             // Assert
-            assertEquals("John Doe", result);
+            assertEquals("Dara Alva", result);
         }
     }
 

--- a/src/test/java/edu/ntnu/idatt2003/millions/controller/StartInputValidatorTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/controller/StartInputValidatorTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.math.BigDecimal;
+import java.util.Currency;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -129,6 +130,30 @@ class StartInputValidatorTest {
                     StartInputValidator.requireFilePath(" ", message));
             // Assert
             assertEquals(message, exception.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("requireCurrency()")
+    class RequireCurrency {
+
+        @Test
+        @DisplayName("Should return currency when input is valid")
+        void returnsCurrencyWhenInputIsValid() {
+            // Arrange
+            Currency currency = Currency.getInstance("USD");
+            // Act
+            Currency result = StartInputValidator.requireCurrency(currency);
+            // Assert
+            assertEquals(currency, result);
+        }
+
+        @Test
+        @DisplayName("Should throw exception when input is null")
+        void throwsExceptionWhenInputIsNull() {
+            // Act & Assert
+            assertThrows(IllegalArgumentException.class, () ->
+                    StartInputValidator.requireCurrency(null));
         }
     }
 

--- a/src/test/java/edu/ntnu/idatt2003/millions/file/stock/CsvStockFileHandlerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/file/stock/CsvStockFileHandlerTest.java
@@ -120,9 +120,11 @@ class CsvStockFileHandlerTest {
         @Test
         @DisplayName("Should throw exception when path is null")
         void throwsExceptionWhenPathIsNull() {
+            // Arrange
+            Path nullPath = null;
             // Act & Assert
             assertThrows(NullPointerException.class, () ->
-                    handler.readStocks(null));
+                    handler.readStocks(nullPath));
         }
 
         @Test

--- a/src/test/java/edu/ntnu/idatt2003/millions/file/stock/CsvStockFileHandlerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/file/stock/CsvStockFileHandlerTest.java
@@ -7,11 +7,15 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Currency;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -135,6 +139,161 @@ class CsvStockFileHandlerTest {
             // Act & Assert
             assertThrows(UncheckedIOException.class, () ->
                     handler.readStocks(file));
+        }
+
+        @Test
+        @DisplayName("Should default stock currency to USD when no currency is supplied")
+        void defaultsCurrencyToUsd() throws Exception {
+            // Arrange
+            Path file = tempDir.resolve("stocks.csv");
+            Files.writeString(file, "AAPL,Apple Inc.,276.43\n");
+            // Act
+            List<Stock> stocks = handler.readStocks(file);
+            // Assert
+            assertEquals(Currency.getInstance("USD"), stocks.getFirst().getCurrency());
+        }
+    }
+
+    @Nested
+    @DisplayName("readStocks(Path, Currency)")
+    class ReadStocksWithCurrency {
+
+        @Test
+        @DisplayName("Should tag every parsed stock with the supplied currency")
+        void tagsStocksWithSuppliedCurrency() throws Exception {
+            // Arrange
+            Path file = tempDir.resolve("stocks.csv");
+            Files.writeString(file, "AAPL,Apple Inc.,276.43\nMSFT,Microsoft,404.68\n");
+            Currency eur = Currency.getInstance("EUR");
+            // Act
+            List<Stock> stocks = handler.readStocks(file, eur);
+            // Assert
+            assertEquals(2, stocks.size());
+            assertTrue(stocks.stream().allMatch(stock -> eur.equals(stock.getCurrency())));
+        }
+
+        @Test
+        @DisplayName("Should return empty list when file is empty")
+        void returnsEmptyListWhenFileIsEmpty() throws Exception {
+            // Arrange
+            Path file = tempDir.resolve("stocks.csv");
+            Files.writeString(file, "");
+            // Act
+            List<Stock> stocks = handler.readStocks(file, Currency.getInstance("NOK"));
+            // Assert
+            assertTrue(stocks.isEmpty());
+        }
+
+        @Test
+        @DisplayName("Should throw exception when path is null")
+        void throwsExceptionWhenPathIsNull() {
+            // Arrange
+            Currency usd = Currency.getInstance("USD");
+            // Act & Assert
+            assertThrows(NullPointerException.class, () ->
+                    handler.readStocks((Path) null, usd));
+        }
+
+        @Test
+        @DisplayName("Should throw exception when currency is null")
+        void throwsExceptionWhenCurrencyIsNull() throws Exception {
+            // Arrange
+            Path file = tempDir.resolve("stocks.csv");
+            Files.writeString(file, "AAPL,Apple Inc.,276.43\n");
+            // Act & Assert
+            assertThrows(NullPointerException.class, () ->
+                    handler.readStocks(file, null));
+        }
+    }
+
+    @Nested
+    @DisplayName("readStocks(InputStream)")
+    class ReadStocksFromStream {
+
+        @Test
+        @DisplayName("Should parse stocks from input stream")
+        void parsesStocksFromStream() {
+            // Arrange
+            InputStream stream = new ByteArrayInputStream(
+                    "AAPL,Apple Inc.,276.43\nMSFT,Microsoft,404.68\n".getBytes(StandardCharsets.UTF_8));
+            // Act
+            List<Stock> stocks = handler.readStocks(stream);
+            // Assert
+            assertEquals(2, stocks.size());
+            assertEquals("AAPL", stocks.getFirst().getSymbol());
+        }
+
+        @Test
+        @DisplayName("Should default stock currency to USD when no currency is supplied")
+        void defaultsCurrencyToUsd() {
+            // Arrange
+            InputStream stream = new ByteArrayInputStream(
+                    "AAPL,Apple Inc.,276.43\n".getBytes(StandardCharsets.UTF_8));
+            // Act
+            List<Stock> stocks = handler.readStocks(stream);
+            // Assert
+            assertEquals(Currency.getInstance("USD"), stocks.getFirst().getCurrency());
+        }
+
+        @Test
+        @DisplayName("Should return empty list when stream is empty")
+        void returnsEmptyListWhenStreamIsEmpty() {
+            // Arrange
+            InputStream stream = new ByteArrayInputStream(new byte[0]);
+            // Act
+            List<Stock> stocks = handler.readStocks(stream);
+            // Assert
+            assertTrue(stocks.isEmpty());
+        }
+
+        @Test
+        @DisplayName("Should throw exception when stream is null")
+        void throwsExceptionWhenStreamIsNull() {
+            // Arrange
+            InputStream nullStream = null;
+            // Act & Assert
+            assertThrows(NullPointerException.class, () ->
+                    handler.readStocks(nullStream));
+        }
+    }
+
+    @Nested
+    @DisplayName("readStocks(InputStream, Currency)")
+    class ReadStocksFromStreamWithCurrency {
+
+        @Test
+        @DisplayName("Should tag every parsed stock with the supplied currency")
+        void tagsStocksWithSuppliedCurrency() {
+            // Arrange
+            InputStream stream = new ByteArrayInputStream(
+                    "AAPL,Apple Inc.,276.43\nMSFT,Microsoft,404.68\n".getBytes(StandardCharsets.UTF_8));
+            Currency gbp = Currency.getInstance("GBP");
+            // Act
+            List<Stock> stocks = handler.readStocks(stream, gbp);
+            // Assert
+            assertEquals(2, stocks.size());
+            assertTrue(stocks.stream().allMatch(stock -> gbp.equals(stock.getCurrency())));
+        }
+
+        @Test
+        @DisplayName("Should throw exception when stream is null")
+        void throwsExceptionWhenStreamIsNull() {
+            // Arrange
+            Currency usd = Currency.getInstance("USD");
+            // Act & Assert
+            assertThrows(NullPointerException.class, () ->
+                    handler.readStocks((InputStream) null, usd));
+        }
+
+        @Test
+        @DisplayName("Should throw exception when currency is null")
+        void throwsExceptionWhenCurrencyIsNull() {
+            // Arrange
+            InputStream stream = new ByteArrayInputStream(
+                    "AAPL,Apple Inc.,276.43\n".getBytes(StandardCharsets.UTF_8));
+            // Act & Assert
+            assertThrows(NullPointerException.class, () ->
+                    handler.readStocks(stream, null));
         }
     }
 

--- a/src/test/java/edu/ntnu/idatt2003/millions/manager/GameManagerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/manager/GameManagerTest.java
@@ -16,7 +16,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
+import java.io.IOException;
 import java.math.BigDecimal;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Currency;
@@ -33,11 +35,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * </p>
  * <p>
  * Game state is set up by saving a known {@link Player} and {@link Exchange}
- * to a temporary file, then loading it via {@link GameManager#loadGame},
- * since the public {@code createNewGame} entry point is not yet implemented.
- * </p>
- * <p>
- * All tests follow the AAA pattern.
+ * to a temporary file, then loading it via {@link GameManager#loadGame}.
  * </p>
  */
 class GameManagerTest {
@@ -141,6 +139,74 @@ class GameManagerTest {
             assertEquals("NYSE", gameManager.getExchange().getName());
             assertTrue(gameManager.getExchange().hasStock("EQNR"));
             assertNotNull(gameManager.getExchange().getCurrencyConverter());
+        }
+    }
+
+    @Nested
+    @DisplayName("createNewGame()")
+    class CreateNewGame {
+
+        @Test
+        @DisplayName("Should create player and exchange from stock file")
+        void createsPlayerAndExchangeFromStockFile() throws IOException {
+            // Arrange
+            File stockFile = createStockFile("AAPL,Apple Inc.,276.43\nMSFT,Microsoft,404.68\n");
+            CountingObserver observer = new CountingObserver();
+            GameManager newGameManager = new GameManager();
+            newGameManager.addObserver(observer);
+            // Act
+            newGameManager.createNewGame("Dara", STARTING_MONEY, stockFile);
+            // Assert
+            assertEquals("Dara", newGameManager.getPlayer().getName());
+            assertEquals(0, STARTING_MONEY.compareTo(newGameManager.getPlayer().getMoney()));
+            assertEquals("MainExchange", newGameManager.getExchange().getName());
+            assertTrue(newGameManager.getExchange().hasStock("AAPL"));
+            assertTrue(newGameManager.getExchange().hasStock("MSFT"));
+            assertNotNull(newGameManager.getExchange().getCurrencyConverter());
+            assertEquals(1, observer.updateCount);
+        }
+
+        @Test
+        @DisplayName("Should throw exception when stock file is null")
+        void throwsExceptionWhenStockFileIsNull() {
+            // Arrange
+            GameManager newGameManager = new GameManager();
+            // Act & Assert
+            assertThrows(NullPointerException.class, () ->
+                    newGameManager.createNewGame("Dara", STARTING_MONEY, null));
+        }
+
+        @Test
+        @DisplayName("Should throw exception when player name is blank")
+        void throwsExceptionWhenPlayerNameIsBlank() throws IOException {
+            // Arrange
+            File stockFile = createStockFile("AAPL,Apple Inc.,276.43\n");
+            GameManager newGameManager = new GameManager();
+            // Act & Assert
+            assertThrows(IllegalArgumentException.class, () ->
+                    newGameManager.createNewGame("", STARTING_MONEY, stockFile));
+        }
+
+        @Test
+        @DisplayName("Should throw exception when capital is negative")
+        void throwsExceptionWhenCapitalIsNegative() throws IOException {
+            // Arrange
+            File stockFile = createStockFile("AAPL,Apple Inc.,276.43\n");
+            GameManager newGameManager = new GameManager();
+            // Act & Assert
+            assertThrows(IllegalArgumentException.class, () ->
+                    newGameManager.createNewGame("Dara", new BigDecimal("-1.00"), stockFile));
+        }
+
+        @Test
+        @DisplayName("Should throw exception when stock file is empty")
+        void throwsExceptionWhenStockFileIsEmpty() throws IOException {
+            // Arrange
+            File stockFile = createStockFile("");
+            GameManager newGameManager = new GameManager();
+            // Act & Assert
+            assertThrows(IllegalArgumentException.class, () ->
+                    newGameManager.createNewGame("Dara", STARTING_MONEY, stockFile));
         }
     }
 
@@ -359,5 +425,11 @@ class GameManagerTest {
         public void onGameUpdated() {
             updateCount++;
         }
+    }
+
+    private File createStockFile(String content) throws IOException {
+        Path file = tempDir.resolve("stocks-" + System.nanoTime() + ".csv");
+        Files.writeString(file, content);
+        return file.toFile();
     }
 }

--- a/src/test/java/edu/ntnu/idatt2003/millions/manager/GameManagerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/manager/GameManagerTest.java
@@ -207,14 +207,25 @@ class GameManagerTest {
         }
 
         @Test
-        @DisplayName("Should throw exception when capital is negative")
-        void throwsExceptionWhenCapitalIsNegative() throws IOException {
+        @DisplayName("Should throw exception when capital is not greater than zero")
+        void throwsExceptionWhenCapitalIsNotPositive() throws IOException {
             // Arrange
             File stockFile = createStockFile("AAPL,Apple Inc.,276.43\n");
             GameManager newGameManager = new GameManager();
             // Act & Assert
             assertThrows(IllegalArgumentException.class, () ->
                     newGameManager.createNewGame("Dara", new BigDecimal("-1.00"), stockFile));
+        }
+
+        @Test
+        @DisplayName("Should throw exception when capital is zero")
+        void throwsExceptionWhenCapitalIsZero() throws IOException {
+            // Arrange
+            File stockFile = createStockFile("AAPL,Apple Inc.,276.43\n");
+            GameManager newGameManager = new GameManager();
+            // Act & Assert
+            assertThrows(IllegalArgumentException.class, () ->
+                    newGameManager.createNewGame("Dara", BigDecimal.ZERO, stockFile));
         }
 
         @Test

--- a/src/test/java/edu/ntnu/idatt2003/millions/manager/GameManagerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/manager/GameManagerTest.java
@@ -227,6 +227,49 @@ class GameManagerTest {
             assertThrows(IllegalArgumentException.class, () ->
                     newGameManager.createNewGame("Dara", STARTING_MONEY, stockFile));
         }
+
+        @Test
+        @DisplayName("Should tag uploaded stocks with the selected currency")
+        void tagsUploadedStocksWithSelectedCurrency() throws IOException {
+            // Arrange
+            File stockFile = createStockFile("AAPL,Apple Inc.,100.00\n");
+            Currency selectedCurrency = Currency.getInstance("EUR");
+            GameManager newGameManager = new GameManager();
+            // Act
+            newGameManager.createNewGame("Dara", STARTING_MONEY, stockFile, selectedCurrency);
+            // Assert
+            assertEquals(selectedCurrency,
+                    newGameManager.getExchange().getStock("AAPL").getCurrency());
+        }
+
+        @Test
+        @DisplayName("Should convert purchase cost from selected currency to NOK")
+        void convertsPurchaseCostFromSelectedCurrencyToNok() throws IOException {
+            // Arrange
+            File stockFile = createStockFile("AAPL,Apple Inc.,100.00\n");
+            Currency usd = Currency.getInstance("USD");
+            GameManager newGameManager = new GameManager();
+            newGameManager.createNewGame("Dara", STARTING_MONEY, stockFile, usd);
+            // Act
+            newGameManager.buy("AAPL", QUANTITY);
+            // Assert: 5 * 100 USD * 1.005 commission = 502.50 USD; * 9.21 NOK/USD = 4628.0250 NOK
+            BigDecimal expectedRemaining = STARTING_MONEY.subtract(new BigDecimal("4628.0250"));
+            assertEquals(0,
+                    expectedRemaining.compareTo(newGameManager.getPlayer().getMoney()));
+            assertEquals(usd,
+                    newGameManager.getExchange().getStock("AAPL").getCurrency());
+        }
+
+        @Test
+        @DisplayName("Should throw exception when currency is null")
+        void throwsExceptionWhenCurrencyIsNull() throws IOException {
+            // Arrange
+            File stockFile = createStockFile("AAPL,Apple Inc.,100.00\n");
+            GameManager newGameManager = new GameManager();
+            // Act & Assert
+            assertThrows(NullPointerException.class, () ->
+                    newGameManager.createNewGame("Dara", STARTING_MONEY, stockFile, null));
+        }
     }
 
     @Nested

--- a/src/test/java/edu/ntnu/idatt2003/millions/manager/GameManagerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/manager/GameManagerTest.java
@@ -167,6 +167,25 @@ class GameManagerTest {
         }
 
         @Test
+        @DisplayName("Should create player and exchange from default stock data")
+        void createsPlayerAndExchangeFromDefaultStockData() {
+            // Arrange
+            CountingObserver observer = new CountingObserver();
+            GameManager newGameManager = new GameManager();
+            newGameManager.addObserver(observer);
+            // Act
+            newGameManager.createNewGame("Dara", STARTING_MONEY);
+            // Assert
+            assertEquals("Dara", newGameManager.getPlayer().getName());
+            assertEquals(0, STARTING_MONEY.compareTo(newGameManager.getPlayer().getMoney()));
+            assertEquals("MainExchange", newGameManager.getExchange().getName());
+            assertTrue(newGameManager.getExchange().hasStock("NVDA"));
+            assertTrue(newGameManager.getExchange().hasStock("AAPL"));
+            assertNotNull(newGameManager.getExchange().getCurrencyConverter());
+            assertEquals(1, observer.updateCount);
+        }
+
+        @Test
         @DisplayName("Should throw exception when stock file is null")
         void throwsExceptionWhenStockFileIsNull() {
             // Arrange

--- a/src/test/java/edu/ntnu/idatt2003/millions/manager/GameManagerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/manager/GameManagerTest.java
@@ -270,6 +270,62 @@ class GameManagerTest {
             assertThrows(NullPointerException.class, () ->
                     newGameManager.createNewGame("Dara", STARTING_MONEY, stockFile, null));
         }
+
+        @Test
+        @DisplayName("Should default stock currency to USD when no currency is supplied")
+        void defaultsStockCurrencyToUsdForCustomFile() throws IOException {
+            // Arrange
+            File stockFile = createStockFile("AAPL,Apple Inc.,100.00\n");
+            GameManager newGameManager = new GameManager();
+            // Act
+            newGameManager.createNewGame("Dara", STARTING_MONEY, stockFile);
+            // Assert
+            assertEquals(Currency.getInstance("USD"),
+                    newGameManager.getExchange().getStock("AAPL").getCurrency());
+        }
+
+        @Test
+        @DisplayName("Should tag default stock data with USD")
+        void tagsDefaultStockDataWithUsd() {
+            // Arrange
+            GameManager newGameManager = new GameManager();
+            // Act
+            newGameManager.createNewGame("Dara", STARTING_MONEY);
+            // Assert
+            assertEquals(Currency.getInstance("USD"),
+                    newGameManager.getExchange().getStock("AAPL").getCurrency());
+        }
+
+        @Test
+        @DisplayName("Should leave previous game state intact when createNewGame fails")
+        void leavesPreviousStateIntactOnFailure() throws IOException {
+            // Arrange: an already-active game from setUp() loaded "NYSE" with EQNR
+            CountingObserver observer = new CountingObserver();
+            gameManager.addObserver(observer);
+            File stockFile = createStockFile("AAPL,Apple Inc.,100.00\n");
+            // Act: a failed createNewGame must not mutate the active state
+            assertThrows(IllegalArgumentException.class, () ->
+                    gameManager.createNewGame("", STARTING_MONEY, stockFile));
+            // Assert: previous player and exchange remain
+            assertEquals("Dara", gameManager.getPlayer().getName());
+            assertEquals("NYSE", gameManager.getExchange().getName());
+            assertTrue(gameManager.getExchange().hasStock("EQNR"));
+            assertFalse(gameManager.getExchange().hasStock("AAPL"));
+            assertEquals(0, observer.updateCount);
+        }
+
+        @Test
+        @DisplayName("Should not notify observers when stock file is null")
+        void doesNotNotifyObserversWhenStockFileIsNull() {
+            // Arrange
+            CountingObserver observer = new CountingObserver();
+            GameManager newGameManager = new GameManager();
+            newGameManager.addObserver(observer);
+            // Act & Assert
+            assertThrows(NullPointerException.class, () ->
+                    newGameManager.createNewGame("Dara", STARTING_MONEY, null));
+            assertEquals(0, observer.updateCount);
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Summary
Implemented the application's startup flow through `GameManager`, replacing the previous controller-driven object construction. `GameManager.createNewGame(...)` now owns creation of the active `Player` and `Exchange`, including stock loading and currency converter setup, and notifies observers once the new game state is in place. `StartController` delegates fully to `GameManager` for both new-game and load-game flows, then navigates to `MainController`.

Also tightened the start flow into a testable, layered design: input validation lives in `StartInputValidator`, file parsing lives in the `file/` layer, and the controller depends on a `StartScreenInputs` seam so its handlers can be unit tested without initialising the JavaFX toolkit. Stock currency is now passed from the UI down through the file handler to the domain model so the exchange's `CurrencyConverter` produces correct NOK values on every trade.

## Changes
- Implemented `GameManager.createNewGame(...)` with overloads for default stocks and custom stock files.
- Wired `StartController.handleStartGame()` and `handleLoadGame()` to call `GameManager` and navigate to `MainController` on success.
- Implemented StartInputValidation for StartController (Closes #12
- Added support for starting a new game with default stock data from `/data/sp500.csv`.
- Made custom stock file upload optional with a fallback to default stock data.
- Restricted custom stock import to CSV files via `StartInputValidator.requireCsvFilePath(...)`.
- Preserved `GameManager.buy(...)` and `sell(...)` facade methods with observer notification.

## Idea
- Game creation now validates player input before performing any file I/O and only mutates the active state once the player and exchange have been fully constructed; failures leave the previous game intact.
- Default stock data is streamed directly through `CsvStockFileHandler.readStocks(InputStream)`,  no temporary file is written to disk. (Closes #73 )
- `StockFileHandler` exposes `Currency`-aware overloads so the chosen UI currency is propagated to every parsed `Stock`. Default currency is USD when none is supplied.
- `StartController` catches the concrete exception types the start flow can produce (`IllegalArgumentException`, `IllegalStateException`, `UncheckedIOException`) and reports them through an injected `Consumer<String>`. Programming errors are intentionally not caught.
- `Player` now requires strictly positive starting capital; `StartInputValidator.parseCapital` rejects zero and negative values at the UI layer with a friendly message.

## Testability
- Introduced `StartScreenInputs` interface in `view/`. `StartView` implements it; `StartController` reads user input through the seam.
- `StartController` exposes a test-only constructor that takes `StartScreenInputs`, `GameManager`, a navigation `Runnable` and an error `Consumer<String>` with no `Stage`, no concrete `StartView` required.
- Event bindings moved from constructor to `show()` so unit tests do not need fully built JavaFX widgets.

## View
- Added `setName(...)` and `setCapital(...)` to `StartView` for controlled input setup.
- Drop zone is now stored as a dedicated field instead of resolved through `getParent()`.
- Stock file path is stored as an independent data field; the label is purely visual.
- Stock file label appears above the drop zone (style fix).
- CSS cleanup at the end of `style.css`.

## Tests
- `GameManagerTest`: startup behaviour, currency propagation, NOK conversion on purchase (verifies `CurrencyConverter` integration end-to-end), atomicity on failed `createNewGame`, observer silence on failure, strict-positive capital rule.
- `CsvStockFileHandlerTest`: positive, negative and edge cases for both new `Currency` overloads and the new `InputStream` overloads, plus default-currency contract.
- `StartInputValidatorTest`: edge cases for `requireName`, `parseCapital` (zero and negative rejected), `requireCsvFilePath` (no extension, absolute paths) and the new `requireCurrency`.
- `StartControllerTest` (new): exercises `handleStartGame()` and `handleLoadGame()` through the seam — happy paths verify `GameManager` is called with parsed values and navigation runs; error paths verify the error sink receives the message and navigation does not run.