### PR TITLE
feat: add realized returns card + freeze Sale financial values at construction

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/millions/manager/GameManager.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/manager/GameManager.java
@@ -20,10 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Currency;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 
 /**
  * Service-layer manager for the game lifecycle: creates new games, loads and
@@ -402,6 +399,74 @@ public class GameManager {
      */
     public BigDecimal getTotalPortfolioReturnPercent() {
         return player.getPortfolio().getTotalReturnPercent(exchange.getCurrencyConverter());
+    }
+
+    /**
+     * Returns the total realized gain across all profitable sales, converted to NOK.
+     *
+     * @return total realized gain in NOK; zero if no profitable sales exist
+     */
+    public BigDecimal getRealizedGainsInNok() {
+        return sumByCurrencyToNok(player.getTransactionArchive().getRealizedGainsByCurrency());
+    }
+
+    /**
+     * Returns the total realized loss across all losing sales, converted to NOK.
+     * The value is non-negative — losses are returned as a positive number for
+     * display purposes; the negative sign is applied by the view.
+     *
+     * @return total realized loss in NOK as a non-negative value
+     */
+    public BigDecimal getRealizedLossesInNok() {
+        return sumByCurrencyToNok(player.getTransactionArchive().getRealizedLossesByCurrency());
+    }
+
+    /**
+     * Returns the net realized result: realized gains minus realized losses,
+     * in NOK. Can be negative if losses exceed gains.
+     *
+     * @return net realized result in NOK
+     */
+    public BigDecimal getNetRealizedInNok() {
+        return getRealizedGainsInNok().subtract(getRealizedLossesInNok());
+    }
+
+    /**
+     * Returns the total tax paid across all sales, converted to NOK.
+     *
+     * @return total tax paid in NOK; zero if no sales exist
+     */
+    public BigDecimal getTotalTaxPaidInNok() {
+        return sumByCurrencyToNok(player.getTransactionArchive().getTotalSaleTaxByCurrency());
+    }
+
+    /**
+     * Returns the total commission paid across all sales, converted to NOK.
+     *
+     * @return total commission paid in NOK; zero if no sales exist
+     */
+    public BigDecimal getTotalSaleCommissionInNok() {
+        return sumByCurrencyToNok(player.getTransactionArchive().getTotalSaleCommissionByCurrency());
+    }
+
+    /**
+     * Returns the total number of completed sales.
+     *
+     * @return the number of sales
+     */
+    public int getSalesCount() {
+        return player.getTransactionArchive().getSalesCount();
+    }
+
+    /**
+     * Converts a per-currency map of amounts into a single sum in NOK.
+     */
+    private BigDecimal sumByCurrencyToNok(Map<Currency, BigDecimal> amountsByCurrency) {
+        CurrencyConverter converter = exchange.getCurrencyConverter();
+        Currency nok = Currency.getInstance("NOK");
+        return amountsByCurrency.entrySet().stream()
+                .map(entry -> converter.convert(entry.getValue(), entry.getKey(), nok))
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/exchange/Exchange.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/exchange/Exchange.java
@@ -2,6 +2,7 @@ package edu.ntnu.idatt2003.millions.model.exchange;
 
 import edu.ntnu.idatt2003.millions.factory.TransactionFactory;
 import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
+import edu.ntnu.idatt2003.millions.model.transaction.Sale;
 import edu.ntnu.idatt2003.millions.model.transaction.Transaction;
 import edu.ntnu.idatt2003.millions.model.player.Player;
 import edu.ntnu.idatt2003.millions.model.stock.Share;
@@ -208,8 +209,8 @@ public class Exchange {
         Objects.requireNonNull(share, "Share cannot be null");
         validatePlayer(player);
 
-        Transaction sale = TransactionFactory.createSale(share, week);
-        BigDecimal totalValue = sale.getCalculator().calculateTotal();
+        Sale sale = (Sale) TransactionFactory.createSale(share, week);
+        BigDecimal totalValue = sale.getTotal();
         BigDecimal totalValueInNok = currencyConverter.convert(totalValue, share.getStock().getCurrency(), NOK);
         player.addMoney(totalValueInNok);
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/Sale.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/Sale.java
@@ -8,26 +8,51 @@ import java.math.BigDecimal;
 import java.util.Objects;
 
 /**
- * Represents a sale transaction for a given share.
- * A sale records the share being sold and the week it was sold,
- * and uses a {@link SalesCalculator} to process the transaction.
+ * Represents an immutable historical record of a stock sale.
+ *
+ * <p>Financial values (gross, commission, tax, total, profit, profitPercent)
+ * are captured at construction in the stock's native currency and never change
+ * afterward, even if the underlying stock price moves. This guarantees that
+ * realized financial values in the transaction archive reflect the price at
+ * sale time, not the current price.
+ *
+ * <p>Note: {@link #getShare()}{@code .getStock().getSalesPrice()} still returns
+ * the current stock price, not the sale-time price. The frozen fields on Sale
+ * cover all current uses. If a future feature requires the sale-time stock price
+ * as a separate piece of data, add a {@code salesPriceAtCommit} field at that point.
  */
 public class Sale extends Transaction {
 
+    private final BigDecimal gross;
+    private final BigDecimal commission;
+    private final BigDecimal tax;
+    private final BigDecimal total;
+    private final BigDecimal profit;
+    private final BigDecimal profitPercent;
+
     /**
      * Constructs a new Sale for the specified share and week.
+     * All financial values are captured immediately from the current stock price
+     * and remain fixed for the lifetime of this object.
      *
      * @param share the share being sold
      * @param week  the week in which the sale takes place
      */
     public Sale(Share share, int week) {
         super(share, week, new SalesCalculator(share));
+        SalesCalculator calc = (SalesCalculator) getCalculator();
+        this.gross        = calc.calculateGross();
+        this.commission   = calc.calculateCommission();
+        this.tax          = calc.calculateTax();
+        this.total        = calc.calculateTotal();
+        this.profit       = calc.calculateProfit();
+        this.profitPercent = calc.calculateProfitPercent();
     }
 
     /**
      * Commits this sale for the given player.
-     * Adds the total payout to the player's balance, removes the share
-     * from the player's portfolio, and records the transaction in the archive.
+     * Removes the share from the player's portfolio and records the transaction
+     * in the archive. Financial values are already frozen from construction.
      *
      * @param player the player executing the sale
      * @throws NullPointerException  if the player is null
@@ -43,5 +68,35 @@ public class Sale extends Transaction {
         player.getPortfolio().removeShare(getShare());
         player.getTransactionArchive().add(this);
         markAsCommitted();
+    }
+
+    /** Returns the gross sale value (sales price × quantity) in native currency. */
+    public BigDecimal getGross() {
+        return gross;
+    }
+
+    /** Returns the commission paid on this sale (1% of gross) in native currency. */
+    public BigDecimal getCommission() {
+        return commission;
+    }
+
+    /** Returns the tax paid on this sale (30% of profit, or zero if a loss) in native currency. */
+    public BigDecimal getTax() {
+        return tax;
+    }
+
+    /** Returns the net payout of this sale (gross − commission − tax) in native currency. */
+    public BigDecimal getTotal() {
+        return total;
+    }
+
+    /** Returns the realized profit or loss on this sale (total − original purchase costs) in native currency. */
+    public BigDecimal getProfit() {
+        return profit;
+    }
+
+    /** Returns the realized profit as a percentage of the original purchase costs. */
+    public BigDecimal getProfitPercent() {
+        return profitPercent;
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/TransactionArchive.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/TransactionArchive.java
@@ -1,8 +1,9 @@
 package edu.ntnu.idatt2003.millions.model.transaction;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+import edu.ntnu.idatt2003.millions.model.calculator.SalesCalculator;
+
+import java.math.BigDecimal;
+import java.util.*;
 
 /**
  * Represents an archive of transactions.
@@ -95,5 +96,99 @@ public class TransactionArchive {
      */
     public int countDistinctWeeks() {
         return (int) transactions.stream().map(Transaction::getWeek).distinct().count();
+    }
+
+    /**
+     * Returns the total realized gain from all profitable sales, grouped by the
+     * stock's native currency. Each entry maps a currency to the sum of profits
+     * from sales in that currency. Sales with zero or negative profit are excluded.
+     *
+     * <p>The caller is responsible for converting to a display currency. This
+     * separation keeps the domain free of currency-conversion concerns.</p>
+     *
+     * @return profits per currency; empty map if no profitable sales exist
+     */
+    public Map<Currency, BigDecimal> getRealizedGainsByCurrency() {
+        return sumSalesByCurrency(profit -> profit.signum() > 0, profit -> profit);
+    }
+
+    /**
+     * Returns the total realized loss from all losing sales, grouped by the stock's
+     * native currency. Each entry maps a currency to the sum of absolute losses
+     * (positive numbers) in that currency. Sales with zero or positive profit are
+     * excluded.
+     *
+     * @return absolute losses per currency; empty map if no losing sales exist
+     */
+    public Map<Currency, BigDecimal> getRealizedLossesByCurrency() {
+        return sumSalesByCurrency(profit -> profit.signum() < 0, BigDecimal::abs);
+    }
+
+    /**
+     * Returns the total commission paid across all sales, grouped by the stock's
+     * native currency.
+     *
+     * @return commission totals per currency; empty map if no sales exist
+     */
+    public Map<Currency, BigDecimal> getTotalSaleCommissionByCurrency() {
+        return sumSalesAttribute(SalesCalculator::calculateCommission);
+    }
+
+    /**
+     * Returns the total tax paid across all sales, grouped by the stock's native
+     * currency.
+     *
+     * @return tax totals per currency; empty map if no sales exist
+     */
+    public Map<Currency, BigDecimal> getTotalSaleTaxByCurrency() {
+        return sumSalesAttribute(SalesCalculator::calculateTax);
+    }
+
+    /**
+     * Returns the total number of completed sales in the archive.
+     *
+     * @return the number of sales
+     */
+    public int getSalesCount() {
+        return (int) transactions.stream()
+                .filter(Sale.class::isInstance)
+                .count();
+    }
+
+    /**
+     * Aggregates per-sale profit values into a sum per currency, applying the
+     * given filter and mapping function. The mapping function is used to convert
+     * the profit value (e.g. take the absolute value for losses).
+     */
+    private Map<Currency, BigDecimal> sumSalesByCurrency(
+            java.util.function.Predicate<BigDecimal> filter,
+            java.util.function.UnaryOperator<BigDecimal> mapper) {
+        Map<Currency, BigDecimal> result = new HashMap<>();
+        for (Transaction transaction : transactions) {
+            if (!(transaction instanceof Sale)) continue;
+            SalesCalculator calculator = new SalesCalculator(transaction.getShare());
+            BigDecimal profit = calculator.calculateProfit();
+            if (!filter.test(profit)) continue;
+            Currency currency = transaction.getShare().getStock().getCurrency();
+            result.merge(currency, mapper.apply(profit), BigDecimal::add);
+        }
+        return result;
+    }
+
+    /**
+     * Aggregates a per-sale attribute (e.g. commission, tax) into a sum per
+     * currency. Used by {@link #getTotalSaleCommissionByCurrency()} and
+     * {@link #getTotalSaleTaxByCurrency()}.
+     */
+    private Map<Currency, BigDecimal> sumSalesAttribute(
+            java.util.function.Function<SalesCalculator, BigDecimal> extractor) {
+        Map<Currency, BigDecimal> result = new HashMap<>();
+        for (Transaction transaction : transactions) {
+            if (!(transaction instanceof Sale)) continue;
+            SalesCalculator calculator = new SalesCalculator(transaction.getShare());
+            Currency currency = transaction.getShare().getStock().getCurrency();
+            result.merge(currency, extractor.apply(calculator), BigDecimal::add);
+        }
+        return result;
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/TransactionArchive.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/TransactionArchive.java
@@ -1,7 +1,5 @@
 package edu.ntnu.idatt2003.millions.model.transaction;
 
-import edu.ntnu.idatt2003.millions.model.calculator.SalesCalculator;
-
 import java.math.BigDecimal;
 import java.util.*;
 
@@ -131,7 +129,7 @@ public class TransactionArchive {
      * @return commission totals per currency; empty map if no sales exist
      */
     public Map<Currency, BigDecimal> getTotalSaleCommissionByCurrency() {
-        return sumSalesAttribute(SalesCalculator::calculateCommission);
+        return sumSalesAttribute(Sale::getCommission);
     }
 
     /**
@@ -141,7 +139,7 @@ public class TransactionArchive {
      * @return tax totals per currency; empty map if no sales exist
      */
     public Map<Currency, BigDecimal> getTotalSaleTaxByCurrency() {
-        return sumSalesAttribute(SalesCalculator::calculateTax);
+        return sumSalesAttribute(Sale::getTax);
     }
 
     /**
@@ -165,11 +163,10 @@ public class TransactionArchive {
             java.util.function.UnaryOperator<BigDecimal> mapper) {
         Map<Currency, BigDecimal> result = new HashMap<>();
         for (Transaction transaction : transactions) {
-            if (!(transaction instanceof Sale)) continue;
-            SalesCalculator calculator = new SalesCalculator(transaction.getShare());
-            BigDecimal profit = calculator.calculateProfit();
+            if (!(transaction instanceof Sale sale)) continue;
+            BigDecimal profit = sale.getProfit();
             if (!filter.test(profit)) continue;
-            Currency currency = transaction.getShare().getStock().getCurrency();
+            Currency currency = sale.getShare().getStock().getCurrency();
             result.merge(currency, mapper.apply(profit), BigDecimal::add);
         }
         return result;
@@ -181,13 +178,12 @@ public class TransactionArchive {
      * {@link #getTotalSaleTaxByCurrency()}.
      */
     private Map<Currency, BigDecimal> sumSalesAttribute(
-            java.util.function.Function<SalesCalculator, BigDecimal> extractor) {
+            java.util.function.Function<Sale, BigDecimal> extractor) {
         Map<Currency, BigDecimal> result = new HashMap<>();
         for (Transaction transaction : transactions) {
-            if (!(transaction instanceof Sale)) continue;
-            SalesCalculator calculator = new SalesCalculator(transaction.getShare());
-            Currency currency = transaction.getShare().getStock().getCurrency();
-            result.merge(currency, extractor.apply(calculator), BigDecimal::add);
+            if (!(transaction instanceof Sale sale)) continue;
+            Currency currency = sale.getShare().getStock().getCurrency();
+            result.merge(currency, extractor.apply(sale), BigDecimal::add);
         }
         return result;
     }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/PortfolioView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/PortfolioView.java
@@ -35,8 +35,9 @@ public class PortfolioView extends VBox {
         HBox topRow = buildTopRow();
         HoldingsCard holdingsCard = new HoldingsCard(gameManager, controller);
         ExploreStocksButton exploreButton = new ExploreStocksButton(onExploreStocks);
+        RealizedReturnsCard realizedReturnsCard = new RealizedReturnsCard(gameManager);
 
-        getChildren().addAll(topRow, holdingsCard, exploreButton);
+        getChildren().addAll(topRow, holdingsCard, exploreButton, realizedReturnsCard);
     }
 
     private HBox buildTopRow() {

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/RealizedReturnsCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/RealizedReturnsCard.java
@@ -1,0 +1,159 @@
+package edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card;
+
+import edu.ntnu.idatt2003.millions.manager.GameManager;
+import edu.ntnu.idatt2003.millions.util.CurrencyFormatter;
+import edu.ntnu.idatt2003.millions.util.LanguageManager;
+import edu.ntnu.idatt2003.millions.view.component.Card;
+import edu.ntnu.idatt2003.millions.view.component.StyledText;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
+
+import java.math.BigDecimal;
+
+/**
+ * Card displaying the player's realized returns — gains, losses,
+ * taxes, and commissions from completed sales.
+ *
+ * <p>Until the player has completed their first sale, the card shows an
+ * empty-state message instead of zero-filled values. Once a sale exists,
+ * the card switches to a two-row, three-column grid of summary values.</p>
+ */
+public class RealizedReturnsCard extends Card {
+
+    private final GameManager gameManager;
+
+    private final StyledText title = StyledText.sectionTitle();
+    private final StyledText emptyMessage = StyledText.detailLabel();
+    private final VBox emptyContainer = new VBox(emptyMessage);
+    private final VBox valuesContainer = new VBox(12);
+
+    private final StyledText gainValue = StyledText.widgetValue();
+    private final StyledText lossValue = StyledText.widgetValue();
+    private final StyledText netValue = StyledText.widgetValue();
+    private final StyledText taxValue = StyledText.widgetValue();
+    private final StyledText commissionValue = StyledText.widgetValue();
+    private final StyledText countValue = StyledText.widgetValue();
+
+    private final StyledText gainLabel = StyledText.widgetLabel();
+    private final StyledText lossLabel = StyledText.widgetLabel();
+    private final StyledText netLabel = StyledText.widgetLabel();
+    private final StyledText taxLabel = StyledText.widgetLabel();
+    private final StyledText commissionLabel = StyledText.widgetLabel();
+    private final StyledText countLabel = StyledText.widgetLabel();
+
+    /**
+     * Constructs a new RealizedReturnsCard.
+     *
+     * @param gameManager the game manager containing player and exchange
+     */
+    public RealizedReturnsCard(GameManager gameManager) {
+        super(gameManager);
+        this.gameManager = gameManager;
+        setSpacing(16);
+
+        emptyContainer.setAlignment(Pos.CENTER);
+        emptyContainer.setPadding(new Insets(12, 0, 12, 0));
+
+        valuesContainer.getChildren().addAll(
+                buildRow(gainLabel, gainValue, lossLabel, lossValue, netLabel, netValue),
+                buildRow(taxLabel, taxValue, commissionLabel, commissionValue, countLabel, countValue)
+        );
+
+        getChildren().addAll(title, emptyContainer, valuesContainer);
+
+        applyLabels();
+        refresh();
+    }
+
+    @Override
+    protected void onLanguageChanged() {
+        applyLabels();
+        refresh();
+    }
+
+    @Override
+    public void onGameUpdated() {
+        refresh();
+    }
+
+    private void refresh() {
+        boolean hasSales = gameManager.getSalesCount() > 0;
+
+        emptyContainer.setVisible(!hasSales);
+        emptyContainer.setManaged(!hasSales);
+        valuesContainer.setVisible(hasSales);
+        valuesContainer.setManaged(hasSales);
+
+        if (!hasSales) return;
+
+        BigDecimal gains = gameManager.getRealizedGainsInNok();
+        BigDecimal losses = gameManager.getRealizedLossesInNok();
+        BigDecimal net = gameManager.getNetRealizedInNok();
+        BigDecimal tax = gameManager.getTotalTaxPaidInNok();
+        BigDecimal commission = gameManager.getTotalSaleCommissionInNok();
+        int count = gameManager.getSalesCount();
+
+        String gainSign = gains.signum() > 0 ? "+" : "";
+        gainValue.setText(gainSign + CurrencyFormatter.format(gains));
+        applyColor(gainValue, gains.signum() > 0 ? "positive" : null);
+
+        lossValue.setText(losses.signum() > 0
+                ? "\u2212" + CurrencyFormatter.format(losses)
+                : CurrencyFormatter.format(losses));
+        applyColor(lossValue, losses.signum() > 0 ? "negative" : null);
+
+        String netSign = net.signum() > 0 ? "+" : (net.signum() < 0 ? "\u2212" : "");
+        netValue.setText(netSign + CurrencyFormatter.format(net.abs()));
+        applyColor(netValue,
+                net.signum() > 0 ? "positive" : (net.signum() < 0 ? "negative" : null));
+
+        taxValue.setText(CurrencyFormatter.format(tax));
+        applyColor(taxValue, null);
+
+        commissionValue.setText(CurrencyFormatter.format(commission));
+        applyColor(commissionValue, null);
+
+        countValue.setText(String.valueOf(count));
+        applyColor(countValue, null);
+    }
+
+    private void applyLabels() {
+        title.setText(LanguageManager.get("dashboard.realized.title"));
+        emptyMessage.setText(LanguageManager.get("dashboard.realized.empty"));
+        gainLabel.setText(LanguageManager.get("dashboard.realized.gain"));
+        lossLabel.setText(LanguageManager.get("dashboard.realized.loss"));
+        netLabel.setText(LanguageManager.get("dashboard.realized.net"));
+        taxLabel.setText(LanguageManager.get("dashboard.realized.tax"));
+        commissionLabel.setText(LanguageManager.get("dashboard.realized.commission"));
+        countLabel.setText(LanguageManager.get("dashboard.realized.count"));
+    }
+
+    private HBox buildRow(StyledText l1, StyledText v1,
+                          StyledText l2, StyledText v2,
+                          StyledText l3, StyledText v3) {
+        HBox row = new HBox(20);
+        row.getChildren().addAll(
+                buildCell(l1, v1),
+                buildCell(l2, v2),
+                buildCell(l3, v3)
+        );
+        return row;
+    }
+
+    private VBox buildCell(StyledText label, StyledText value) {
+        VBox cell = new VBox(4, label, value);
+        HBox.setHgrow(cell, Priority.ALWAYS);
+        cell.setMaxWidth(Double.MAX_VALUE);
+        return cell;
+    }
+
+    private void applyColor(StyledText node, String modifier) {
+        node.getStyleClass().removeAll("positive", "negative");
+        if (modifier != null) {
+            node.getStyleClass().add(modifier);
+        }
+    }
+}

--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -54,6 +54,9 @@ dashboard.realized.gain=Realized gain
 dashboard.realized.loss=Realized loss
 dashboard.realized.net=Net realized
 dashboard.realized.tax=Total tax paid
+dashboard.realized.commission=Total commission paid
+dashboard.realized.count=Number of sales
+dashboard.realized.empty=Sell shares to see realized returns here.
 dashboard.sinceStart=since start
 dashboard.portfolio.empty=You don't own any shares yet
 # Exchange

--- a/src/main/resources/i18n/messages_no.properties
+++ b/src/main/resources/i18n/messages_no.properties
@@ -54,6 +54,9 @@ dashboard.realized.gain=Realisert gevinst
 dashboard.realized.loss=Realisert tap
 dashboard.realized.net=Netto realisert
 dashboard.realized.tax=Total skatt betalt
+dashboard.realized.commission=Total kurtasje betalt
+dashboard.realized.count=Antall salg
+dashboard.realized.empty=Selg aksjer for å se realisert avkastning her.
 dashboard.sinceStart=siden start
 dashboard.portfolio.empty=Du eier ingen andeler ennå
 # Exchange

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/SaleTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/SaleTest.java
@@ -1,5 +1,6 @@
 package edu.ntnu.idatt2003.millions.model;
 
+import edu.ntnu.idatt2003.millions.model.calculator.SalesCalculator;
 import edu.ntnu.idatt2003.millions.model.player.Player;
 import edu.ntnu.idatt2003.millions.model.stock.Share;
 import edu.ntnu.idatt2003.millions.model.stock.Stock;
@@ -38,6 +39,53 @@ class SaleTest {
                         new ArrayList<>(List.of(new BigDecimal("100.00")))),
                 new BigDecimal("10"), new BigDecimal("50.00"));
         player.getPortfolio().addShare(share);
+    }
+
+    @Nested
+    @DisplayName("Frozen financial values")
+    class FrozenValues {
+
+        @Test
+        @DisplayName("Financial values are non-null after construction")
+        void valuesAreSetOnConstruction() {
+            Sale sale = new Sale(share, 1);
+            assertNotNull(sale.getGross());
+            assertNotNull(sale.getCommission());
+            assertNotNull(sale.getTax());
+            assertNotNull(sale.getTotal());
+            assertNotNull(sale.getProfit());
+            assertNotNull(sale.getProfitPercent());
+        }
+
+        @Test
+        @DisplayName("Frozen values match SalesCalculator results at construction time")
+        void valuesMatchCalculatorAtConstruction() {
+            SalesCalculator expected = new SalesCalculator(share);
+            Sale sale = new Sale(share, 1);
+            assertEquals(0, expected.calculateGross().compareTo(sale.getGross()));
+            assertEquals(0, expected.calculateCommission().compareTo(sale.getCommission()));
+            assertEquals(0, expected.calculateTax().compareTo(sale.getTax()));
+            assertEquals(0, expected.calculateTotal().compareTo(sale.getTotal()));
+            assertEquals(0, expected.calculateProfit().compareTo(sale.getProfit()));
+            assertEquals(0, expected.calculateProfitPercent().compareTo(sale.getProfitPercent()));
+        }
+
+        @Test
+        @DisplayName("Frozen values do not change when stock price advances")
+        void valuesDoNotChangeWhenPriceMoves() {
+            Sale sale = new Sale(share, 1);
+            BigDecimal frozenCommission = sale.getCommission();
+            BigDecimal frozenTax        = sale.getTax();
+            BigDecimal frozenTotal      = sale.getTotal();
+            BigDecimal frozenProfit     = sale.getProfit();
+
+            share.getStock().addNewSalesPrice(new BigDecimal("999.00"));
+
+            assertEquals(0, frozenCommission.compareTo(sale.getCommission()));
+            assertEquals(0, frozenTax.compareTo(sale.getTax()));
+            assertEquals(0, frozenTotal.compareTo(sale.getTotal()));
+            assertEquals(0, frozenProfit.compareTo(sale.getProfit()));
+        }
     }
 
     @Nested

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/TransactionArchiveTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/TransactionArchiveTest.java
@@ -1,5 +1,6 @@
 package edu.ntnu.idatt2003.millions.model;
 
+import edu.ntnu.idatt2003.millions.model.calculator.SalesCalculator;
 import edu.ntnu.idatt2003.millions.model.player.Player;
 import edu.ntnu.idatt2003.millions.model.stock.Share;
 import edu.ntnu.idatt2003.millions.model.stock.Stock;
@@ -314,6 +315,33 @@ class TransactionArchiveTest {
             // Assert
             assertEquals(1, result.size());
             assertTrue(result.containsKey(Currency.getInstance("USD")));
+        }
+
+        @Test
+        @DisplayName("Realized gain reflects sale-time price, not current price")
+        void usesConstructionTimePriceNotCurrentPrice() {
+            // Arrange — sale at price 200.00
+            Player player = new Player("Alva", new BigDecimal("100000.00"));
+            Share gainShare = makeShare("DIS", new BigDecimal("200.00"), new BigDecimal("100.00"));
+            player.getPortfolio().addShare(gainShare);
+            Sale sale = new Sale(gainShare, 1);
+            BigDecimal profitAtSaleTime = sale.getProfit();
+            sale.commit(player);
+            archive.add(sale);
+
+            // Stock price advances to a much higher value after the sale
+            gainShare.getStock().addNewSalesPrice(new BigDecimal("999.00"));
+
+            // A live SalesCalculator would now compute a higher profit
+            BigDecimal liveProfit = new SalesCalculator(gainShare).calculateProfit();
+            assertNotEquals(0, profitAtSaleTime.compareTo(liveProfit),
+                    "Pre-condition: live price should produce a different profit");
+
+            // Act
+            Map<Currency, BigDecimal> result = archive.getRealizedGainsByCurrency();
+
+            // Assert — archive must reflect the frozen sale-time value, not the live price
+            assertEquals(0, profitAtSaleTime.compareTo(result.get(Currency.getInstance("USD"))));
         }
     }
 

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/TransactionArchiveTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/TransactionArchiveTest.java
@@ -1,5 +1,6 @@
 package edu.ntnu.idatt2003.millions.model;
 
+import edu.ntnu.idatt2003.millions.model.player.Player;
 import edu.ntnu.idatt2003.millions.model.stock.Share;
 import edu.ntnu.idatt2003.millions.model.stock.Stock;
 import edu.ntnu.idatt2003.millions.model.transaction.Purchase;
@@ -13,7 +14,9 @@ import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Currency;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -278,5 +281,102 @@ class TransactionArchiveTest {
             // Act & Assert
             assertEquals(1, archive.countDistinctWeeks());
         }
+    }
+
+    @Nested
+    @DisplayName("getRealizedGainsByCurrency()")
+    class GetRealizedGainsByCurrency {
+
+        @Test
+        @DisplayName("Should return empty map when archive is empty")
+        void returnsEmptyMapWhenArchiveIsEmpty() {
+            // Act & Assert
+            assertTrue(archive.getRealizedGainsByCurrency().isEmpty());
+        }
+
+        @Test
+        @DisplayName("Should include profitable sale and exclude losing sale")
+        void includesOnlyProfitableSales() {
+            // Arrange
+            Player player = new Player("Alva", new BigDecimal("100000.00"));
+            Share gainShare = makeShare("DIS", new BigDecimal("200.00"), new BigDecimal("100.00"));
+            Share lossShare = makeShare("NKE", new BigDecimal("50.00"), new BigDecimal("100.00"));
+            player.getPortfolio().addShare(gainShare);
+            player.getPortfolio().addShare(lossShare);
+            Sale gainSale = new Sale(gainShare, 1);
+            Sale lossSale = new Sale(lossShare, 1);
+            gainSale.commit(player);
+            lossSale.commit(player);
+            archive.add(gainSale);
+            archive.add(lossSale);
+            // Act
+            Map<Currency, BigDecimal> result = archive.getRealizedGainsByCurrency();
+            // Assert
+            assertEquals(1, result.size());
+            assertTrue(result.containsKey(Currency.getInstance("USD")));
+        }
+    }
+
+    @Nested
+    @DisplayName("getRealizedLossesByCurrency()")
+    class GetRealizedLossesByCurrency {
+
+        @Test
+        @DisplayName("Should return absolute loss as a positive number")
+        void returnsLossAsPositive() {
+            // Arrange
+            Player player = new Player("Alva", new BigDecimal("100000.00"));
+            Share lossShare = makeShare("NKE", new BigDecimal("50.00"), new BigDecimal("100.00"));
+            player.getPortfolio().addShare(lossShare);
+            Sale sale = new Sale(lossShare, 1);
+            sale.commit(player);
+            archive.add(sale);
+            // Act
+            Map<Currency, BigDecimal> result = archive.getRealizedLossesByCurrency();
+            // Assert
+            assertFalse(result.isEmpty());
+            assertTrue(result.get(Currency.getInstance("USD")).signum() > 0);
+        }
+    }
+
+    @Nested
+    @DisplayName("getSalesCount()")
+    class GetSalesCount {
+
+        @Test
+        @DisplayName("Should return zero when archive has no sales")
+        void returnsZeroWhenNoSales() {
+            // Arrange
+            archive.add(new Purchase(share, 1));
+            // Act & Assert
+            assertEquals(0, archive.getSalesCount());
+        }
+
+        @Test
+        @DisplayName("Should count only sales, not purchases")
+        void countsOnlySales() {
+            // Arrange
+            Player player = new Player("Alva", new BigDecimal("100000.00"));
+            Share shareA = makeShare("DIS", new BigDecimal("150.00"), new BigDecimal("100.00"));
+            Share shareB = makeShare("NKE", new BigDecimal("150.00"), new BigDecimal("100.00"));
+            player.getPortfolio().addShare(shareA);
+            player.getPortfolio().addShare(shareB);
+            Sale sale1 = new Sale(shareA, 1);
+            Sale sale2 = new Sale(shareB, 1);
+            sale1.commit(player);
+            sale2.commit(player);
+            archive.add(new Purchase(share, 1));
+            archive.add(sale1);
+            archive.add(sale2);
+            // Act & Assert
+            assertEquals(2, archive.getSalesCount());
+        }
+    }
+
+    private static Share makeShare(String symbol, BigDecimal salesPrice, BigDecimal purchasePrice) {
+        return new Share(
+                new Stock(symbol, "Test Co",
+                        new ArrayList<>(List.of(salesPrice))),
+                new BigDecimal("10"), purchasePrice);
     }
 }


### PR DESCRIPTION
## Summary

Adds a new "Realisert avkastning" card to the Portfolio tab showing aggregated realized financial outcomes across all completed sales, and fixes a latent correctness bug where realized values drifted as stock prices moved.

## Background

While building the realized returns card, we discovered that `TransactionArchive`'s aggregation methods constructed a fresh `SalesCalculator` for each archived sale to compute profit, commission, and tax. The calculator reads `share.getStock().getSalesPrice()`, which returns the *current* stock price - not the price at sale time. This meant that historical "realized" values changed every time the week advanced, corrupting what should by definition be immutable historical facts.

The realized returns card surfaced this clearly: the displayed gains and losses moved as soon as the user clicked "Advance week".

## Changes

### 1. Sale-freezing fix

`Sale` now captures its six financial values - gross, commission, tax, total, profit, profitPercent - as `final` fields in the constructor, computed from `SalesCalculator` at the moment of construction. The values are then immutable for the lifetime of the object regardless of subsequent stock price changes.

- New `final BigDecimal` fields on `Sale` with public getters for each
- `Exchange.sell()` now reads `sale.getTotal()` directly instead of going through `sale.getCalculator().calculateTotal()`, removing the last external usage of `getCalculator()` on the normal sales path
- `TransactionArchive`'s private aggregation helpers read from `Sale` getters instead of reconstructing `SalesCalculator` instances - removes the `SalesCalculator` import from `TransactionArchive` entirely
- `sumSalesAttribute` signature changed from `Function<SalesCalculator, BigDecimal>` to `Function<Sale, BigDecimal>` so callers can pass method references like `Sale::getCommission` and `Sale::getTax`

#### Design choice: constructor capture vs commit() capture

We considered storing the values as non-final fields set in `commit()` instead of final fields set in the constructor. We chose constructor capture because:

- Symmetry with `Purchase.settlementAmount`, which is also final and set in the constructor
- `final` is enforced by the language; convention-based "write-once" via the `committed` flag is weaker
- `Sale` is always constructed immediately before commit in `Exchange.sell()`, so there is no real "uncommitted Sale carrying frozen values" concern in practice
- Constructor capture removed the external `getCalculator()` call from `Exchange.sell()`, making the calculator a fully internal implementation detail of `Sale`

We also considered freezing the underlying stock price (e.g. adding a `salesPriceAtCommit` field), but concluded this was out of scope: after the fix, no code reads `sale.getShare().getStock().getSalesPrice()` from an archived sale. The dormant accessor is documented as a known limitation in `Sale`'s class-level Javadoc.

### 2. Realized returns card

New `RealizedReturnsCard` placed on the Portfolio tab below the "Explore Stocks" button. Displays six aggregated metrics in a 2x3 grid:

- Realisert gevinst (positive sales only)
- Realisert tap (losing sales only, shown as a positive number with the negative styling handled by the view)
- Netto realisert (gains minus losses)
- Total skatt betalt
- Total kurtasje betalt
- Antall salg

Shows an empty-state message ("Selg aksjer for å se realisert avkastning her.") when no sales have been committed.

#### Currency handling

`TransactionArchive` aggregates values per-currency, returning `Map<Currency, BigDecimal>`. `GameManager`'s facade methods (`getRealizedGainsInNok`, `getRealizedLossesInNok`, etc.) convert each currency to NOK individually using the active `CurrencyConverter` from `Exchange`, then sum the results. This keeps `Sale` storing native-currency values - it never knows about NOK conversion.

#### Card styling

`RealizedReturnsCard` extends `Card` directly rather than `WidgetCard` so its title uses `StyledText.sectionTitle()` (20px bold), matching the styling of the "Beholdning" section title above it. Earlier iterations extended `WidgetCard`, which gave the card a smaller grey widget-label header that did not align visually with the rest of the portfolio tab.

