### PR TITLE
fix: add leading hyphens to CSS design token declarations and refer…

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/millions/view/StartView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/StartView.java
@@ -125,6 +125,7 @@ public class StartView implements StartScreenInputs {
 
         scene = new Scene(root, SCENE_WIDTH, SCENE_HEIGHT);
         StylesheetLoader.load(scene,
+                StylesheetLoader.Stylesheet.TOKENS,
                 StylesheetLoader.Stylesheet.TITLE,
                 StylesheetLoader.Stylesheet.DROP_ZONE,
                 StylesheetLoader.Stylesheet.OTHER);

--- a/src/main/resources/css/chart.css
+++ b/src/main/resources/css/chart.css
@@ -24,7 +24,7 @@
 }
 
 .area-chart .chart-series-area-line {
-    -fx-stroke: primary;
+    -fx-stroke: -primary;
     -fx-stroke-width: 2;
 }
 

--- a/src/main/resources/css/dropfile.css
+++ b/src/main/resources/css/dropfile.css
@@ -1,10 +1,10 @@
 .drop-zone {
-    -fx-border-color: border-strong;
+    -fx-border-color: -border-strong;
     -fx-border-style: dashed;
     -fx-border-width: 2;
     -fx-border-radius: 8;
     -fx-background-radius: 8;
-    -fx-background-color: surface-alt;
+    -fx-background-color: -surface-alt;
 }
 
 /* Highlight on drag over */
@@ -13,16 +13,16 @@
     -fx-border-width: 2;
     -fx-border-radius: 8;
     -fx-background-radius: 8;
-    -fx-background-color: border-light;
+    -fx-background-color: -border-light;
 }
 .drop-zone-hint {
     -fx-font-size: 24;
     -fx-font-family: "Sans-Serif";
-    -fx-text-fill: text-muted;
+    -fx-text-fill: -text-muted;
 }
 
 .drop-zone-or {
     -fx-font-size: 16;
     -fx-font-family: "Sans-Serif";
-    -fx-text-fill: text-muted;
+    -fx-text-fill: -text-muted;
 }

--- a/src/main/resources/css/holdings.css
+++ b/src/main/resources/css/holdings.css
@@ -1,13 +1,13 @@
 .holdings-header {
     -fx-font-size: 13;
     -fx-font-weight: bold;
-    -fx-text-fill: text-primary;
+    -fx-text-fill: -text-primary;
     -fx-padding: 0 0 8 0;
 }
 
 .holdings-cell {
     -fx-font-size: 13;
-    -fx-text-fill: text-primary;
+    -fx-text-fill: -text-primary;
     -fx-padding: 10 0 10 0;
 }
 
@@ -21,17 +21,17 @@
 }
 
 .holdings-action-buy {
-    -fx-text-fill: primary;
+    -fx-text-fill: -primary;
 }
 .holdings-action-buy:hover {
-    -fx-text-fill: primary-dark;
+    -fx-text-fill: -primary-dark;
 }
 
 .holdings-action-sell {
-    -fx-text-fill: danger;
+    -fx-text-fill: -danger;
 }
 .holdings-action-sell:hover {
-    -fx-text-fill: danger-dark;
+    -fx-text-fill: -danger-dark;
 }
 
 .holdings-empty {
@@ -42,7 +42,7 @@
     -fx-min-height: 17;
     -fx-pref-height: 17;
     -fx-max-height: 17;
-    -fx-border-color: border;
+    -fx-border-color: -border;
     -fx-border-width: 1 0 0 0;
     -fx-border-insets: 8 0 0 0;
 }
@@ -50,7 +50,7 @@
 .holdings-details-chevron {
     -fx-font-size: 11;
     -fx-font-weight: bold;
-    -fx-text-fill: text-secondary;
+    -fx-text-fill: -text-secondary;
     -fx-background-color: transparent;
     -fx-background-insets: 0;
     -fx-background-radius: 0;
@@ -64,9 +64,8 @@
     -fx-pref-height: -infinity;
 }
 .holdings-details-chevron:hover {
-    -fx-text-fill: text-primary;
+    -fx-text-fill: -text-primary;
 }
 .holdings-details-chevron:focused {
     -fx-background-color: transparent;
 }
-

--- a/src/main/resources/css/layout.css
+++ b/src/main/resources/css/layout.css
@@ -5,7 +5,7 @@
 
 .advance-button {
     -fx-background-color: transparent;
-    -fx-border-color: border;
+    -fx-border-color: -border;
     -fx-border-radius: 20;
     -fx-background-radius: 20;
     -fx-cursor: hand;
@@ -14,12 +14,12 @@
 }
 
 .advance-button:hover {
-    -fx-background-color: surface-alt;
+    -fx-background-color: -surface-alt;
 }
 
 /* === Card === */
 .card {
-    -fx-background-color: surface;
+    -fx-background-color: -surface;
     -fx-background-radius: 12;
     -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.06), 12, 0, 0, 2);
     -fx-padding: 16;
@@ -48,17 +48,17 @@
 }
 
 .content-scroll .scroll-bar:vertical .thumb {
-    -fx-background-color: border;
+    -fx-background-color: -border;
     -fx-background-radius: 6;
     -fx-background-insets: 0;
 }
 
 .content-scroll .scroll-bar:vertical .thumb:hover {
-    -fx-background-color: border-strong;
+    -fx-background-color: -border-strong;
 }
 
 .content-scroll .scroll-bar:vertical .thumb:pressed {
-    -fx-background-color: text-secondary;
+    -fx-background-color: -text-secondary;
 }
 
 .content-scroll .scroll-bar:vertical .increment-button,

--- a/src/main/resources/css/modal.css
+++ b/src/main/resources/css/modal.css
@@ -3,7 +3,7 @@
 }
 
 .modal-card {
-    -fx-background-color: surface;
+    -fx-background-color: -surface;
     -fx-background-radius: 12;
     -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.15), 24, 0, 0, 4);
     -fx-min-width: 460;
@@ -12,7 +12,7 @@
 
 .modal-header {
     -fx-padding: 20 24 16 24;
-    -fx-border-color: border-light;
+    -fx-border-color: -border-light;
     -fx-border-width: 0 0 1 0;
     -fx-alignment: center-left;
 }
@@ -24,7 +24,7 @@
 
 .modal-close {
     -fx-font-size: 18;
-    -fx-text-fill: text-secondary;
+    -fx-text-fill: -text-secondary;
     -fx-background-color: transparent;
     -fx-border-color: transparent;
     -fx-padding: 0 4 0 4;
@@ -47,17 +47,17 @@
 .modal-input {
     -fx-font-size: 14;
     -fx-padding: 8 12 8 12;
-    -fx-background-color: surface;
-    -fx-border-color: border;
+    -fx-background-color: -surface;
+    -fx-border-color: -border;
     -fx-border-radius: 6;
     -fx-background-radius: 6;
 }
 .modal-input:focused {
-    -fx-border-color: primary;
+    -fx-border-color: -primary;
 }
 
 .modal-summary {
-    -fx-background-color: surface-alt;
+    -fx-background-color: -surface-alt;
     -fx-background-radius: 8;
     -fx-padding: 14 16 14 16;
     -fx-spacing: 6;
@@ -68,7 +68,7 @@
 }
 
 .modal-summary-total {
-    -fx-border-color: border;
+    -fx-border-color: -border;
     -fx-border-width: 1 0 0 0;
     -fx-padding: 8 0 0 0;
 }
@@ -92,32 +92,32 @@
     -fx-padding: 10 20 10 20;
     -fx-background-radius: 8;
     -fx-cursor: hand;
-    -fx-background-color: surface;
-    -fx-border-color: border;
+    -fx-background-color: -surface;
+    -fx-border-color: -border;
     -fx-border-radius: 8;
 }
 .modal-button:hover {
-    -fx-background-color: surface-alt;
+    -fx-background-color: -surface-alt;
 }
 
 .modal-button-primary {
-    -fx-background-color: primary;
+    -fx-background-color: -primary;
     -fx-text-fill: white;
-    -fx-border-color: primary;
+    -fx-border-color: -primary;
 }
 .modal-button-primary:hover {
-    -fx-background-color: primary-dark;
-    -fx-border-color: primary-dark;
+    -fx-background-color: -primary-dark;
+    -fx-border-color: -primary-dark;
 }
 
 .modal-button-danger {
-    -fx-background-color: danger;
+    -fx-background-color: -danger;
     -fx-text-fill: white;
-    -fx-border-color: danger;
+    -fx-border-color: -danger;
 }
 .modal-button-danger:hover {
-    -fx-background-color: danger-dark;
-    -fx-border-color: danger-dark;
+    -fx-background-color: -danger-dark;
+    -fx-border-color: -danger-dark;
 }
 
 .modal-button:disabled {
@@ -127,7 +127,7 @@
 
 .modal-error {
     -fx-font-size: 12;
-    -fx-text-fill: danger;
+    -fx-text-fill: -danger;
 }
 
 .modal-info {
@@ -137,18 +137,18 @@
 }
 
 .modal-info-positive {
-    -fx-background-color: success-bg;
-    -fx-text-fill: success-text;
+    -fx-background-color: -success-bg;
+    -fx-text-fill: -success-text;
 }
 
 .modal-info-negative {
-    -fx-background-color: danger-bg;
-    -fx-text-fill: danger-text;
+    -fx-background-color: -danger-bg;
+    -fx-text-fill: -danger-text;
 }
 
 .modal-success-icon {
-    -fx-background-color: success-bg;
-    -fx-text-fill: success-text;
+    -fx-background-color: -success-bg;
+    -fx-text-fill: -success-text;
     -fx-min-width: 32px;
     -fx-min-height: 32px;
     -fx-max-width: 32px;
@@ -160,13 +160,13 @@
 }
 
 .modal-header-success {
-    -fx-background-color: success-bg;
+    -fx-background-color: -success-bg;
     -fx-background-radius: 12 12 0 0;
     -fx-padding: 16 20;
-    -fx-border-color: success-border;
+    -fx-border-color: -success-border;
     -fx-border-width: 0 0 1 0;
 }
 
 .modal-header-success .modal-title {
-    -fx-text-fill: success-text;
+    -fx-text-fill: -success-text;
 }

--- a/src/main/resources/css/portfolio.css
+++ b/src/main/resources/css/portfolio.css
@@ -1,14 +1,14 @@
 .explore-stocks-button {
-    -fx-background-color: surface;
-    -fx-border-color: border;
+    -fx-background-color: -surface;
+    -fx-border-color: -border;
     -fx-border-radius: 8;
     -fx-background-radius: 8;
     -fx-padding: 14 0 14 0;
     -fx-font-size: 14;
-    -fx-text-fill: text-primary;
+    -fx-text-fill: -text-primary;
     -fx-cursor: hand;
 }
 
 .explore-stocks-button:hover {
-    -fx-background-color: surface-alt;
+    -fx-background-color: -surface-alt;
 }

--- a/src/main/resources/css/tabs.css
+++ b/src/main/resources/css/tabs.css
@@ -5,7 +5,7 @@
     -fx-cursor: hand;
     -fx-border-color: transparent;
     -fx-border-width: 0 0 2 0;
-    -fx-text-fill: text-muted;
+    -fx-text-fill: -text-muted;
     -fx-padding: 8 0 10 0;
 }
 
@@ -16,7 +16,7 @@
 }
 
 .tab-bar {
-    -fx-border-color: border-strong;
+    -fx-border-color: -border-strong;
     -fx-border-width: 0 0 1 0;
     -fx-padding: 0;
 }
@@ -31,7 +31,7 @@
     -fx-font-family: "Sans-Serif";
     -fx-font-size: 18px;
     -fx-font-weight: normal;
-    -fx-text-fill: text-secondary;
+    -fx-text-fill: -text-secondary;
 }
 
 .tab-pane .tab:selected .tab-label {

--- a/src/main/resources/css/tokens.css
+++ b/src/main/resources/css/tokens.css
@@ -1,26 +1,26 @@
 /* === Design Tokens === */
 .root {
-    primary:          #2980b9;
-    primary-dark:     #1f6391;
+    -primary:          #2980b9;
+    -primary-dark:     #1f6391;
 
-    danger:           #e74c3c;
-    danger-dark:      #b03a2e;
-    danger-text:      #c0392b;
-    danger-bg:        #fdecea;
+    -danger:           #e74c3c;
+    -danger-dark:      #b03a2e;
+    -danger-text:      #c0392b;
+    -danger-bg:        #fdecea;
 
-    success:          #27ae60;
-    success-bg:       #EAF3DE;
-    success-text:     #2E5A0E;
-    success-border:   #C4DDA0;
+    -success:          #27ae60;
+    -success-bg:       #EAF3DE;
+    -success-text:     #2E5A0E;
+    -success-border:   #C4DDA0;
 
-    text-primary:     #333333;
-    text-secondary:   #888888;
-    text-muted:       #555555;
+    -text-primary:     #333333;
+    -text-secondary:   #888888;
+    -text-muted:       #555555;
 
-    border-strong:    #999999;
-    border:           #cccccc;
-    border-light:     #eeeeee;
+    -border-strong:    #999999;
+    -border:           #cccccc;
+    -border-light:     #eeeeee;
 
-    surface:          white;
-    surface-alt:      #f5f5f5;
+    -surface:          white;
+    -surface-alt:      #f5f5f5;
 }

--- a/src/main/resources/css/typography.css
+++ b/src/main/resources/css/typography.css
@@ -4,10 +4,10 @@
 .week-label    { -fx-font-size: 14; -fx-font-weight: bold; }
 
 /* Widget cards */
-.widget-label  { -fx-font-size: 12; -fx-text-fill: text-secondary; }
+.widget-label  { -fx-font-size: 12; -fx-text-fill: -text-secondary; }
 .widget-value  { -fx-font-size: 18; -fx-font-weight: bold; }
 .widget-change { -fx-font-size: 16; }
 
 /* Detail rows in modals, dialogs, and receipts */
-.detail-label  { -fx-font-size: 13; -fx-text-fill: text-secondary; }
-.detail-value  { -fx-font-size: 13; -fx-text-fill: text-primary; }
+.detail-label  { -fx-font-size: 13; -fx-text-fill: -text-secondary; }
+.detail-value  { -fx-font-size: 13; -fx-text-fill: -text-primary; }

--- a/src/main/resources/css/utilities.css
+++ b/src/main/resources/css/utilities.css
@@ -1,9 +1,9 @@
 .positive {
-    -fx-text-fill: success;
+    -fx-text-fill: -success;
 }
 
 .negative {
-    -fx-text-fill: danger;
+    -fx-text-fill: -danger;
 }
 
 .bold {


### PR DESCRIPTION
Dara had trouble with CSS being applied to the application. 
JavaFX CSS requires looked-up colors (design tokens) to be declared with a leading hyphen in their name, both at declaration and at every reference site. If tokens.css declares them without the hyphen, JavaFX cannot resolve them - but it doesn't fail loudly; it just falls back to whatever defaults each property has. This is now fixed.