### PR TITLE
refactor: split GameManager into GameService and read services

### DIFF
--- a/docs/SoC.md
+++ b/docs/SoC.md
@@ -7,10 +7,13 @@
 Builds the JavaFX user interface and captures user input. Reads from the model, observes state changes, and delegates user actions to controllers via callbacks. Contains no business logic and never mutates the model directly.
 
 **Controller** (`controller/`)
-Translates user input into calls on `GameManager` for actions that change game state, and reads from the model directly when only displaying or previewing data. Validates UI input and orchestrates dialogs. Contains no business logic itself.
+Translates user input into calls on `GameService` for actions that change game state, and reads from the model directly when only displaying or previewing data. Validates UI input and orchestrates dialogs. Contains no business logic itself.
 
-**GameManager** (`manager/`)
-Service Layer. Owns the game state (`Player`, `Exchange`), coordinates operations that span multiple domain objects, and notifies observers after each change. Provides controllers with a stable API for performing actions.
+**GameService** (`service/`)
+Owns the live game state (`Player`, `Exchange`), coordinates operations that span multiple domain objects, and notifies observers after each change. Provides controllers and views with a stable API for performing actions (buy, sell, advance week, save/load).
+
+**Application read services** (`service/`)
+Stateless query services — `PlayerStatsService`, `PortfolioService`, `RealizedReturnsService` — that compute derived values from `Player` and `CurrencyConverter` without holding any state themselves. Views call these directly instead of asking `GameService` to re-expose every query as a facade method.
 
 **Domain model** (`model/`)
 Holds all business logic and business rules. The domain objects own their own state and validation. Operations that do not naturally belong to a single domain object are placed in dedicated Domain Services, such as `TransactionPreviewService`, which coordinates calculations across multiple domain objects without mutating anything.
@@ -19,7 +22,7 @@ Holds all business logic and business rules. The domain objects own their own st
 Centralised creation of `Transaction` objects. Used by `Exchange` and controllers to avoid direct instantiation of concrete subclasses.
 
 **File layer** (`file/`)
-Infrastructure for reading and writing game data. Called from `GameManager` or controllers; never directly from the view or the domain.
+Infrastructure for reading and writing game data. Called from `GameService` or controllers; never directly from the view or the domain.
 
 ## Read/write access matrix
 
@@ -28,13 +31,14 @@ The following table summarises which layers may read from and write to the domai
 | Layer | Read from model? | Mutate model? |
 |---|---|---|
 | **View** | Yes (getters, derived values) | No |
-| **Controller** | Yes (getters, Domain Services such as `TransactionPreviewService`) | No (delegates to `GameManager`) |
-| **GameManager** | Yes | Yes (performs mutations and notifies observers) |
+| **Controller** | Yes (getters, Domain Services such as `TransactionPreviewService`) | No (delegates to `GameService`) |
+| **GameService** | Yes | Yes (performs mutations and notifies observers) |
+| **Application read service** | Yes | No (stateless, read-only operations) |
 | **Domain Service** | Yes | No (stateless, read-only operations) |
 | **Factory** | No (constructs new objects, does not read state) | No |
 | **File layer** | Yes (serialises domain state to disk) | Yes (deserialises saved state into the domain on load) |
 
-The rule is: **read freely, mutate via `GameManager`.** Reading derived values from the model is safe at any layer, but every state change passes through `GameManager` so observers can be notified consistently.
+The rule is: **read freely, mutate via `GameService`.** Reading derived values from the model is safe at any layer, but every state change passes through `GameService` so observers can be notified consistently.
 
 ## Details
 
@@ -49,20 +53,27 @@ The rule is: **read freely, mutate via `GameManager`.** Reading derived values f
 ### Controller
 - Receives user actions from the view through callbacks (e.g. `onBuyClick`, `onConfirm`) and decides which operation to perform
 - Validates UI input before delegating (e.g. that a quantity field is filled in and contains a valid number)
-- Reads from the model directly for any non-mutating operation (e.g. `gameManager.getPlayer().getMoney()`, `previewService.previewPurchase(...)`)
-- Calls `GameManager` for any action that changes game state (`gameManager.buy(...)`, `gameManager.sell(...)`, `gameManager.advanceWeek()`)
+- Reads from the model directly for any non-mutating operation (e.g. `gameService.getPlayer().getMoney()`, `previewService.previewPurchase(...)`)
+- Calls `GameService` for any action that changes game state (`gameService.buy(...)`, `gameService.sell(...)`, `gameService.advanceWeek()`)
 - Decides which dialog or view to show in response to a user action, and supplies it with the data it needs (e.g. opens a `BuyDialog` for the selected stock and provides a confirmation callback)
 - Surfaces errors from the model back to the view (catches domain exceptions and forwards readable messages)
 - Supplies the view with action callbacks via constructor parameters or setters
 
-### GameManager
-- Owns the live game state (`Player`, `Exchange`) and exposes it for reading
-- Performs all state-changing operations on the game (e.g. `buy(...)`, `sell(...)`, `advanceWeek(...)`, `startNewGame(...)`, `loadGame(...)`)
+### GameService
+- Owns the live game state (`Player`, `Exchange`) and exposes it for reading via `getPlayer()`, `getExchange()`, and `getCurrencyConverter()`
+- Performs all state-changing operations on the game (e.g. `buy(...)`, `sell(...)`, `advanceWeek(...)`, `createNewGame(...)`, `loadGame(...)`)
 - Coordinates operations that span multiple domain objects, ensuring they happen in the correct order (e.g. a buy involves `Exchange`, the `TransactionFactory`, the `Player`'s portfolio, and the transaction archive)
 - Notifies registered observers (`GameObserver`) after each state change, so views can react and refresh
 - Provides controllers with a stable, high-level API so that the same operation can be invoked from different parts of the UI without duplicating coordination logic
 - Delegates infrastructure work to the file layer for saving and loading game data, without exposing file handling to controllers or views
-- Holds no business rules itself; the rules live in the domain model, and `GameManager` only orchestrates calls to them
+- Holds no business rules itself; the rules live in the domain model, and `GameService` only orchestrates calls to them
+
+### Application read services
+- `PlayerStatsService` — net worth, weekly change, percent change since start, player status
+- `PortfolioService` — portfolio market value, share value and return in NOK, total return in NOK and as a percentage
+- `RealizedReturnsService` — realized gains, losses, net result, tax, commission, and sale count
+
+All three are stateless: they hold no fields and accept `Player` and `CurrencyConverter` as method parameters on every call. Views instantiate the relevant service as a field and call it from their `refreshDisplay()` / `onGameUpdated()` methods, passing `gameService.getPlayer()` and `gameService.getCurrencyConverter()`. This keeps computed-value logic out of both `GameService` (which would grow unbounded) and the views (which would contain business logic).
 
 ### Domain model
 - Represents the core concepts of the game as objects (`Player`, `Stock`, `Share`, `Portfolio`, `Exchange`, `Transaction` and its subclasses)
@@ -91,8 +102,8 @@ buyButton.setOnAction(e -> onBuyClick.accept(stock));
 ```java
 // In PortfolioController
 public void openBuyDialog(Stock stock) {
-    BuyDialog dialog = new BuyDialog(stock, gameManager.getPlayer().getMoney());
-    dialog.setOnPreview(quantity -> previewService.previewPurchase(stock, quantity, gameManager.getPlayer()));
+    BuyDialog dialog = new BuyDialog(stock, gameService.getPlayer().getMoney());
+    dialog.setOnPreview(quantity -> previewService.previewPurchase(stock, quantity, gameService.getPlayer(), gameService.getCurrencyConverter()));
     dialog.setOnConfirm(quantity -> confirmBuy(stock, quantity, dialog));
     dialog.show();
 }
@@ -108,7 +119,7 @@ The dialog's confirm handler invokes the callback the controller registered. Con
 // In PortfolioController
 private void confirmBuy(Stock stock, BigDecimal quantity, BuyDialog dialog) {
     try {
-        Transaction t = gameManager.buy(stock.getSymbol(), quantity);
+        Transaction t = gameService.buy(stock.getSymbol(), quantity);
         dialog.close();
         showReceipt(t);
     } catch (InsufficientFundsException e) {
@@ -118,10 +129,10 @@ private void confirmBuy(Stock stock, BigDecimal quantity, BuyDialog dialog) {
 ```
 
 **5. The manager performs the operation and notifies observers.**
-`GameManager.buy(...)` coordinates the actual purchase: it asks `Exchange` to create the transaction (via `TransactionFactory`), commits it on the player, and finally notifies all registered observers:
+`GameService.buy(...)` coordinates the actual purchase: it asks `Exchange` to create the transaction (via `TransactionFactory`), commits it on the player, and finally notifies all registered observers:
 
 ```java
-// In GameManager
+// In GameService
 public Transaction buy(String symbol, BigDecimal quantity) {
     Transaction t = exchange.buy(symbol, quantity, player);
     notifyObservers();

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/MainController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/MainController.java
@@ -1,6 +1,6 @@
 package edu.ntnu.idatt2003.millions.controller;
 
-import edu.ntnu.idatt2003.millions.manager.GameManager;
+import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.observer.GameObserver;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
 import edu.ntnu.idatt2003.millions.view.MainView;
@@ -15,27 +15,27 @@ import java.io.File;
 /**
  * Controller for the main view of the application.
  * Handles save, exit and advance-week actions and delegates them to
- * {@link GameManager}. Navigation between Dashboard and Exchange is
+ * {@link GameService}. Navigation between Dashboard and Exchange is
  * purely visual state and handled inside the view.
  */
 public class MainController {
 
     private final Stage stage;
     private final MainView view;
-    private final GameManager gameManager;
+    private final GameService gameService;
 
     /**
      * Constructs a new MainController and creates the main view.
      *
      * @param stage       the primary stage
-     * @param gameManager the game manager containing player and exchange
+     * @param gameService the game manager containing player and exchange
      */
-    public MainController(Stage stage, GameManager gameManager) {
+    public MainController(Stage stage, GameService gameService) {
         this.stage = stage;
-        this.gameManager = gameManager;
-        PortfolioController portfolioController = new PortfolioController(gameManager);
+        this.gameService = gameService;
+        PortfolioController portfolioController = new PortfolioController(gameService);
         this.view = new MainView(
-                gameManager,
+                gameService,
                 portfolioController,
                 this::handleSaveGame,
                 this::handleExitGame,
@@ -46,10 +46,10 @@ public class MainController {
     /**
      * Advances the game by one week.
      * Registered {@link GameObserver}s are notified automatically by
-     * {@link GameManager}.
+     * {@link GameService}.
      */
     private void handleAdvanceWeek() {
-        gameManager.advanceWeek();
+        gameService.advanceWeek();
     }
 
     /**
@@ -68,7 +68,7 @@ public class MainController {
         File file = fileChooser.showSaveDialog(stage);
 
         if (file != null) {
-            gameManager.saveGame(file);
+            gameService.saveGame(file);
             return true;
         }
         return false;

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/PortfolioController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/PortfolioController.java
@@ -56,7 +56,7 @@ public class PortfolioController {
     public TransactionPreview previewBuy(Stock stock, BigDecimal quantity) {
         return previewService.previewPurchase(
                 stock, quantity, gameService.getPlayer(),
-                gameService.getExchange().getCurrencyConverter());
+                gameService.getCurrencyConverter());
     }
 
     /**
@@ -69,7 +69,7 @@ public class PortfolioController {
     public TransactionPreview previewSell(Share share, BigDecimal quantity) {
         return previewService.previewSale(
                 share, quantity, gameService.getPlayer(),
-                gameService.getExchange().getCurrencyConverter());
+                gameService.getCurrencyConverter());
     }
 
     // Dialog opening
@@ -116,7 +116,7 @@ public class PortfolioController {
         BigDecimal balanceBefore = gameService.getPlayer().getMoney();
         TransactionPreview preview = previewService.previewPurchase(
                 stock, quantity, gameService.getPlayer(),
-                gameService.getExchange().getCurrencyConverter());
+                gameService.getCurrencyConverter());
         try {
             Transaction transaction = gameService.buy(stock.getSymbol(), quantity);
             dialog.close();
@@ -136,7 +136,7 @@ public class PortfolioController {
         BigDecimal balanceBefore = gameService.getPlayer().getMoney();
         TransactionPreview preview = previewService.previewSale(
                 share, share.getQuantity(), gameService.getPlayer(),
-                gameService.getExchange().getCurrencyConverter());
+                gameService.getCurrencyConverter());
         try {
             // TODO: when partial sale is implemented, pass quantity through.
             //  For now, the model only supports selling the full Share instance.

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/PortfolioController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/PortfolioController.java
@@ -1,6 +1,6 @@
 package edu.ntnu.idatt2003.millions.controller;
 
-import edu.ntnu.idatt2003.millions.manager.GameManager;
+import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.model.stock.Share;
 import edu.ntnu.idatt2003.millions.model.stock.Stock;
 import edu.ntnu.idatt2003.millions.model.transaction.Transaction;
@@ -14,7 +14,7 @@ import java.math.BigDecimal;
 /**
  * Controller for portfolio actions (buy, sell, sell all, view details).
  * Opens the corresponding dialogs and delegates the actual transactions
- * to the model via {@link GameManager}.
+ * to the model via {@link GameService}.
  *
  * <p>Provides read-only operations such as {@link #previewBuy(Stock, BigDecimal)}
  * and {@link #getCurrentBalance()} for views that need to display
@@ -22,16 +22,16 @@ import java.math.BigDecimal;
  */
 public class PortfolioController {
 
-    private final GameManager gameManager;
+    private final GameService gameService;
     private final TransactionPreviewService previewService;
 
     /**
      * Constructs a new PortfolioController.
      *
-     * @param gameManager the game manager containing player and exchange
+     * @param gameService the game manager containing player and exchange
      */
-    public PortfolioController(GameManager gameManager) {
-        this.gameManager = gameManager;
+    public PortfolioController(GameService gameService) {
+        this.gameService = gameService;
         this.previewService = new TransactionPreviewService();
     }
 
@@ -43,7 +43,7 @@ public class PortfolioController {
      * @return the player's available funds
      */
     public BigDecimal getCurrentBalance() {
-        return gameManager.getPlayer().getMoney();
+        return gameService.getPlayer().getMoney();
     }
 
     /**
@@ -55,8 +55,8 @@ public class PortfolioController {
      */
     public TransactionPreview previewBuy(Stock stock, BigDecimal quantity) {
         return previewService.previewPurchase(
-                stock, quantity, gameManager.getPlayer(),
-                gameManager.getExchange().getCurrencyConverter());
+                stock, quantity, gameService.getPlayer(),
+                gameService.getExchange().getCurrencyConverter());
     }
 
     /**
@@ -68,8 +68,8 @@ public class PortfolioController {
      */
     public TransactionPreview previewSell(Share share, BigDecimal quantity) {
         return previewService.previewSale(
-                share, quantity, gameManager.getPlayer(),
-                gameManager.getExchange().getCurrencyConverter());
+                share, quantity, gameService.getPlayer(),
+                gameService.getExchange().getCurrencyConverter());
     }
 
     // Dialog opening
@@ -113,14 +113,14 @@ public class PortfolioController {
     // Mutating operations
 
     private void buy(Stock stock, BigDecimal quantity, BuyDialog dialog) {
-        BigDecimal balanceBefore = gameManager.getPlayer().getMoney();
+        BigDecimal balanceBefore = gameService.getPlayer().getMoney();
         TransactionPreview preview = previewService.previewPurchase(
-                stock, quantity, gameManager.getPlayer(),
-                gameManager.getExchange().getCurrencyConverter());
+                stock, quantity, gameService.getPlayer(),
+                gameService.getExchange().getCurrencyConverter());
         try {
-            Transaction transaction = gameManager.buy(stock.getSymbol(), quantity);
+            Transaction transaction = gameService.buy(stock.getSymbol(), quantity);
             dialog.close();
-            BigDecimal balanceAfter = gameManager.getPlayer().getMoney();
+            BigDecimal balanceAfter = gameService.getPlayer().getMoney();
             Platform.runLater(() ->
                     new BuyReceipt(transaction, balanceBefore, balanceAfter, preview).show());
         } catch (Exception e) {
@@ -133,16 +133,16 @@ public class PortfolioController {
     }
 
     private void sell(Share share, BigDecimal quantity, AbstractSellDialog dialog) {
-        BigDecimal balanceBefore = gameManager.getPlayer().getMoney();
+        BigDecimal balanceBefore = gameService.getPlayer().getMoney();
         TransactionPreview preview = previewService.previewSale(
-                share, share.getQuantity(), gameManager.getPlayer(),
-                gameManager.getExchange().getCurrencyConverter());
+                share, share.getQuantity(), gameService.getPlayer(),
+                gameService.getExchange().getCurrencyConverter());
         try {
             // TODO: when partial sale is implemented, pass quantity through.
             //  For now, the model only supports selling the full Share instance.
-            Transaction transaction = gameManager.sell(share);
+            Transaction transaction = gameService.sell(share);
             dialog.close();
-            BigDecimal balanceAfter = gameManager.getPlayer().getMoney();
+            BigDecimal balanceAfter = gameService.getPlayer().getMoney();
             Platform.runLater(() ->
                     new SellReceipt(transaction, balanceBefore, balanceAfter, preview).show());
         } catch (Exception e) {

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
@@ -1,6 +1,6 @@
 package edu.ntnu.idatt2003.millions.controller;
 
-import edu.ntnu.idatt2003.millions.manager.GameManager;
+import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.view.StartScreenInputs;
 import edu.ntnu.idatt2003.millions.view.StartView;
 import java.io.File;
@@ -34,38 +34,38 @@ public class StartController {
     private final Stage stage;
     private final StartView view;
     private final StartScreenInputs inputs;
-    private final GameManager gameManager;
+    private final GameService gameService;
     private final Runnable showMainViewAction;
     private final Consumer<String> errorSink;
 
     /**
-     * Constructs a new StartController with a default {@link GameManager}.
+     * Constructs a new StartController with a default {@link GameService}.
      *
      * <p>This constructor is used by the application startup flow. It delegates
-     * to {@link #StartController(Stage, GameManager)} so alternate startup paths
+     * to {@link #StartController(Stage, GameService)} so alternate startup paths
      * can inject their own game manager.</p>
      *
      * @param stage the primary application stage
      * @throws NullPointerException if stage is null
      */
     public StartController(Stage stage) {
-        this(stage, new GameManager());
+        this(stage, new GameService());
     }
 
     /**
-     * Constructs a new StartController with the given {@link GameManager}.
+     * Constructs a new StartController with the given {@link GameService}.
      *
      * <p>Injecting the manager keeps the controller flexible while preserving
      * the normal production flow through {@link #StartController(Stage)}.
      * Event bindings are deferred to {@link #show()}.</p>
      *
      * @param stage       the primary application stage
-     * @param gameManager the game manager used to create or load game state
+     * @param gameService the game manager used to create or load game state
      * @throws NullPointerException if stage or game manager is null
      */
-    public StartController(Stage stage, GameManager gameManager) {
-        this(stage, gameManager, new StartView(),
-                () -> new MainController(stage, gameManager).show(),
+    public StartController(Stage stage, GameService gameService) {
+        this(stage, gameService, new StartView(),
+                () -> new MainController(stage, gameService).show(),
                 StartController::showAlert);
     }
 
@@ -75,19 +75,19 @@ public class StartController {
      * Event bindings are deferred to {@link #show()}.
      *
      * @param stage              the primary application stage
-     * @param gameManager        the game manager used to create or load game state
+     * @param gameService        the game manager used to create or load game state
      * @param view               the start view that exposes user input and controls
      * @param showMainViewAction the action used to navigate to the main view
      * @param errorSink          the consumer that displays user-facing error messages
      * @throws NullPointerException if any argument is null
      */
     StartController(Stage stage,
-                    GameManager gameManager,
+                    GameService gameService,
                     StartView view,
                     Runnable showMainViewAction,
                     Consumer<String> errorSink) {
         this.stage = Objects.requireNonNull(stage, "Stage cannot be null");
-        this.gameManager = Objects.requireNonNull(gameManager, "GameManager cannot be null");
+        this.gameService = Objects.requireNonNull(gameService, "GameService cannot be null");
         this.view = Objects.requireNonNull(view, "StartView cannot be null");
         this.inputs = view;
         this.showMainViewAction = Objects.requireNonNull(showMainViewAction, "Show main view action cannot be null");
@@ -102,19 +102,19 @@ public class StartController {
      * {@link #show()} and the file-chooser handlers are not safe to call
      * on instances created through this constructor.
      *
-     * @param gameManager        the game manager used to create or load game state
+     * @param gameService        the game manager used to create or load game state
      * @param inputs             the input seam the start flow reads from
      * @param showMainViewAction the action used to navigate to the main view
      * @param errorSink          the consumer that receives user-facing error messages
      * @throws NullPointerException if any argument is null
      */
-    StartController(GameManager gameManager,
+    StartController(GameService gameService,
                     StartScreenInputs inputs,
                     Runnable showMainViewAction,
                     Consumer<String> errorSink) {
         this.stage = null;
         this.view = null;
-        this.gameManager = Objects.requireNonNull(gameManager, "GameManager cannot be null");
+        this.gameService = Objects.requireNonNull(gameService, "GameService cannot be null");
         this.inputs = Objects.requireNonNull(inputs, "Inputs cannot be null");
         this.showMainViewAction = Objects.requireNonNull(showMainViewAction, "Show main view action cannot be null");
         this.errorSink = Objects.requireNonNull(errorSink, "Error sink cannot be null");
@@ -169,7 +169,7 @@ public class StartController {
     }
 
     /**
-     * Validates input, starts a new game session through {@link GameManager},
+     * Validates input, starts a new game session through {@link GameService},
      * and shows the main view. A custom stock file is optional; if none is
      * selected, the default stock data is used.
      *
@@ -183,18 +183,18 @@ public class StartController {
             String stockFilePath = inputs.getStockFilePath();
 
             if (stockFilePath.isBlank()) {
-                gameManager.createNewGame(name, parsedCapital);
+                gameService.createNewGame(name, parsedCapital);
             } else {
                 File stockFile = StartInputValidator.requireCsvFilePath(stockFilePath);
                 Currency currency = StartInputValidator.requireCurrency(inputs.getSelectedCurrency());
-                gameManager.createNewGame(name, parsedCapital, stockFile, currency);
+                gameService.createNewGame(name, parsedCapital, stockFile, currency);
             }
             showMainView();
         });
     }
 
     /**
-     * Validates input, loads an existing saved game through {@link GameManager},
+     * Validates input, loads an existing saved game through {@link GameService},
      * and shows the main view.
      *
      * <p>Package-private visibility allows controller tests in this package
@@ -204,7 +204,7 @@ public class StartController {
         runOrShowError(() -> {
             String saveFilePath = inputs.getSaveFilePath();
             File saveFile = StartInputValidator.requireFilePath(saveFilePath, "Save file must be selected");
-            gameManager.loadGame(saveFile);
+            gameService.loadGame(saveFile);
             showMainView();
         });
     }
@@ -227,7 +227,7 @@ public class StartController {
     }
 
     /**
-     * Shows the main view using the active {@link GameManager}.
+     * Shows the main view using the active {@link GameService}.
      */
     private void showMainView() {
         showMainViewAction.run();

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/game/JsonGameFileHandler.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/game/JsonGameFileHandler.java
@@ -24,7 +24,7 @@ import java.util.Objects;
  * <p>This class is pure infrastructure: it does not own domain decisions,
  * such as which {@link edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter}
  * implementation to use. Callers (typically
- * {@link edu.ntnu.idatt2003.millions.manager.GameManager}) are responsible for
+ * {@link edu.ntnu.idatt2003.millions.service.GameService}) are responsible for
  * reinitializing the loaded {@link Exchange} with a converter via
  * {@link Exchange#reinitialize} before it is used.
  */

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/player/Player.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/player/Player.java
@@ -141,7 +141,7 @@ public class Player {
 
     /**
      * Records the player's current net worth in the history.
-     * Called by {@link edu.ntnu.idatt2003.millions.manager.GameManager}
+     * Called by {@link edu.ntnu.idatt2003.millions.service.GameService}
      * before advancing the week.
      *
      * @param converter the currency converter used to compute the net worth
@@ -177,7 +177,7 @@ public class Player {
 
     /**
      * Sets the player's previous net worth.
-     * Called by {@link edu.ntnu.idatt2003.millions.manager.GameManager}
+     * Called by {@link edu.ntnu.idatt2003.millions.service.GameService}
      * before advancing the week.
      *
      * @param previousNetWorth the net worth to store

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/GameService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/GameService.java
@@ -1,4 +1,4 @@
-package edu.ntnu.idatt2003.millions.manager;
+package edu.ntnu.idatt2003.millions.service;
 
 import edu.ntnu.idatt2003.millions.file.game.GameFileHandler;
 import edu.ntnu.idatt2003.millions.file.game.GameState;
@@ -39,7 +39,7 @@ import java.util.*;
  * portfolio value) so views can read derived values without composing
  * {@link Player} and {@link Exchange} through the converter themselves.</p>
  */
-public class GameManager {
+public class GameService {
 
     private static final String DEFAULT_EXCHANGE_NAME = "MainExchange";
     private static final String DEFAULT_STOCK_RESOURCE = "/data/sp500.csv";
@@ -51,10 +51,10 @@ public class GameManager {
     private final List<GameObserver> observers = new ArrayList<>();
 
     /**
-     * Constructs a new GameManager.
+     * Constructs a new GameService.
      * Initializes the file handler for JSON serialization.
      */
-    public GameManager() {
+    public GameService() {
         this.gameFileHandler = new JsonGameFileHandler();
     }
 
@@ -171,7 +171,7 @@ public class GameManager {
      */
     private List<Stock> loadDefaultStocks() {
         StockFileHandler stockFileHandler = new CsvStockFileHandler();
-        try (InputStream inputStream = GameManager.class.getResourceAsStream(DEFAULT_STOCK_RESOURCE)) {
+        try (InputStream inputStream = GameService.class.getResourceAsStream(DEFAULT_STOCK_RESOURCE)) {
             if (inputStream == null) {
                 throw new IllegalStateException("Default stock data not found: " + DEFAULT_STOCK_RESOURCE);
             }

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/GameService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/GameService.java
@@ -9,7 +9,6 @@ import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
 import edu.ntnu.idatt2003.millions.model.currency.FixedRateCurrencyConverter;
 import edu.ntnu.idatt2003.millions.model.exchange.Exchange;
 import edu.ntnu.idatt2003.millions.model.player.Player;
-import edu.ntnu.idatt2003.millions.model.player.PlayerStatusLevel;
 import edu.ntnu.idatt2003.millions.model.stock.Share;
 import edu.ntnu.idatt2003.millions.model.stock.Stock;
 import edu.ntnu.idatt2003.millions.model.transaction.Transaction;
@@ -35,9 +34,6 @@ import java.util.*;
  * {@link Exchange} can convert to NOK through its {@link CurrencyConverter};
  * the three-argument overload defaults to USD.</p>
  *
- * <p>Also exposes facade query methods (net worth, weekly change, status,
- * portfolio value) so views can read derived values without composing
- * {@link Player} and {@link Exchange} through the converter themselves.</p>
  */
 public class GameService {
 
@@ -264,6 +260,16 @@ public class GameService {
     }
 
     /**
+     * Returns the currency converter from the active exchange.
+     * Convenience shortcut for {@code getExchange().getCurrencyConverter()}.
+     *
+     * @return the active currency converter
+     */
+    public CurrencyConverter getCurrencyConverter() {
+        return exchange.getCurrencyConverter();
+    }
+
+    /**
      * Returns the player's net worth from before the last week advance.
      * Returns null if the week has not been advanced yet.
      *
@@ -271,202 +277,6 @@ public class GameService {
      */
     public BigDecimal getPreviousNetWorth() {
         return player.getPreviousNetWorth();
-    }
-
-    /**
-     * Returns the player's current net worth in NOK.
-     * Facade method that fetches the converter from the active {@link Exchange}
-     * and delegates to {@link Player}.
-     *
-     * @return the player's net worth in NOK
-     */
-    public BigDecimal getPlayerNetWorth() {
-        return player.getNetWorth(exchange.getCurrencyConverter());
-    }
-
-    /**
-     * Returns the absolute change in the player's net worth since the start of the game,
-     * in NOK. Facade method that delegates to {@link Player}.
-     *
-     * @return current net worth minus starting money, in NOK
-     */
-    public BigDecimal getPlayerNetWorthChangeSinceStart() {
-        return player.getNetWorthChangeSinceStart(exchange.getCurrencyConverter());
-    }
-
-    /**
-     * Returns the percentage change in the player's net worth since the start of the game.
-     * Facade method that delegates to {@link Player}.
-     *
-     * @return percent change since start, e.g. 12.5 means +12.5%
-     */
-    public BigDecimal getPlayerNetWorthChangePercentSinceStart() {
-        return player.getNetWorthChangePercentSinceStart(exchange.getCurrencyConverter());
-    }
-
-    /**
-     * Returns the absolute change in the player's net worth since the previous week, in NOK.
-     * Returns null if no week has been advanced yet. Facade method that delegates to {@link Player}.
-     *
-     * @return current net worth minus previous net worth, or null if not available
-     */
-    public BigDecimal getPlayerWeeklyNetWorthChange() {
-        return player.getWeeklyNetWorthChange(exchange.getCurrencyConverter());
-    }
-
-    /**
-     * Returns the percentage change in the player's net worth since the previous week.
-     * Returns null if no week has been advanced yet. Facade method that delegates to {@link Player}.
-     *
-     * @return percent change since last week, or null if not available
-     */
-    public BigDecimal getPlayerWeeklyNetWorthChangePercent() {
-        return player.getWeeklyNetWorthChangePercent(exchange.getCurrencyConverter());
-    }
-
-    /**
-     * Returns the player's current status level. Facade method that delegates to
-     * {@link Player#getStatus(CurrencyConverter)}.
-     *
-     * @return the player's status level
-     */
-    public PlayerStatusLevel getPlayerStatus() {
-        return player.getStatus(exchange.getCurrencyConverter());
-    }
-
-    /**
-     * Returns the total market value of the player's portfolio in NOK
-     * ({@code salesPrice × quantity} per share, converted to NOK).
-     * Sale commission and tax are not deducted.
-     * Facade method that delegates to {@link Player}.
-     *
-     * @return the portfolio market value in NOK
-     */
-    public BigDecimal getPortfolioValue() {
-        return player.getPortfolio().getNetWorth(exchange.getCurrencyConverter());
-    }
-
-    /**
-     * Returns the current market value of the given share position in NOK
-     * (salesPrice × quantity × exchange rate, no fees deducted).
-     *
-     * @param share the share to value
-     * @return the position's market value in NOK
-     */
-    public BigDecimal getShareValueInNok(Share share) {
-        CurrencyConverter converter = exchange.getCurrencyConverter();
-        return converter.convert(
-                share.getCurrentValue(), share.getStock().getCurrency(), Currency.getInstance("NOK"));
-    }
-
-    /**
-     * Returns the unrealized return on the given share position in NOK
-     * (currentValue − cost, converted to NOK at the current rate).
-     *
-     * @param share the share to evaluate
-     * @return the position's return in NOK
-     */
-    public BigDecimal getShareReturnInNok(Share share) {
-        CurrencyConverter converter = exchange.getCurrencyConverter();
-        return converter.convert(
-                share.getReturnNative(), share.getStock().getCurrency(), Currency.getInstance("NOK"));
-    }
-
-    /**
-     * Returns the total market value of all portfolio positions in NOK
-     * (no fees deducted). Used for the holdings table "Verdi NOK" total.
-     *
-     * @return total market value in NOK
-     */
-    public BigDecimal getTotalPortfolioValueInNok() {
-        return player.getPortfolio().getNetWorth(exchange.getCurrencyConverter());
-    }
-
-    /**
-     * Returns the total unrealized return across all portfolio positions in NOK.
-     *
-     * @return total return in NOK
-     */
-    public BigDecimal getTotalPortfolioReturnInNok() {
-        return player.getPortfolio().getTotalReturnInNok(exchange.getCurrencyConverter());
-    }
-
-    /**
-     * Returns the total portfolio return as a percentage of total cost,
-     * with all amounts converted to NOK before computing the ratio.
-     *
-     * @return total return percentage
-     */
-    public BigDecimal getTotalPortfolioReturnPercent() {
-        return player.getPortfolio().getTotalReturnPercent(exchange.getCurrencyConverter());
-    }
-
-    /**
-     * Returns the total realized gain across all profitable sales, converted to NOK.
-     *
-     * @return total realized gain in NOK; zero if no profitable sales exist
-     */
-    public BigDecimal getRealizedGainsInNok() {
-        return sumByCurrencyToNok(player.getTransactionArchive().getRealizedGainsByCurrency());
-    }
-
-    /**
-     * Returns the total realized loss across all losing sales, converted to NOK.
-     * The value is non-negative — losses are returned as a positive number for
-     * display purposes; the negative sign is applied by the view.
-     *
-     * @return total realized loss in NOK as a non-negative value
-     */
-    public BigDecimal getRealizedLossesInNok() {
-        return sumByCurrencyToNok(player.getTransactionArchive().getRealizedLossesByCurrency());
-    }
-
-    /**
-     * Returns the net realized result: realized gains minus realized losses,
-     * in NOK. Can be negative if losses exceed gains.
-     *
-     * @return net realized result in NOK
-     */
-    public BigDecimal getNetRealizedInNok() {
-        return getRealizedGainsInNok().subtract(getRealizedLossesInNok());
-    }
-
-    /**
-     * Returns the total tax paid across all sales, converted to NOK.
-     *
-     * @return total tax paid in NOK; zero if no sales exist
-     */
-    public BigDecimal getTotalTaxPaidInNok() {
-        return sumByCurrencyToNok(player.getTransactionArchive().getTotalSaleTaxByCurrency());
-    }
-
-    /**
-     * Returns the total commission paid across all sales, converted to NOK.
-     *
-     * @return total commission paid in NOK; zero if no sales exist
-     */
-    public BigDecimal getTotalSaleCommissionInNok() {
-        return sumByCurrencyToNok(player.getTransactionArchive().getTotalSaleCommissionByCurrency());
-    }
-
-    /**
-     * Returns the total number of completed sales.
-     *
-     * @return the number of sales
-     */
-    public int getSalesCount() {
-        return player.getTransactionArchive().getSalesCount();
-    }
-
-    /**
-     * Converts a per-currency map of amounts into a single sum in NOK.
-     */
-    private BigDecimal sumByCurrencyToNok(Map<Currency, BigDecimal> amountsByCurrency) {
-        CurrencyConverter converter = exchange.getCurrencyConverter();
-        Currency nok = Currency.getInstance("NOK");
-        return amountsByCurrency.entrySet().stream()
-                .map(entry -> converter.convert(entry.getValue(), entry.getKey(), nok))
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/PlayerStatsService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/PlayerStatsService.java
@@ -1,0 +1,51 @@
+package edu.ntnu.idatt2003.millions.service;
+
+import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
+import edu.ntnu.idatt2003.millions.model.player.Player;
+import edu.ntnu.idatt2003.millions.model.player.PlayerStatusLevel;
+
+import java.math.BigDecimal;
+
+/**
+ * Stateless read service for player net-worth and status queries.
+ * All methods accept {@link Player} and {@link CurrencyConverter} as parameters
+ * so this service holds no state and can be shared freely.
+ */
+public class PlayerStatsService {
+
+    /** Returns the player's current net worth in NOK. */
+    public BigDecimal getNetWorth(Player player, CurrencyConverter converter) {
+        return player.getNetWorth(converter);
+    }
+
+    /** Returns the absolute change in net worth since the start of the game, in NOK. */
+    public BigDecimal getNetWorthChangeSinceStart(Player player, CurrencyConverter converter) {
+        return player.getNetWorthChangeSinceStart(converter);
+    }
+
+    /** Returns the percentage change in net worth since the start of the game. */
+    public BigDecimal getNetWorthChangePercentSinceStart(Player player, CurrencyConverter converter) {
+        return player.getNetWorthChangePercentSinceStart(converter);
+    }
+
+    /**
+     * Returns the absolute change in net worth since the previous week, in NOK.
+     * Returns null if no week has been advanced yet.
+     */
+    public BigDecimal getWeeklyNetWorthChange(Player player, CurrencyConverter converter) {
+        return player.getWeeklyNetWorthChange(converter);
+    }
+
+    /**
+     * Returns the percentage change in net worth since the previous week.
+     * Returns null if no week has been advanced yet.
+     */
+    public BigDecimal getWeeklyNetWorthChangePercent(Player player, CurrencyConverter converter) {
+        return player.getWeeklyNetWorthChangePercent(converter);
+    }
+
+    /** Returns the player's current status level. */
+    public PlayerStatusLevel getStatus(Player player, CurrencyConverter converter) {
+        return player.getStatus(converter);
+    }
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/PortfolioService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/PortfolioService.java
@@ -1,0 +1,51 @@
+package edu.ntnu.idatt2003.millions.service;
+
+import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
+import edu.ntnu.idatt2003.millions.model.player.Player;
+import edu.ntnu.idatt2003.millions.model.stock.Share;
+
+import java.math.BigDecimal;
+import java.util.Currency;
+
+/**
+ * Stateless read service for portfolio value queries.
+ * All methods accept domain objects as parameters so this service holds no state.
+ */
+public class PortfolioService {
+
+    private static final Currency NOK = Currency.getInstance("NOK");
+
+    /**
+     * Returns the total market value of the player's portfolio in NOK
+     * ({@code salesPrice × quantity} per share, converted to NOK, no fees deducted).
+     */
+    public BigDecimal getValue(Player player, CurrencyConverter converter) {
+        return player.getPortfolio().getNetWorth(converter);
+    }
+
+    /**
+     * Returns the current market value of a share position in NOK
+     * (salesPrice × quantity × exchange rate, no fees deducted).
+     */
+    public BigDecimal getShareValueInNok(Share share, CurrencyConverter converter) {
+        return converter.convert(share.getCurrentValue(), share.getStock().getCurrency(), NOK);
+    }
+
+    /**
+     * Returns the unrealized return on a share position in NOK
+     * (currentValue − cost, converted to NOK at the current rate).
+     */
+    public BigDecimal getShareReturnInNok(Share share, CurrencyConverter converter) {
+        return converter.convert(share.getReturnNative(), share.getStock().getCurrency(), NOK);
+    }
+
+    /** Returns the total unrealized return across all portfolio positions in NOK. */
+    public BigDecimal getTotalReturnInNok(Player player, CurrencyConverter converter) {
+        return player.getPortfolio().getTotalReturnInNok(converter);
+    }
+
+    /** Returns the total portfolio return as a percentage of total cost in NOK. */
+    public BigDecimal getTotalReturnPercent(Player player, CurrencyConverter converter) {
+        return player.getPortfolio().getTotalReturnPercent(converter);
+    }
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/RealizedReturnsService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/RealizedReturnsService.java
@@ -1,0 +1,65 @@
+package edu.ntnu.idatt2003.millions.service;
+
+import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
+import edu.ntnu.idatt2003.millions.model.player.Player;
+
+import java.math.BigDecimal;
+import java.util.Currency;
+import java.util.Map;
+
+/**
+ * Stateless read service for realized-return queries (gains, losses, tax, commission).
+ * All methods accept domain objects as parameters so this service holds no state.
+ */
+public class RealizedReturnsService {
+
+    private static final Currency NOK = Currency.getInstance("NOK");
+
+    /**
+     * Returns the total realized gain across all profitable sales, converted to NOK.
+     *
+     * @return total realized gain in NOK; zero if no profitable sales exist
+     */
+    public BigDecimal getGainsInNok(Player player, CurrencyConverter converter) {
+        return sumToNok(player.getTransactionArchive().getRealizedGainsByCurrency(), converter);
+    }
+
+    /**
+     * Returns the total realized loss across all losing sales, converted to NOK.
+     * The value is non-negative — losses are returned as a positive number for display purposes.
+     *
+     * @return total realized loss in NOK as a non-negative value
+     */
+    public BigDecimal getLossesInNok(Player player, CurrencyConverter converter) {
+        return sumToNok(player.getTransactionArchive().getRealizedLossesByCurrency(), converter);
+    }
+
+    /**
+     * Returns the net realized result: gains minus losses, in NOK.
+     * Can be negative if losses exceed gains.
+     */
+    public BigDecimal getNetRealizedInNok(Player player, CurrencyConverter converter) {
+        return getGainsInNok(player, converter).subtract(getLossesInNok(player, converter));
+    }
+
+    /** Returns the total tax paid across all sales, converted to NOK. */
+    public BigDecimal getTotalTaxPaidInNok(Player player, CurrencyConverter converter) {
+        return sumToNok(player.getTransactionArchive().getTotalSaleTaxByCurrency(), converter);
+    }
+
+    /** Returns the total commission paid across all sales, converted to NOK. */
+    public BigDecimal getTotalSaleCommissionInNok(Player player, CurrencyConverter converter) {
+        return sumToNok(player.getTransactionArchive().getTotalSaleCommissionByCurrency(), converter);
+    }
+
+    /** Returns the total number of completed sales. */
+    public int getSalesCount(Player player) {
+        return player.getTransactionArchive().getSalesCount();
+    }
+
+    private BigDecimal sumToNok(Map<Currency, BigDecimal> amounts, CurrencyConverter converter) {
+        return amounts.entrySet().stream()
+                .map(e -> converter.convert(e.getValue(), e.getKey(), NOK))
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/util/CurrencyFormatter.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/util/CurrencyFormatter.java
@@ -9,7 +9,7 @@ import java.util.Objects;
  * Utility class for formatting monetary values.
  *
  * <p>All amounts are formatted in NOK, since portfolio values and net worth
- * are converted to NOK by {@code GameManager} before being passed in.
+ * are converted to NOK by {@code GameService} before being passed in.
  * Language-based display currency is tracked separately.
  */
 public class CurrencyFormatter {

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/MainView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/MainView.java
@@ -1,7 +1,7 @@
 package edu.ntnu.idatt2003.millions.view;
 
 import edu.ntnu.idatt2003.millions.controller.PortfolioController;
-import edu.ntnu.idatt2003.millions.manager.GameManager;
+import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.view.component.Header;
 import edu.ntnu.idatt2003.millions.view.component.WeekBar;
 import edu.ntnu.idatt2003.millions.view.dashboard.DashboardView;
@@ -21,7 +21,7 @@ import javafx.scene.layout.BorderPane;
  */
 public class MainView {
 
-    private final GameManager gameManager;
+    private final GameService gameService;
     private final PortfolioController portfolioController;
     private final BorderPane root;
     private final Header header;
@@ -30,19 +30,19 @@ public class MainView {
     /**
      * Constructs a new MainView with a header and dashboard as the default content.
      *
-     * @param gameManager    the game manager containing player and exchange
+     * @param gameService    the game manager containing player and exchange
      * @param onSaveGame     callback invoked when the user clicks "Save game"
      * @param onExitGame     callback invoked when the user clicks "Exit game"
      * @param onAdvanceWeek  callback invoked when the user clicks "Advance week"
      */
-    public MainView(GameManager gameManager,
+    public MainView(GameService gameService,
                     PortfolioController portfolioController,
                     Runnable onSaveGame,
                     Runnable onExitGame,
                     Runnable onAdvanceWeek) {
-        this.gameManager = gameManager;
+        this.gameService = gameService;
         this.portfolioController = portfolioController;
-        this.weekBar = new WeekBar(gameManager, onAdvanceWeek);
+        this.weekBar = new WeekBar(gameService, onAdvanceWeek);
         this.header = new Header(
                 this::showDashboard,
                 this::showExchange,
@@ -68,18 +68,18 @@ public class MainView {
      */
     private void showDashboard() {
         root.setCenter(wrapScrollable(
-                new DashboardView(gameManager, portfolioController, weekBar, this::showExchangeOnStocksTab)));
+                new DashboardView(gameService, portfolioController, weekBar, this::showExchangeOnStocksTab)));
     }
 
     /**
      * Switches the content area to the exchange view.
      */
     private void showExchange() {
-        root.setCenter(wrapScrollable(new ExchangeView(gameManager, weekBar)));
+        root.setCenter(wrapScrollable(new ExchangeView(gameService, weekBar)));
     }
 
     private void showExchangeOnStocksTab() {
-        ExchangeView exchangeView = new ExchangeView(gameManager, weekBar);
+        ExchangeView exchangeView = new ExchangeView(gameService, weekBar);
         exchangeView.selectStocksTab();
         root.setCenter(wrapScrollable(exchangeView));
     }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/StartView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/StartView.java
@@ -349,7 +349,7 @@ public class StartView implements StartScreenInputs {
     /**
      * Returns the currency currently selected in the currency selector.
      * Used when uploading custom stock data so the controller can pass the
-     * chosen currency to the {@code GameManager}.
+     * chosen currency to the {@code GameService}.
      *
      * @return the selected currency, or {@code null} if none is selected
      */

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/Card.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/Card.java
@@ -1,6 +1,6 @@
 package edu.ntnu.idatt2003.millions.view.component;
 
-import edu.ntnu.idatt2003.millions.manager.GameManager;
+import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.observer.GameObserver;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
 import javafx.scene.layout.VBox;
@@ -15,11 +15,11 @@ public abstract class Card extends VBox implements GameObserver {
     /**
      * Constructs a new Card and registers itself as a game observer.
      *
-     * @param gameManager the game manager to observe
+     * @param gameService the game manager to observe
      */
-    protected Card(GameManager gameManager) {
+    protected Card(GameService gameService) {
         getStyleClass().add("card");
-        gameManager.addObserver(this);
+        gameService.addObserver(this);
         LanguageManager.addObserver(this::onLanguageChanged);
     }
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/WeekBar.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/WeekBar.java
@@ -1,6 +1,6 @@
 package edu.ntnu.idatt2003.millions.view.component;
 
-import edu.ntnu.idatt2003.millions.manager.GameManager;
+import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.observer.GameObserver;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
 import javafx.geometry.Pos;
@@ -14,25 +14,25 @@ import javafx.scene.layout.HBox;
  */
 public class WeekBar extends HBox implements GameObserver {
 
-    private final GameManager gameManager;
+    private final GameService gameService;
     private final StyledText weekLabel;
     private final Button advanceButton;
 
     /**
      * Constructs a new WeekBar and registers itself as a game observer.
      *
-     * @param gameManager    the game manager to observe
+     * @param gameService    the game manager to observe
      * @param onAdvanceWeek  callback invoked when the user clicks "Advance week"
      */
-    public WeekBar(GameManager gameManager, Runnable onAdvanceWeek) {
-        this.gameManager = gameManager;
-        gameManager.addObserver(this);
+    public WeekBar(GameService gameService, Runnable onAdvanceWeek) {
+        this.gameService = gameService;
+        gameService.addObserver(this);
 
         setSpacing(24);
         setAlignment(Pos.CENTER_RIGHT);
 
         weekLabel = StyledText.weekLabel(LanguageManager.get("app.week") + " "
-                + gameManager.getExchange().getWeek());
+                + gameService.getExchange().getWeek());
 
         advanceButton = new Button(LanguageManager.get("app.advanceWeek"));
         advanceButton.getStyleClass().add("advance-button");
@@ -50,7 +50,7 @@ public class WeekBar extends HBox implements GameObserver {
     private void onLanguageChanged() {
         advanceButton.setText(LanguageManager.get("app.advanceWeek"));
         weekLabel.setText(LanguageManager.get("app.week") + " "
-                + gameManager.getExchange().getWeek());
+                + gameService.getExchange().getWeek());
     }
 
     /**
@@ -59,6 +59,6 @@ public class WeekBar extends HBox implements GameObserver {
     @Override
     public void onGameUpdated() {
         weekLabel.setText(LanguageManager.get("app.week") + " "
-                + gameManager.getExchange().getWeek());
+                + gameService.getExchange().getWeek());
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/WidgetCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/WidgetCard.java
@@ -1,6 +1,6 @@
 package edu.ntnu.idatt2003.millions.view.component;
 
-import edu.ntnu.idatt2003.millions.manager.GameManager;
+import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
 
 /**
@@ -13,8 +13,8 @@ public abstract class WidgetCard extends Card {
     private final String titleKey;
     protected final StyledText titleLabel = StyledText.widgetLabel();
 
-    protected WidgetCard(GameManager gameManager, String titleKey) {
-        super(gameManager);
+    protected WidgetCard(GameService gameService, String titleKey) {
+        super(gameService);
         this.titleKey = titleKey;
         setSpacing(4);
         titleLabel.setText(LanguageManager.get(titleKey));

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/DashboardView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/DashboardView.java
@@ -1,7 +1,7 @@
 package edu.ntnu.idatt2003.millions.view.dashboard;
 
 import edu.ntnu.idatt2003.millions.controller.PortfolioController;
-import edu.ntnu.idatt2003.millions.manager.GameManager;
+import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.view.component.ViewHeader;
 import edu.ntnu.idatt2003.millions.view.component.WeekBar;
 import edu.ntnu.idatt2003.millions.view.dashboard.portfolio.PortfolioView;
@@ -18,7 +18,7 @@ import java.util.List;
  */
 public class DashboardView extends VBox {
 
-    private final GameManager gameManager;
+    private final GameService gameService;
     private final PortfolioController portfolioController;
     private final Runnable onExploreStocks;
     private final VBox contentArea;
@@ -26,14 +26,14 @@ public class DashboardView extends VBox {
     /**
      * Constructs a new DashboardView with a tab bar.
      *
-     * @param gameManager the game manager containing player and exchange
+     * @param gameService the game manager containing player and exchange
      * @param weekBar     the week bar shared with the rest of the application
      */
-    public DashboardView(GameManager gameManager,
+    public DashboardView(GameService gameService,
                          PortfolioController portfolioController,
                          WeekBar weekBar,
                          Runnable onExploreStocks) {
-        this.gameManager = gameManager;
+        this.gameService = gameService;
         this.portfolioController = portfolioController;
         this.onExploreStocks = onExploreStocks;
         getStyleClass().add("content-area");
@@ -63,21 +63,21 @@ public class DashboardView extends VBox {
 
     private void showPortfolio() {
         contentArea.getChildren().setAll(
-                new PortfolioView(gameManager, portfolioController, onExploreStocks));
+                new PortfolioView(gameService, portfolioController, onExploreStocks));
     }
 
     private void showTransactions() {
         contentArea.getChildren().clear(); // remove this when implementing setAll
-        // contentArea.getChildren().setAll(new TransactionsView(gameManager));
+        // contentArea.getChildren().setAll(new TransactionsView(gameService));
     }
 
     private void showWatchlist() {
         contentArea.getChildren().clear(); // remove this when implementing setAll
-        // contentArea.getChildren().setAll(new WatchlistView(gameManager));
+        // contentArea.getChildren().setAll(new WatchlistView(gameService));
     }
 
     private void showLoans() {
         contentArea.getChildren().clear(); // remove this when implementing setAll
-        // contentArea.getChildren().setAll(new LoansView(gameManager));
+        // contentArea.getChildren().setAll(new LoansView(gameService));
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/PortfolioView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/PortfolioView.java
@@ -1,7 +1,7 @@
 package edu.ntnu.idatt2003.millions.view.dashboard.portfolio;
 
 import edu.ntnu.idatt2003.millions.controller.PortfolioController;
-import edu.ntnu.idatt2003.millions.manager.GameManager;
+import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card.*;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
@@ -14,28 +14,28 @@ import javafx.scene.layout.VBox;
  */
 public class PortfolioView extends VBox {
 
-    private final GameManager gameManager;
+    private final GameService gameService;
     private final PortfolioController controller;
     private final Runnable onExploreStocks;
 
     /**
      * Constructs a new PortfolioView.
      *
-     * @param gameManager the game manager containing player and exchange
+     * @param gameService the game manager containing player and exchange
      * @param controller  the controller handling portfolio actions
      */
-    public PortfolioView(GameManager gameManager,
+    public PortfolioView(GameService gameService,
                          PortfolioController controller,
                          Runnable onExploreStocks) {
-        this.gameManager = gameManager;
+        this.gameService = gameService;
         this.controller = controller;
         this.onExploreStocks = onExploreStocks;
         setSpacing(16);
 
         HBox topRow = buildTopRow();
-        HoldingsCard holdingsCard = new HoldingsCard(gameManager, controller);
+        HoldingsCard holdingsCard = new HoldingsCard(gameService, controller);
         ExploreStocksButton exploreButton = new ExploreStocksButton(onExploreStocks);
-        RealizedReturnsCard realizedReturnsCard = new RealizedReturnsCard(gameManager);
+        RealizedReturnsCard realizedReturnsCard = new RealizedReturnsCard(gameService);
 
         getChildren().addAll(topRow, holdingsCard, exploreButton, realizedReturnsCard);
     }
@@ -43,14 +43,14 @@ public class PortfolioView extends VBox {
     private HBox buildTopRow() {
         HBox row = new HBox(16);
 
-        NetWorthCard netWorthCard = new NetWorthCard(gameManager);
+        NetWorthCard netWorthCard = new NetWorthCard(gameService);
         HBox.setHgrow(netWorthCard, Priority.ALWAYS);
 
         VBox rightCards = new VBox(12,
-                new WeeklyChangeCard(gameManager),
-                new AvailableFundsCard(gameManager),
-                new PortfolioValueCard(gameManager),
-                new StatusCard(gameManager)
+                new WeeklyChangeCard(gameService),
+                new AvailableFundsCard(gameService),
+                new PortfolioValueCard(gameService),
+                new StatusCard(gameService)
         );
         rightCards.setMinWidth(220);
         rightCards.setMaxWidth(260);

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/AvailableFundsCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/AvailableFundsCard.java
@@ -1,6 +1,6 @@
 package edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card;
 
-import edu.ntnu.idatt2003.millions.manager.GameManager;
+import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.util.CurrencyFormatter;
 import edu.ntnu.idatt2003.millions.view.component.StyledText;
 import edu.ntnu.idatt2003.millions.view.component.WidgetCard;
@@ -10,18 +10,18 @@ import edu.ntnu.idatt2003.millions.view.component.WidgetCard;
  */
 public class AvailableFundsCard extends WidgetCard {
 
-    private final GameManager gameManager;
+    private final GameService gameService;
     private final StyledText valueLabel = StyledText.widgetValue();
 
-    public AvailableFundsCard(GameManager gameManager) {
-        super(gameManager, "dashboard.availableFunds");
-        this.gameManager = gameManager;
+    public AvailableFundsCard(GameService gameService) {
+        super(gameService, "dashboard.availableFunds");
+        this.gameService = gameService;
         getChildren().addAll(titleLabel, valueLabel);
         refreshDisplay();
     }
 
     @Override
     protected void refreshDisplay() {
-        valueLabel.setText(CurrencyFormatter.format(gameManager.getPlayer().getMoney()));
+        valueLabel.setText(CurrencyFormatter.format(gameService.getPlayer().getMoney()));
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/HoldingsCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/HoldingsCard.java
@@ -2,6 +2,7 @@ package edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card;
 
 import edu.ntnu.idatt2003.millions.controller.PortfolioController;
 import edu.ntnu.idatt2003.millions.service.GameService;
+import edu.ntnu.idatt2003.millions.service.PortfolioService;
 import edu.ntnu.idatt2003.millions.model.player.Portfolio;
 import edu.ntnu.idatt2003.millions.model.stock.Share;
 import edu.ntnu.idatt2003.millions.model.stock.Stock;
@@ -44,6 +45,7 @@ public class HoldingsCard extends Card {
     }
 
     private final GameService gameService;
+    private final PortfolioService portfolioService = new PortfolioService();
     private final PortfolioController controller;
     private final GridPane grid = new GridPane();
 
@@ -152,9 +154,9 @@ public class HoldingsCard extends Card {
         grid.add(cell(stock.getSymbol() + ", " + stock.getCompany()), 1, row);
         grid.add(cell(NUMBER_FORMAT.format(share.getQuantity())), 2, row);
         grid.add(coloredPercentCell(stock.getWeeklyChangePercent()), 3, row);
-        grid.add(cell(NUMBER_FORMAT.format(gameService.getShareValueInNok(share))), 4, row);
+        grid.add(cell(NUMBER_FORMAT.format(portfolioService.getShareValueInNok(share, gameService.getCurrencyConverter()))), 4, row);
         grid.add(coloredPercentCell(share.getReturnPercent()), 5, row);
-        grid.add(coloredAmountCell(gameService.getShareReturnInNok(share)), 6, row);
+        grid.add(coloredAmountCell(portfolioService.getShareReturnInNok(share, gameService.getCurrencyConverter())), 6, row);
         grid.add(buildDetailsButton(share), 7, row);
     }
 
@@ -170,12 +172,12 @@ public class HoldingsCard extends Card {
         totalLabel.getStyleClass().addAll("holdings-cell", "bold");
         grid.add(totalLabel, 1, dataRow);
 
-        Label valueNok = new Label(NUMBER_FORMAT.format(gameService.getTotalPortfolioValueInNok()));
+        Label valueNok = new Label(NUMBER_FORMAT.format(portfolioService.getValue(gameService.getPlayer(), gameService.getCurrencyConverter())));
         valueNok.getStyleClass().addAll("holdings-cell", "bold");
         grid.add(valueNok, 4, dataRow);
 
-        grid.add(coloredPercentCell(gameService.getTotalPortfolioReturnPercent()), 5, dataRow);
-        grid.add(coloredAmountCell(gameService.getTotalPortfolioReturnInNok()), 6, dataRow);
+        grid.add(coloredPercentCell(portfolioService.getTotalReturnPercent(gameService.getPlayer(), gameService.getCurrencyConverter())), 5, dataRow);
+        grid.add(coloredAmountCell(portfolioService.getTotalReturnInNok(gameService.getPlayer(), gameService.getCurrencyConverter())), 6, dataRow);
     }
 
     private HBox buildActionButtons(Share share) {

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/HoldingsCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/HoldingsCard.java
@@ -1,7 +1,7 @@
 package edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card;
 
 import edu.ntnu.idatt2003.millions.controller.PortfolioController;
-import edu.ntnu.idatt2003.millions.manager.GameManager;
+import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.model.player.Portfolio;
 import edu.ntnu.idatt2003.millions.model.stock.Share;
 import edu.ntnu.idatt2003.millions.model.stock.Stock;
@@ -43,19 +43,19 @@ public class HoldingsCard extends Card {
         PERCENT_FORMAT = new DecimalFormat("+#,##0.0;-#,##0.0", symbols);
     }
 
-    private final GameManager gameManager;
+    private final GameService gameService;
     private final PortfolioController controller;
     private final GridPane grid = new GridPane();
 
     /**
      * Constructs a new HoldingsCard.
      *
-     * @param gameManager the game manager containing player and exchange
+     * @param gameService the game manager containing player and exchange
      * @param controller the controller handling portfolio actions
      */
-    public HoldingsCard(GameManager gameManager, PortfolioController controller) {
-        super(gameManager);
-        this.gameManager = gameManager;
+    public HoldingsCard(GameService gameService, PortfolioController controller) {
+        super(gameService);
+        this.gameService = gameService;
         this.controller = controller;
 
         StyledText title = StyledText.sectionTitle(LanguageManager.get("dashboard.portfolio.title"));
@@ -106,7 +106,7 @@ public class HoldingsCard extends Card {
     private void refresh() {
         grid.getChildren().clear();
 
-        Portfolio portfolio = gameManager.getPlayer().getPortfolio();
+        Portfolio portfolio = gameService.getPlayer().getPortfolio();
         List<Share> shares = portfolio.getShares();
 
         addHeaderRow();
@@ -152,9 +152,9 @@ public class HoldingsCard extends Card {
         grid.add(cell(stock.getSymbol() + ", " + stock.getCompany()), 1, row);
         grid.add(cell(NUMBER_FORMAT.format(share.getQuantity())), 2, row);
         grid.add(coloredPercentCell(stock.getWeeklyChangePercent()), 3, row);
-        grid.add(cell(NUMBER_FORMAT.format(gameManager.getShareValueInNok(share))), 4, row);
+        grid.add(cell(NUMBER_FORMAT.format(gameService.getShareValueInNok(share))), 4, row);
         grid.add(coloredPercentCell(share.getReturnPercent()), 5, row);
-        grid.add(coloredAmountCell(gameManager.getShareReturnInNok(share)), 6, row);
+        grid.add(coloredAmountCell(gameService.getShareReturnInNok(share)), 6, row);
         grid.add(buildDetailsButton(share), 7, row);
     }
 
@@ -170,12 +170,12 @@ public class HoldingsCard extends Card {
         totalLabel.getStyleClass().addAll("holdings-cell", "bold");
         grid.add(totalLabel, 1, dataRow);
 
-        Label valueNok = new Label(NUMBER_FORMAT.format(gameManager.getTotalPortfolioValueInNok()));
+        Label valueNok = new Label(NUMBER_FORMAT.format(gameService.getTotalPortfolioValueInNok()));
         valueNok.getStyleClass().addAll("holdings-cell", "bold");
         grid.add(valueNok, 4, dataRow);
 
-        grid.add(coloredPercentCell(gameManager.getTotalPortfolioReturnPercent()), 5, dataRow);
-        grid.add(coloredAmountCell(gameManager.getTotalPortfolioReturnInNok()), 6, dataRow);
+        grid.add(coloredPercentCell(gameService.getTotalPortfolioReturnPercent()), 5, dataRow);
+        grid.add(coloredAmountCell(gameService.getTotalPortfolioReturnInNok()), 6, dataRow);
     }
 
     private HBox buildActionButtons(Share share) {

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/NetWorthCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/NetWorthCard.java
@@ -1,6 +1,7 @@
 package edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card;
 
 import edu.ntnu.idatt2003.millions.service.GameService;
+import edu.ntnu.idatt2003.millions.service.PlayerStatsService;
 import edu.ntnu.idatt2003.millions.util.CurrencyFormatter;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
 import edu.ntnu.idatt2003.millions.view.component.StyledText;
@@ -22,6 +23,7 @@ import java.util.Locale;
 public class NetWorthCard extends WidgetCard {
 
     private final GameService gameService;
+    private final PlayerStatsService statsService = new PlayerStatsService();
     private final StyledText netWorthLabel = StyledText.widgetValue();
     private final StyledText changeLabel = StyledText.widgetChange();
     private final NumberAxis xAxis;
@@ -84,9 +86,9 @@ public class NetWorthCard extends WidgetCard {
      */
     @Override
     protected void refreshDisplay() {
-        BigDecimal netWorth = gameService.getPlayerNetWorth();
-        BigDecimal change = gameService.getPlayerNetWorthChangeSinceStart();
-        BigDecimal percentChange = gameService.getPlayerNetWorthChangePercentSinceStart();
+        BigDecimal netWorth = statsService.getNetWorth(gameService.getPlayer(), gameService.getCurrencyConverter());
+        BigDecimal change = statsService.getNetWorthChangeSinceStart(gameService.getPlayer(), gameService.getCurrencyConverter());
+        BigDecimal percentChange = statsService.getNetWorthChangePercentSinceStart(gameService.getPlayer(), gameService.getCurrencyConverter());
 
         String sign = change.compareTo(BigDecimal.ZERO) >= 0 ? "+" : "";
         String formattedPercent = String.format(Locale.of("no"), "%.1f", percentChange);
@@ -111,7 +113,7 @@ public class NetWorthCard extends WidgetCard {
     @Override
     public void onGameUpdated() {
         int nextPoint = series.getData().size() + 1;
-        double netWorth = gameService.getPlayerNetWorth().doubleValue();
+        double netWorth = statsService.getNetWorth(gameService.getPlayer(), gameService.getCurrencyConverter()).doubleValue();
         series.getData().add(new XYChart.Data<>(nextPoint, netWorth));
         xAxis.setUpperBound(nextPoint);
         xAxis.setTickUnit(Math.max(1, nextPoint / 8));

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/NetWorthCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/NetWorthCard.java
@@ -1,6 +1,6 @@
 package edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card;
 
-import edu.ntnu.idatt2003.millions.manager.GameManager;
+import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.util.CurrencyFormatter;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
 import edu.ntnu.idatt2003.millions.view.component.StyledText;
@@ -21,17 +21,17 @@ import java.util.Locale;
  */
 public class NetWorthCard extends WidgetCard {
 
-    private final GameManager gameManager;
+    private final GameService gameService;
     private final StyledText netWorthLabel = StyledText.widgetValue();
     private final StyledText changeLabel = StyledText.widgetChange();
     private final NumberAxis xAxis;
     private final XYChart.Series<Number, Number> series;
 
-    public NetWorthCard(GameManager gameManager) {
-        super(gameManager, "dashboard.netWorth");
-        this.gameManager = gameManager;
+    public NetWorthCard(GameService gameService) {
+        super(gameService, "dashboard.netWorth");
+        this.gameService = gameService;
 
-        List<BigDecimal> history = gameManager.getPlayer().getNetWorthHistory();
+        List<BigDecimal> history = gameService.getPlayer().getNetWorthHistory();
         int historySize = history.size();
 
         xAxis = new NumberAxis(1, Math.max(historySize, 1), Math.max(1, historySize / 8));
@@ -72,7 +72,7 @@ public class NetWorthCard extends WidgetCard {
     }
 
     private void loadHistory() {
-        List<BigDecimal> history = gameManager.getPlayer().getNetWorthHistory();
+        List<BigDecimal> history = gameService.getPlayer().getNetWorthHistory();
         for (int i = 0; i < history.size(); i++) {
             series.getData().add(new XYChart.Data<>(i + 1, history.get(i).doubleValue()));
         }
@@ -80,13 +80,13 @@ public class NetWorthCard extends WidgetCard {
 
     /**
      * Updates the net worth label and change label with current values.
-     * Reads derived values from {@link GameManager} via facade methods.
+     * Reads derived values from {@link GameService} via facade methods.
      */
     @Override
     protected void refreshDisplay() {
-        BigDecimal netWorth = gameManager.getPlayerNetWorth();
-        BigDecimal change = gameManager.getPlayerNetWorthChangeSinceStart();
-        BigDecimal percentChange = gameManager.getPlayerNetWorthChangePercentSinceStart();
+        BigDecimal netWorth = gameService.getPlayerNetWorth();
+        BigDecimal change = gameService.getPlayerNetWorthChangeSinceStart();
+        BigDecimal percentChange = gameService.getPlayerNetWorthChangePercentSinceStart();
 
         String sign = change.compareTo(BigDecimal.ZERO) >= 0 ? "+" : "";
         String formattedPercent = String.format(Locale.of("no"), "%.1f", percentChange);
@@ -111,7 +111,7 @@ public class NetWorthCard extends WidgetCard {
     @Override
     public void onGameUpdated() {
         int nextPoint = series.getData().size() + 1;
-        double netWorth = gameManager.getPlayerNetWorth().doubleValue();
+        double netWorth = gameService.getPlayerNetWorth().doubleValue();
         series.getData().add(new XYChart.Data<>(nextPoint, netWorth));
         xAxis.setUpperBound(nextPoint);
         xAxis.setTickUnit(Math.max(1, nextPoint / 8));

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/PortfolioValueCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/PortfolioValueCard.java
@@ -1,6 +1,6 @@
 package edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card;
 
-import edu.ntnu.idatt2003.millions.manager.GameManager;
+import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.util.CurrencyFormatter;
 import edu.ntnu.idatt2003.millions.view.component.StyledText;
 import edu.ntnu.idatt2003.millions.view.component.WidgetCard;
@@ -10,18 +10,18 @@ import edu.ntnu.idatt2003.millions.view.component.WidgetCard;
  */
 public class PortfolioValueCard extends WidgetCard {
 
-    private final GameManager gameManager;
+    private final GameService gameService;
     private final StyledText valueLabel = StyledText.widgetValue();
 
-    public PortfolioValueCard(GameManager gameManager) {
-        super(gameManager, "dashboard.portfolioValue");
-        this.gameManager = gameManager;
+    public PortfolioValueCard(GameService gameService) {
+        super(gameService, "dashboard.portfolioValue");
+        this.gameService = gameService;
         getChildren().addAll(titleLabel, valueLabel);
         refreshDisplay();
     }
 
     @Override
     protected void refreshDisplay() {
-        valueLabel.setText(CurrencyFormatter.format(gameManager.getPortfolioValue()));
+        valueLabel.setText(CurrencyFormatter.format(gameService.getPortfolioValue()));
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/PortfolioValueCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/PortfolioValueCard.java
@@ -1,6 +1,7 @@
 package edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card;
 
 import edu.ntnu.idatt2003.millions.service.GameService;
+import edu.ntnu.idatt2003.millions.service.PortfolioService;
 import edu.ntnu.idatt2003.millions.util.CurrencyFormatter;
 import edu.ntnu.idatt2003.millions.view.component.StyledText;
 import edu.ntnu.idatt2003.millions.view.component.WidgetCard;
@@ -11,6 +12,7 @@ import edu.ntnu.idatt2003.millions.view.component.WidgetCard;
 public class PortfolioValueCard extends WidgetCard {
 
     private final GameService gameService;
+    private final PortfolioService portfolioService = new PortfolioService();
     private final StyledText valueLabel = StyledText.widgetValue();
 
     public PortfolioValueCard(GameService gameService) {
@@ -22,6 +24,6 @@ public class PortfolioValueCard extends WidgetCard {
 
     @Override
     protected void refreshDisplay() {
-        valueLabel.setText(CurrencyFormatter.format(gameService.getPortfolioValue()));
+        valueLabel.setText(CurrencyFormatter.format(portfolioService.getValue(gameService.getPlayer(), gameService.getCurrencyConverter())));
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/RealizedReturnsCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/RealizedReturnsCard.java
@@ -1,6 +1,6 @@
 package edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card;
 
-import edu.ntnu.idatt2003.millions.manager.GameManager;
+import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.util.CurrencyFormatter;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
 import edu.ntnu.idatt2003.millions.view.component.Card;
@@ -23,7 +23,7 @@ import java.math.BigDecimal;
  */
 public class RealizedReturnsCard extends Card {
 
-    private final GameManager gameManager;
+    private final GameService gameService;
 
     private final StyledText title = StyledText.sectionTitle();
     private final StyledText emptyMessage = StyledText.detailLabel();
@@ -47,11 +47,11 @@ public class RealizedReturnsCard extends Card {
     /**
      * Constructs a new RealizedReturnsCard.
      *
-     * @param gameManager the game manager containing player and exchange
+     * @param gameService the game manager containing player and exchange
      */
-    public RealizedReturnsCard(GameManager gameManager) {
-        super(gameManager);
-        this.gameManager = gameManager;
+    public RealizedReturnsCard(GameService gameService) {
+        super(gameService);
+        this.gameService = gameService;
         setSpacing(16);
 
         emptyContainer.setAlignment(Pos.CENTER);
@@ -80,7 +80,7 @@ public class RealizedReturnsCard extends Card {
     }
 
     private void refresh() {
-        boolean hasSales = gameManager.getSalesCount() > 0;
+        boolean hasSales = gameService.getSalesCount() > 0;
 
         emptyContainer.setVisible(!hasSales);
         emptyContainer.setManaged(!hasSales);
@@ -89,12 +89,12 @@ public class RealizedReturnsCard extends Card {
 
         if (!hasSales) return;
 
-        BigDecimal gains = gameManager.getRealizedGainsInNok();
-        BigDecimal losses = gameManager.getRealizedLossesInNok();
-        BigDecimal net = gameManager.getNetRealizedInNok();
-        BigDecimal tax = gameManager.getTotalTaxPaidInNok();
-        BigDecimal commission = gameManager.getTotalSaleCommissionInNok();
-        int count = gameManager.getSalesCount();
+        BigDecimal gains = gameService.getRealizedGainsInNok();
+        BigDecimal losses = gameService.getRealizedLossesInNok();
+        BigDecimal net = gameService.getNetRealizedInNok();
+        BigDecimal tax = gameService.getTotalTaxPaidInNok();
+        BigDecimal commission = gameService.getTotalSaleCommissionInNok();
+        int count = gameService.getSalesCount();
 
         String gainSign = gains.signum() > 0 ? "+" : "";
         gainValue.setText(gainSign + CurrencyFormatter.format(gains));

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/RealizedReturnsCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/RealizedReturnsCard.java
@@ -1,6 +1,7 @@
 package edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card;
 
 import edu.ntnu.idatt2003.millions.service.GameService;
+import edu.ntnu.idatt2003.millions.service.RealizedReturnsService;
 import edu.ntnu.idatt2003.millions.util.CurrencyFormatter;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
 import edu.ntnu.idatt2003.millions.view.component.Card;
@@ -24,6 +25,7 @@ import java.math.BigDecimal;
 public class RealizedReturnsCard extends Card {
 
     private final GameService gameService;
+    private final RealizedReturnsService realizedService = new RealizedReturnsService();
 
     private final StyledText title = StyledText.sectionTitle();
     private final StyledText emptyMessage = StyledText.detailLabel();
@@ -80,7 +82,7 @@ public class RealizedReturnsCard extends Card {
     }
 
     private void refresh() {
-        boolean hasSales = gameService.getSalesCount() > 0;
+        boolean hasSales = realizedService.getSalesCount(gameService.getPlayer()) > 0;
 
         emptyContainer.setVisible(!hasSales);
         emptyContainer.setManaged(!hasSales);
@@ -89,12 +91,12 @@ public class RealizedReturnsCard extends Card {
 
         if (!hasSales) return;
 
-        BigDecimal gains = gameService.getRealizedGainsInNok();
-        BigDecimal losses = gameService.getRealizedLossesInNok();
-        BigDecimal net = gameService.getNetRealizedInNok();
-        BigDecimal tax = gameService.getTotalTaxPaidInNok();
-        BigDecimal commission = gameService.getTotalSaleCommissionInNok();
-        int count = gameService.getSalesCount();
+        BigDecimal gains = realizedService.getGainsInNok(gameService.getPlayer(), gameService.getCurrencyConverter());
+        BigDecimal losses = realizedService.getLossesInNok(gameService.getPlayer(), gameService.getCurrencyConverter());
+        BigDecimal net = realizedService.getNetRealizedInNok(gameService.getPlayer(), gameService.getCurrencyConverter());
+        BigDecimal tax = realizedService.getTotalTaxPaidInNok(gameService.getPlayer(), gameService.getCurrencyConverter());
+        BigDecimal commission = realizedService.getTotalSaleCommissionInNok(gameService.getPlayer(), gameService.getCurrencyConverter());
+        int count = realizedService.getSalesCount(gameService.getPlayer());
 
         String gainSign = gains.signum() > 0 ? "+" : "";
         gainValue.setText(gainSign + CurrencyFormatter.format(gains));

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/StatusCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/StatusCard.java
@@ -1,6 +1,6 @@
 package edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card;
 
-import edu.ntnu.idatt2003.millions.manager.GameManager;
+import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
 import edu.ntnu.idatt2003.millions.view.component.StyledText;
 import edu.ntnu.idatt2003.millions.view.component.WidgetCard;
@@ -10,19 +10,19 @@ import edu.ntnu.idatt2003.millions.view.component.WidgetCard;
  */
 public class StatusCard extends WidgetCard {
 
-    private final GameManager gameManager;
+    private final GameService gameService;
     private final StyledText valueLabel = StyledText.widgetValue();
 
-    public StatusCard(GameManager gameManager) {
-        super(gameManager, "dashboard.status");
-        this.gameManager = gameManager;
+    public StatusCard(GameService gameService) {
+        super(gameService, "dashboard.status");
+        this.gameService = gameService;
         getChildren().addAll(titleLabel, valueLabel);
         refreshDisplay();
     }
 
     @Override
     protected void refreshDisplay() {
-        String key = switch (gameManager.getPlayerStatus()) {
+        String key = switch (gameService.getPlayerStatus()) {
             case NOVICE -> "status.novice";
             case INVESTOR -> "status.investor";
             case SPECULATOR -> "status.speculator";

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/StatusCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/StatusCard.java
@@ -1,6 +1,7 @@
 package edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card;
 
 import edu.ntnu.idatt2003.millions.service.GameService;
+import edu.ntnu.idatt2003.millions.service.PlayerStatsService;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
 import edu.ntnu.idatt2003.millions.view.component.StyledText;
 import edu.ntnu.idatt2003.millions.view.component.WidgetCard;
@@ -11,6 +12,7 @@ import edu.ntnu.idatt2003.millions.view.component.WidgetCard;
 public class StatusCard extends WidgetCard {
 
     private final GameService gameService;
+    private final PlayerStatsService statsService = new PlayerStatsService();
     private final StyledText valueLabel = StyledText.widgetValue();
 
     public StatusCard(GameService gameService) {
@@ -22,7 +24,7 @@ public class StatusCard extends WidgetCard {
 
     @Override
     protected void refreshDisplay() {
-        String key = switch (gameService.getPlayerStatus()) {
+        String key = switch (statsService.getStatus(gameService.getPlayer(), gameService.getCurrencyConverter())) {
             case NOVICE -> "status.novice";
             case INVESTOR -> "status.investor";
             case SPECULATOR -> "status.speculator";

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/WeeklyChangeCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/WeeklyChangeCard.java
@@ -1,6 +1,7 @@
 package edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card;
 
 import edu.ntnu.idatt2003.millions.service.GameService;
+import edu.ntnu.idatt2003.millions.service.PlayerStatsService;
 import edu.ntnu.idatt2003.millions.util.CurrencyFormatter;
 import edu.ntnu.idatt2003.millions.view.component.StyledText;
 import edu.ntnu.idatt2003.millions.view.component.WidgetCard;
@@ -16,6 +17,7 @@ import java.util.Locale;
 public class WeeklyChangeCard extends WidgetCard {
 
     private final GameService gameService;
+    private final PlayerStatsService statsService = new PlayerStatsService();
     private final StyledText changeLabel = StyledText.widgetChange();
 
     public WeeklyChangeCard(GameService gameService) {
@@ -32,14 +34,14 @@ public class WeeklyChangeCard extends WidgetCard {
      */
     @Override
     protected void refreshDisplay() {
-        BigDecimal change = gameService.getPlayerWeeklyNetWorthChange();
+        BigDecimal change = statsService.getWeeklyNetWorthChange(gameService.getPlayer(), gameService.getCurrencyConverter());
         if (change == null) {
             changeLabel.setText("–");
             changeLabel.getStyleClass().removeAll("positive", "negative");
             return;
         }
 
-        BigDecimal percentChange = gameService.getPlayerWeeklyNetWorthChangePercent();
+        BigDecimal percentChange = statsService.getWeeklyNetWorthChangePercent(gameService.getPlayer(), gameService.getCurrencyConverter());
 
         String arrow = change.compareTo(BigDecimal.ZERO) >= 0 ? "↗" : "↘";
         String sign = change.compareTo(BigDecimal.ZERO) >= 0 ? "+" : "";

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/WeeklyChangeCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/WeeklyChangeCard.java
@@ -1,6 +1,6 @@
 package edu.ntnu.idatt2003.millions.view.dashboard.portfolio.card;
 
-import edu.ntnu.idatt2003.millions.manager.GameManager;
+import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.util.CurrencyFormatter;
 import edu.ntnu.idatt2003.millions.view.component.StyledText;
 import edu.ntnu.idatt2003.millions.view.component.WidgetCard;
@@ -15,12 +15,12 @@ import java.util.Locale;
  */
 public class WeeklyChangeCard extends WidgetCard {
 
-    private final GameManager gameManager;
+    private final GameService gameService;
     private final StyledText changeLabel = StyledText.widgetChange();
 
-    public WeeklyChangeCard(GameManager gameManager) {
-        super(gameManager, "dashboard.weeklyChange");
-        this.gameManager = gameManager;
+    public WeeklyChangeCard(GameService gameService) {
+        super(gameService, "dashboard.weeklyChange");
+        this.gameService = gameService;
         getChildren().addAll(titleLabel, changeLabel);
         refreshDisplay();
     }
@@ -28,18 +28,18 @@ public class WeeklyChangeCard extends WidgetCard {
     /**
      * Updates the displayed week change based on the current and previous net worth.
      * Shows a dash if no week has been advanced yet. Reads derived values from
-     * {@link GameManager} via facade methods.
+     * {@link GameService} via facade methods.
      */
     @Override
     protected void refreshDisplay() {
-        BigDecimal change = gameManager.getPlayerWeeklyNetWorthChange();
+        BigDecimal change = gameService.getPlayerWeeklyNetWorthChange();
         if (change == null) {
             changeLabel.setText("–");
             changeLabel.getStyleClass().removeAll("positive", "negative");
             return;
         }
 
-        BigDecimal percentChange = gameManager.getPlayerWeeklyNetWorthChangePercent();
+        BigDecimal percentChange = gameService.getPlayerWeeklyNetWorthChangePercent();
 
         String arrow = change.compareTo(BigDecimal.ZERO) >= 0 ? "↗" : "↘";
         String sign = change.compareTo(BigDecimal.ZERO) >= 0 ? "+" : "";

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/exchange/ExchangeView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/exchange/ExchangeView.java
@@ -1,6 +1,6 @@
 package edu.ntnu.idatt2003.millions.view.exchange;
 
-import edu.ntnu.idatt2003.millions.manager.GameManager;
+import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.view.component.ViewHeader;
 import edu.ntnu.idatt2003.millions.view.component.WeekBar;
 import javafx.scene.layout.Priority;
@@ -15,18 +15,18 @@ import java.util.List;
  */
 public class ExchangeView extends VBox {
 
-    private final GameManager gameManager;
+    private final GameService gameService;
     private final ViewHeader viewHeader;
     private final VBox contentArea;
 
     /**
      * Constructs a new ExchangeView with the overview tab active.
      *
-     * @param gameManager the game manager containing player and exchange
+     * @param gameService the game manager containing player and exchange
      * @param weekBar     the week bar shared with the rest of the application
      */
-    public ExchangeView(GameManager gameManager, WeekBar weekBar) {
-        this.gameManager = gameManager;
+    public ExchangeView(GameService gameService, WeekBar weekBar) {
+        this.gameService = gameService;
         getStyleClass().add("content-area");
 
         viewHeader = new ViewHeader(
@@ -62,16 +62,16 @@ public class ExchangeView extends VBox {
 
     private void showOverview() {
         contentArea.getChildren().clear(); // remove this when implementing setAll
-        // contentArea.getChildren().setAll(new OverviewView(gameManager));
+        // contentArea.getChildren().setAll(new OverviewView(gameService));
     }
 
     private void showStocks() {
         contentArea.getChildren().clear(); // remove this when implementing setAll
-        // contentArea.getChildren().setAll(new StocksView(gameManager));
+        // contentArea.getChildren().setAll(new StocksView(gameService));
     }
 
     private void showAnalysis() {
         contentArea.getChildren().clear(); // remove this when implementing setAll
-        // contentArea.getChildren().setAll(new AnalysisView(gameManager));
+        // contentArea.getChildren().setAll(new AnalysisView(gameService));
     }
 }

--- a/src/test/java/edu/ntnu/idatt2003/millions/controller/StartControllerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/controller/StartControllerTest.java
@@ -1,6 +1,6 @@
 package edu.ntnu.idatt2003.millions.controller;
 
-import edu.ntnu.idatt2003.millions.manager.GameManager;
+import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.view.StartScreenInputs;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class StartControllerTest {
 
     private StubInputs inputs;
-    private RecordingGameManager gameManager;
+    private RecordingGameService gameService;
     private List<String> errors;
     private boolean showMainCalled;
     private StartController controller;
@@ -36,11 +36,11 @@ class StartControllerTest {
     @BeforeEach
     void setUp() {
         inputs = new StubInputs();
-        gameManager = new RecordingGameManager();
+        gameService = new RecordingGameService();
         errors = new ArrayList<>();
         showMainCalled = false;
         controller = new StartController(
-                gameManager,
+                gameService,
                 inputs,
                 () -> showMainCalled = true,
                 errors::add);
@@ -60,10 +60,10 @@ class StartControllerTest {
             // Act
             controller.handleStartGame();
             // Assert
-            assertEquals("Dara", gameManager.lastName);
-            assertEquals(0, new BigDecimal("10000.00").compareTo(gameManager.lastCapital));
-            assertNull(gameManager.lastStockFile);
-            assertNull(gameManager.lastCurrency);
+            assertEquals("Dara", gameService.lastName);
+            assertEquals(0, new BigDecimal("10000.00").compareTo(gameService.lastCapital));
+            assertNull(gameService.lastStockFile);
+            assertNull(gameService.lastCurrency);
             assertTrue(showMainCalled);
             assertTrue(errors.isEmpty());
         }
@@ -79,10 +79,10 @@ class StartControllerTest {
             // Act
             controller.handleStartGame();
             // Assert
-            assertEquals("Dara", gameManager.lastName);
-            assertEquals(0, new BigDecimal("10000.00").compareTo(gameManager.lastCapital));
-            assertEquals(Path.of("/tmp/stocks.csv"), gameManager.lastStockFile.toPath());
-            assertEquals(Currency.getInstance("EUR"), gameManager.lastCurrency);
+            assertEquals("Dara", gameService.lastName);
+            assertEquals(0, new BigDecimal("10000.00").compareTo(gameService.lastCapital));
+            assertEquals(Path.of("/tmp/stocks.csv"), gameService.lastStockFile.toPath());
+            assertEquals(Currency.getInstance("EUR"), gameService.lastCurrency);
             assertTrue(showMainCalled);
             assertTrue(errors.isEmpty());
         }
@@ -97,7 +97,7 @@ class StartControllerTest {
             controller.handleStartGame();
             // Assert
             assertEquals(1, errors.size());
-            assertEquals(0, gameManager.createNewGameCalls);
+            assertEquals(0, gameService.createNewGameCalls);
             assertFalse(showMainCalled);
         }
 
@@ -112,7 +112,7 @@ class StartControllerTest {
             controller.handleStartGame();
             // Assert
             assertEquals(1, errors.size());
-            assertEquals(0, gameManager.createNewGameCalls);
+            assertEquals(0, gameService.createNewGameCalls);
             assertFalse(showMainCalled);
         }
 
@@ -128,7 +128,7 @@ class StartControllerTest {
             controller.handleStartGame();
             // Assert
             assertEquals(1, errors.size());
-            assertEquals(0, gameManager.createNewGameCalls);
+            assertEquals(0, gameService.createNewGameCalls);
             assertFalse(showMainCalled);
         }
 
@@ -144,18 +144,18 @@ class StartControllerTest {
             controller.handleStartGame();
             // Assert
             assertEquals(1, errors.size());
-            assertEquals(0, gameManager.createNewGameCalls);
+            assertEquals(0, gameService.createNewGameCalls);
             assertFalse(showMainCalled);
         }
 
         @Test
         @DisplayName("Should report error and not navigate when game manager fails")
-        void reportsErrorWhenGameManagerFails() {
+        void reportsErrorWhenGameServiceFails() {
             // Arrange
             inputs.name = "Dara";
             inputs.capital = "10000.00";
             inputs.stockFilePath = "";
-            gameManager.failNextCreate = new IllegalStateException("default stock data missing");
+            gameService.failNextCreate = new IllegalStateException("default stock data missing");
             // Act
             controller.handleStartGame();
             // Assert
@@ -166,12 +166,12 @@ class StartControllerTest {
 
         @Test
         @DisplayName("Should report error and not navigate when game manager throws UncheckedIOException")
-        void reportsErrorWhenGameManagerThrowsIoException() {
+        void reportsErrorWhenGameServiceThrowsIoException() {
             // Arrange
             inputs.name = "Dara";
             inputs.capital = "10000.00";
             inputs.stockFilePath = "";
-            gameManager.failNextCreate =
+            gameService.failNextCreate =
                     new UncheckedIOException("read failed", new java.io.IOException("disk error"));
             // Act
             controller.handleStartGame();
@@ -193,7 +193,7 @@ class StartControllerTest {
             // Act
             controller.handleLoadGame();
             // Assert
-            assertEquals(Path.of("/tmp/save.json"), gameManager.lastLoadedFile.toPath());
+            assertEquals(Path.of("/tmp/save.json"), gameService.lastLoadedFile.toPath());
             assertTrue(showMainCalled);
             assertTrue(errors.isEmpty());
         }
@@ -207,16 +207,16 @@ class StartControllerTest {
             controller.handleLoadGame();
             // Assert
             assertEquals(1, errors.size());
-            assertEquals(0, gameManager.loadGameCalls);
+            assertEquals(0, gameService.loadGameCalls);
             assertFalse(showMainCalled);
         }
 
         @Test
         @DisplayName("Should report error and not navigate when game manager fails to load")
-        void reportsErrorWhenGameManagerFailsToLoad() {
+        void reportsErrorWhenGameServiceFailsToLoad() {
             // Arrange
             inputs.saveFilePath = "/tmp/save.json";
-            gameManager.failNextLoad = new IllegalArgumentException("corrupt save file");
+            gameService.failNextLoad = new IllegalArgumentException("corrupt save file");
             // Act
             controller.handleLoadGame();
             // Assert
@@ -247,10 +247,10 @@ class StartControllerTest {
     }
 
     /**
-     * Test double for {@link GameManager} that records the arguments passed
+     * Test double for {@link GameService} that records the arguments passed
      * to its mutating methods and lets tests trigger controlled failures.
      */
-    private static class RecordingGameManager extends GameManager {
+    private static class RecordingGameService extends GameService {
         String lastName;
         BigDecimal lastCapital;
         File lastStockFile;

--- a/src/test/java/edu/ntnu/idatt2003/millions/service/GameServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/service/GameServiceTest.java
@@ -4,7 +4,6 @@ import edu.ntnu.idatt2003.millions.file.game.JsonGameFileHandler;
 import edu.ntnu.idatt2003.millions.model.currency.FixedRateCurrencyConverter;
 import edu.ntnu.idatt2003.millions.model.exchange.Exchange;
 import edu.ntnu.idatt2003.millions.model.player.Player;
-import edu.ntnu.idatt2003.millions.model.player.PlayerStatusLevel;
 import edu.ntnu.idatt2003.millions.model.stock.Share;
 import edu.ntnu.idatt2003.millions.model.stock.Stock;
 import edu.ntnu.idatt2003.millions.model.transaction.Transaction;
@@ -45,8 +44,6 @@ class GameServiceTest {
     private static final BigDecimal QUANTITY = new BigDecimal("5");
     private static final BigDecimal PURCHASE_COMMISSION = new BigDecimal("2.50000");
     private static final BigDecimal SALE_COMMISSION = new BigDecimal("5.0000");
-    private static final BigDecimal EXPECTED_PORTFOLIO_VALUE = new BigDecimal("500.0000");
-    private static final BigDecimal EXPECTED_NET_WORTH_AFTER_PURCHASE = new BigDecimal("9997.50000");
 
     private GameService gameService;
 
@@ -402,148 +399,6 @@ class GameServiceTest {
             assertEquals(0, STARTING_MONEY.compareTo(gameService.getPreviousNetWorth()));
             assertEquals(2, gameService.getPlayer().getNetWorthHistory().size());
             assertEquals(1, observer.updateCount);
-        }
-    }
-
-    @Nested
-    @DisplayName("getPlayerNetWorth()")
-    class GetPlayerNetWorth {
-
-        @Test
-        @DisplayName("Should return starting money for fresh player with empty portfolio")
-        void returnsStartingMoneyForFreshPlayer() {
-            // Act
-            BigDecimal netWorth = gameService.getPlayerNetWorth();
-            // Assert
-            assertEquals(0, STARTING_MONEY.compareTo(netWorth));
-        }
-
-        @Test
-        @DisplayName("Should return same total when shares are bought at current price")
-        void returnsSameTotalAfterPurchaseAtCurrentPrice() {
-            // Arrange
-            gameService.buy("EQNR", QUANTITY);
-            // Act
-            BigDecimal netWorth = gameService.getPlayerNetWorth();
-            // Assert: cash after purchase plus portfolio market value (5 × 100 NOK)
-            assertEquals(0, EXPECTED_NET_WORTH_AFTER_PURCHASE.compareTo(netWorth));
-        }
-    }
-
-    @Nested
-    @DisplayName("getPlayerNetWorthChangeSinceStart()")
-    class GetPlayerNetWorthChangeSinceStart {
-
-        @Test
-        @DisplayName("Should return zero for fresh player")
-        void returnsZeroForFreshPlayer() {
-            // Act
-            BigDecimal change = gameService.getPlayerNetWorthChangeSinceStart();
-            // Assert
-            assertEquals(0, BigDecimal.ZERO.compareTo(change));
-        }
-    }
-
-    @Nested
-    @DisplayName("getPlayerNetWorthChangePercentSinceStart()")
-    class GetPlayerNetWorthChangePercentSinceStart {
-
-        @Test
-        @DisplayName("Should return zero for fresh player")
-        void returnsZeroForFreshPlayer() {
-            // Act
-            BigDecimal percent = gameService.getPlayerNetWorthChangePercentSinceStart();
-            // Assert
-            assertEquals(0, BigDecimal.ZERO.compareTo(percent));
-        }
-    }
-
-    @Nested
-    @DisplayName("getPlayerWeeklyNetWorthChange()")
-    class GetPlayerWeeklyNetWorthChange {
-
-        @Test
-        @DisplayName("Should return null before the first week advance")
-        void returnsNullBeforeFirstAdvance() {
-            // Act
-            BigDecimal change = gameService.getPlayerWeeklyNetWorthChange();
-            // Assert
-            assertNull(change);
-        }
-
-        @Test
-        @DisplayName("Should return non-null value after a week is advanced")
-        void returnsNonNullAfterAdvance() {
-            // Arrange
-            gameService.advanceWeek();
-            // Act
-            BigDecimal change = gameService.getPlayerWeeklyNetWorthChange();
-            // Assert
-            assertNotNull(change);
-        }
-    }
-
-    @Nested
-    @DisplayName("getPlayerWeeklyNetWorthChangePercent()")
-    class GetPlayerWeeklyNetWorthChangePercent {
-
-        @Test
-        @DisplayName("Should return null before the first week advance")
-        void returnsNullBeforeFirstAdvance() {
-            // Act
-            BigDecimal percent = gameService.getPlayerWeeklyNetWorthChangePercent();
-            // Assert
-            assertNull(percent);
-        }
-
-        @Test
-        @DisplayName("Should return non-null value after a week is advanced")
-        void returnsNonNullAfterAdvance() {
-            // Arrange
-            gameService.advanceWeek();
-            // Act
-            BigDecimal percent = gameService.getPlayerWeeklyNetWorthChangePercent();
-            // Assert
-            assertNotNull(percent);
-        }
-    }
-
-    @Nested
-    @DisplayName("getPlayerStatus()")
-    class GetPlayerStatus {
-
-        @Test
-        @DisplayName("Should return NOVICE for fresh player")
-        void returnsNoviceForFreshPlayer() {
-            // Act
-            PlayerStatusLevel status = gameService.getPlayerStatus();
-            // Assert
-            assertEquals(PlayerStatusLevel.NOVICE, status);
-        }
-    }
-
-    @Nested
-    @DisplayName("getPortfolioValue()")
-    class GetPortfolioValue {
-
-        @Test
-        @DisplayName("Should return zero for empty portfolio")
-        void returnsZeroForEmptyPortfolio() {
-            // Act
-            BigDecimal value = gameService.getPortfolioValue();
-            // Assert
-            assertEquals(0, BigDecimal.ZERO.compareTo(value));
-        }
-
-        @Test
-        @DisplayName("Should return shares times price after purchase")
-        void returnsSharesTimesPriceAfterPurchase() {
-            // Arrange
-            gameService.buy("EQNR", QUANTITY);
-            // Act
-            BigDecimal value = gameService.getPortfolioValue();
-            // Assert: 5 shares × 100 NOK = 500 NOK market value (no fees deducted)
-            assertEquals(0, EXPECTED_PORTFOLIO_VALUE.compareTo(value));
         }
     }
 

--- a/src/test/java/edu/ntnu/idatt2003/millions/service/GameServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/service/GameServiceTest.java
@@ -1,4 +1,4 @@
-package edu.ntnu.idatt2003.millions.manager;
+package edu.ntnu.idatt2003.millions.service;
 
 import edu.ntnu.idatt2003.millions.file.game.JsonGameFileHandler;
 import edu.ntnu.idatt2003.millions.model.currency.FixedRateCurrencyConverter;
@@ -27,18 +27,18 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Unit tests for the facade methods on {@link GameManager}.
+ * Unit tests for the facade methods on {@link GameService}.
  * <p>
- * This test class verifies that the facade methods on GameManager correctly
+ * This test class verifies that the facade methods on GameService correctly
  * delegate to the underlying domain objects ({@link Player}, Portfolio,
  * {@link Exchange}) and return the expected derived values.
  * </p>
  * <p>
  * Game state is set up by saving a known {@link Player} and {@link Exchange}
- * to a temporary file, then loading it via {@link GameManager#loadGame}.
+ * to a temporary file, then loading it via {@link GameService#loadGame}.
  * </p>
  */
-class GameManagerTest {
+class GameServiceTest {
 
     private static final BigDecimal STARTING_MONEY = new BigDecimal("10000.00");
     private static final BigDecimal STOCK_PRICE = new BigDecimal("100.00");
@@ -48,7 +48,7 @@ class GameManagerTest {
     private static final BigDecimal EXPECTED_PORTFOLIO_VALUE = new BigDecimal("500.0000");
     private static final BigDecimal EXPECTED_NET_WORTH_AFTER_PURCHASE = new BigDecimal("9997.50000");
 
-    private GameManager gameManager;
+    private GameService gameService;
 
     @TempDir
     Path tempDir;
@@ -66,8 +66,8 @@ class GameManagerTest {
         Path file = tempDir.resolve("save.json");
         new JsonGameFileHandler().saveGame(player, exchange, file.toFile());
 
-        gameManager = new GameManager();
-        gameManager.loadGame(file.toFile());
+        gameService = new GameService();
+        gameService.loadGame(file.toFile());
     }
 
     @Nested
@@ -79,7 +79,7 @@ class GameManagerTest {
         void throwsExceptionWhenObserverIsNull() {
             // Act & Assert
             assertThrows(NullPointerException.class, () ->
-                    gameManager.addObserver(null));
+                    gameService.addObserver(null));
         }
     }
 
@@ -92,18 +92,18 @@ class GameManagerTest {
         void throwsExceptionWhenFileIsNull() {
             // Act & Assert
             assertThrows(NullPointerException.class, () ->
-                    gameManager.saveGame(null));
+                    gameService.saveGame(null));
         }
 
         @Test
         @DisplayName("Should throw exception when no active game exists")
         void throwsExceptionWhenNoActiveGameExists() {
             // Arrange
-            GameManager emptyGameManager = new GameManager();
+            GameService emptyGameService = new GameService();
             File file = tempDir.resolve("empty-save.json").toFile();
             // Act & Assert
             assertThrows(IllegalStateException.class, () ->
-                    emptyGameManager.saveGame(file));
+                    emptyGameService.saveGame(file));
         }
 
         @Test
@@ -112,7 +112,7 @@ class GameManagerTest {
             // Arrange
             File file = tempDir.resolve("saved-game.json").toFile();
             // Act
-            gameManager.saveGame(file);
+            gameService.saveGame(file);
             // Assert
             assertTrue(file.isFile());
             assertTrue(file.length() > 0);
@@ -128,17 +128,17 @@ class GameManagerTest {
         void throwsExceptionWhenFileIsNull() {
             // Act & Assert
             assertThrows(NullPointerException.class, () ->
-                    gameManager.loadGame(null));
+                    gameService.loadGame(null));
         }
 
         @Test
         @DisplayName("Should load player and exchange from file")
         void loadsPlayerAndExchangeFromFile() {
             // Act & Assert
-            assertEquals("Dara", gameManager.getPlayer().getName());
-            assertEquals("NYSE", gameManager.getExchange().getName());
-            assertTrue(gameManager.getExchange().hasStock("EQNR"));
-            assertNotNull(gameManager.getExchange().getCurrencyConverter());
+            assertEquals("Dara", gameService.getPlayer().getName());
+            assertEquals("NYSE", gameService.getExchange().getName());
+            assertTrue(gameService.getExchange().hasStock("EQNR"));
+            assertNotNull(gameService.getExchange().getCurrencyConverter());
         }
     }
 
@@ -152,17 +152,17 @@ class GameManagerTest {
             // Arrange
             File stockFile = createStockFile("AAPL,Apple Inc.,276.43\nMSFT,Microsoft,404.68\n");
             CountingObserver observer = new CountingObserver();
-            GameManager newGameManager = new GameManager();
-            newGameManager.addObserver(observer);
+            GameService newGameService = new GameService();
+            newGameService.addObserver(observer);
             // Act
-            newGameManager.createNewGame("Dara", STARTING_MONEY, stockFile);
+            newGameService.createNewGame("Dara", STARTING_MONEY, stockFile);
             // Assert
-            assertEquals("Dara", newGameManager.getPlayer().getName());
-            assertEquals(0, STARTING_MONEY.compareTo(newGameManager.getPlayer().getMoney()));
-            assertEquals("MainExchange", newGameManager.getExchange().getName());
-            assertTrue(newGameManager.getExchange().hasStock("AAPL"));
-            assertTrue(newGameManager.getExchange().hasStock("MSFT"));
-            assertNotNull(newGameManager.getExchange().getCurrencyConverter());
+            assertEquals("Dara", newGameService.getPlayer().getName());
+            assertEquals(0, STARTING_MONEY.compareTo(newGameService.getPlayer().getMoney()));
+            assertEquals("MainExchange", newGameService.getExchange().getName());
+            assertTrue(newGameService.getExchange().hasStock("AAPL"));
+            assertTrue(newGameService.getExchange().hasStock("MSFT"));
+            assertNotNull(newGameService.getExchange().getCurrencyConverter());
             assertEquals(1, observer.updateCount);
         }
 
@@ -171,17 +171,17 @@ class GameManagerTest {
         void createsPlayerAndExchangeFromDefaultStockData() {
             // Arrange
             CountingObserver observer = new CountingObserver();
-            GameManager newGameManager = new GameManager();
-            newGameManager.addObserver(observer);
+            GameService newGameService = new GameService();
+            newGameService.addObserver(observer);
             // Act
-            newGameManager.createNewGame("Dara", STARTING_MONEY);
+            newGameService.createNewGame("Dara", STARTING_MONEY);
             // Assert
-            assertEquals("Dara", newGameManager.getPlayer().getName());
-            assertEquals(0, STARTING_MONEY.compareTo(newGameManager.getPlayer().getMoney()));
-            assertEquals("MainExchange", newGameManager.getExchange().getName());
-            assertTrue(newGameManager.getExchange().hasStock("NVDA"));
-            assertTrue(newGameManager.getExchange().hasStock("AAPL"));
-            assertNotNull(newGameManager.getExchange().getCurrencyConverter());
+            assertEquals("Dara", newGameService.getPlayer().getName());
+            assertEquals(0, STARTING_MONEY.compareTo(newGameService.getPlayer().getMoney()));
+            assertEquals("MainExchange", newGameService.getExchange().getName());
+            assertTrue(newGameService.getExchange().hasStock("NVDA"));
+            assertTrue(newGameService.getExchange().hasStock("AAPL"));
+            assertNotNull(newGameService.getExchange().getCurrencyConverter());
             assertEquals(1, observer.updateCount);
         }
 
@@ -189,10 +189,10 @@ class GameManagerTest {
         @DisplayName("Should throw exception when stock file is null")
         void throwsExceptionWhenStockFileIsNull() {
             // Arrange
-            GameManager newGameManager = new GameManager();
+            GameService newGameService = new GameService();
             // Act & Assert
             assertThrows(NullPointerException.class, () ->
-                    newGameManager.createNewGame("Dara", STARTING_MONEY, null));
+                    newGameService.createNewGame("Dara", STARTING_MONEY, null));
         }
 
         @Test
@@ -200,10 +200,10 @@ class GameManagerTest {
         void throwsExceptionWhenPlayerNameIsBlank() throws IOException {
             // Arrange
             File stockFile = createStockFile("AAPL,Apple Inc.,276.43\n");
-            GameManager newGameManager = new GameManager();
+            GameService newGameService = new GameService();
             // Act & Assert
             assertThrows(IllegalArgumentException.class, () ->
-                    newGameManager.createNewGame("", STARTING_MONEY, stockFile));
+                    newGameService.createNewGame("", STARTING_MONEY, stockFile));
         }
 
         @Test
@@ -211,10 +211,10 @@ class GameManagerTest {
         void throwsExceptionWhenCapitalIsNotPositive() throws IOException {
             // Arrange
             File stockFile = createStockFile("AAPL,Apple Inc.,276.43\n");
-            GameManager newGameManager = new GameManager();
+            GameService newGameService = new GameService();
             // Act & Assert
             assertThrows(IllegalArgumentException.class, () ->
-                    newGameManager.createNewGame("Dara", new BigDecimal("-1.00"), stockFile));
+                    newGameService.createNewGame("Dara", new BigDecimal("-1.00"), stockFile));
         }
 
         @Test
@@ -222,10 +222,10 @@ class GameManagerTest {
         void throwsExceptionWhenCapitalIsZero() throws IOException {
             // Arrange
             File stockFile = createStockFile("AAPL,Apple Inc.,276.43\n");
-            GameManager newGameManager = new GameManager();
+            GameService newGameService = new GameService();
             // Act & Assert
             assertThrows(IllegalArgumentException.class, () ->
-                    newGameManager.createNewGame("Dara", BigDecimal.ZERO, stockFile));
+                    newGameService.createNewGame("Dara", BigDecimal.ZERO, stockFile));
         }
 
         @Test
@@ -233,10 +233,10 @@ class GameManagerTest {
         void throwsExceptionWhenStockFileIsEmpty() throws IOException {
             // Arrange
             File stockFile = createStockFile("");
-            GameManager newGameManager = new GameManager();
+            GameService newGameService = new GameService();
             // Act & Assert
             assertThrows(IllegalArgumentException.class, () ->
-                    newGameManager.createNewGame("Dara", STARTING_MONEY, stockFile));
+                    newGameService.createNewGame("Dara", STARTING_MONEY, stockFile));
         }
 
         @Test
@@ -245,12 +245,12 @@ class GameManagerTest {
             // Arrange
             File stockFile = createStockFile("AAPL,Apple Inc.,100.00\n");
             Currency selectedCurrency = Currency.getInstance("EUR");
-            GameManager newGameManager = new GameManager();
+            GameService newGameService = new GameService();
             // Act
-            newGameManager.createNewGame("Dara", STARTING_MONEY, stockFile, selectedCurrency);
+            newGameService.createNewGame("Dara", STARTING_MONEY, stockFile, selectedCurrency);
             // Assert
             assertEquals(selectedCurrency,
-                    newGameManager.getExchange().getStock("AAPL").getCurrency());
+                    newGameService.getExchange().getStock("AAPL").getCurrency());
         }
 
         @Test
@@ -259,16 +259,16 @@ class GameManagerTest {
             // Arrange
             File stockFile = createStockFile("AAPL,Apple Inc.,100.00\n");
             Currency usd = Currency.getInstance("USD");
-            GameManager newGameManager = new GameManager();
-            newGameManager.createNewGame("Dara", STARTING_MONEY, stockFile, usd);
+            GameService newGameService = new GameService();
+            newGameService.createNewGame("Dara", STARTING_MONEY, stockFile, usd);
             // Act
-            newGameManager.buy("AAPL", QUANTITY);
+            newGameService.buy("AAPL", QUANTITY);
             // Assert: 5 * 100 USD * 1.005 commission = 502.50 USD; * 9.21 NOK/USD = 4628.0250 NOK
             BigDecimal expectedRemaining = STARTING_MONEY.subtract(new BigDecimal("4628.0250"));
             assertEquals(0,
-                    expectedRemaining.compareTo(newGameManager.getPlayer().getMoney()));
+                    expectedRemaining.compareTo(newGameService.getPlayer().getMoney()));
             assertEquals(usd,
-                    newGameManager.getExchange().getStock("AAPL").getCurrency());
+                    newGameService.getExchange().getStock("AAPL").getCurrency());
         }
 
         @Test
@@ -276,10 +276,10 @@ class GameManagerTest {
         void throwsExceptionWhenCurrencyIsNull() throws IOException {
             // Arrange
             File stockFile = createStockFile("AAPL,Apple Inc.,100.00\n");
-            GameManager newGameManager = new GameManager();
+            GameService newGameService = new GameService();
             // Act & Assert
             assertThrows(NullPointerException.class, () ->
-                    newGameManager.createNewGame("Dara", STARTING_MONEY, stockFile, null));
+                    newGameService.createNewGame("Dara", STARTING_MONEY, stockFile, null));
         }
 
         @Test
@@ -287,24 +287,24 @@ class GameManagerTest {
         void defaultsStockCurrencyToUsdForCustomFile() throws IOException {
             // Arrange
             File stockFile = createStockFile("AAPL,Apple Inc.,100.00\n");
-            GameManager newGameManager = new GameManager();
+            GameService newGameService = new GameService();
             // Act
-            newGameManager.createNewGame("Dara", STARTING_MONEY, stockFile);
+            newGameService.createNewGame("Dara", STARTING_MONEY, stockFile);
             // Assert
             assertEquals(Currency.getInstance("USD"),
-                    newGameManager.getExchange().getStock("AAPL").getCurrency());
+                    newGameService.getExchange().getStock("AAPL").getCurrency());
         }
 
         @Test
         @DisplayName("Should tag default stock data with USD")
         void tagsDefaultStockDataWithUsd() {
             // Arrange
-            GameManager newGameManager = new GameManager();
+            GameService newGameService = new GameService();
             // Act
-            newGameManager.createNewGame("Dara", STARTING_MONEY);
+            newGameService.createNewGame("Dara", STARTING_MONEY);
             // Assert
             assertEquals(Currency.getInstance("USD"),
-                    newGameManager.getExchange().getStock("AAPL").getCurrency());
+                    newGameService.getExchange().getStock("AAPL").getCurrency());
         }
 
         @Test
@@ -312,16 +312,16 @@ class GameManagerTest {
         void leavesPreviousStateIntactOnFailure() throws IOException {
             // Arrange: an already-active game from setUp() loaded "NYSE" with EQNR
             CountingObserver observer = new CountingObserver();
-            gameManager.addObserver(observer);
+            gameService.addObserver(observer);
             File stockFile = createStockFile("AAPL,Apple Inc.,100.00\n");
             // Act: a failed createNewGame must not mutate the active state
             assertThrows(IllegalArgumentException.class, () ->
-                    gameManager.createNewGame("", STARTING_MONEY, stockFile));
+                    gameService.createNewGame("", STARTING_MONEY, stockFile));
             // Assert: previous player and exchange remain
-            assertEquals("Dara", gameManager.getPlayer().getName());
-            assertEquals("NYSE", gameManager.getExchange().getName());
-            assertTrue(gameManager.getExchange().hasStock("EQNR"));
-            assertFalse(gameManager.getExchange().hasStock("AAPL"));
+            assertEquals("Dara", gameService.getPlayer().getName());
+            assertEquals("NYSE", gameService.getExchange().getName());
+            assertTrue(gameService.getExchange().hasStock("EQNR"));
+            assertFalse(gameService.getExchange().hasStock("AAPL"));
             assertEquals(0, observer.updateCount);
         }
 
@@ -330,11 +330,11 @@ class GameManagerTest {
         void doesNotNotifyObserversWhenStockFileIsNull() {
             // Arrange
             CountingObserver observer = new CountingObserver();
-            GameManager newGameManager = new GameManager();
-            newGameManager.addObserver(observer);
+            GameService newGameService = new GameService();
+            newGameService.addObserver(observer);
             // Act & Assert
             assertThrows(NullPointerException.class, () ->
-                    newGameManager.createNewGame("Dara", STARTING_MONEY, null));
+                    newGameService.createNewGame("Dara", STARTING_MONEY, null));
             assertEquals(0, observer.updateCount);
         }
     }
@@ -348,16 +348,16 @@ class GameManagerTest {
         void buysSharesAndNotifiesObservers() {
             // Arrange
             CountingObserver observer = new CountingObserver();
-            gameManager.addObserver(observer);
+            gameService.addObserver(observer);
             // Act
-            Transaction transaction = gameManager.buy("EQNR", QUANTITY);
+            Transaction transaction = gameService.buy("EQNR", QUANTITY);
             // Assert
             assertNotNull(transaction);
-            assertEquals(1, gameManager.getPlayer().getPortfolio().getShares("EQNR").size());
+            assertEquals(1, gameService.getPlayer().getPortfolio().getShares("EQNR").size());
             assertEquals(1, observer.updateCount);
             assertEquals(0, STARTING_MONEY.subtract(STOCK_PRICE.multiply(QUANTITY))
                     .subtract(PURCHASE_COMMISSION)
-                    .compareTo(gameManager.getPlayer().getMoney()));
+                    .compareTo(gameService.getPlayer().getMoney()));
         }
     }
 
@@ -369,19 +369,19 @@ class GameManagerTest {
         @DisplayName("Should sell share and notify observers")
         void sellsShareAndNotifiesObservers() {
             // Arrange
-            gameManager.buy("EQNR", QUANTITY);
-            Share share = gameManager.getPlayer().getPortfolio().getShares("EQNR").getFirst();
+            gameService.buy("EQNR", QUANTITY);
+            Share share = gameService.getPlayer().getPortfolio().getShares("EQNR").getFirst();
             CountingObserver observer = new CountingObserver();
-            gameManager.addObserver(observer);
+            gameService.addObserver(observer);
             // Act
-            Transaction transaction = gameManager.sell(share);
+            Transaction transaction = gameService.sell(share);
             // Assert
             assertNotNull(transaction);
-            assertTrue(gameManager.getPlayer().getPortfolio().getShares("EQNR").isEmpty());
+            assertTrue(gameService.getPlayer().getPortfolio().getShares("EQNR").isEmpty());
             assertEquals(1, observer.updateCount);
             assertEquals(0, STARTING_MONEY.subtract(PURCHASE_COMMISSION)
                     .subtract(SALE_COMMISSION)
-                    .compareTo(gameManager.getPlayer().getMoney()));
+                    .compareTo(gameService.getPlayer().getMoney()));
         }
     }
 
@@ -394,13 +394,13 @@ class GameManagerTest {
         void advancesWeekRecordsPreviousNetWorthAndNotifiesObservers() {
             // Arrange
             CountingObserver observer = new CountingObserver();
-            gameManager.addObserver(observer);
+            gameService.addObserver(observer);
             // Act
-            gameManager.advanceWeek();
+            gameService.advanceWeek();
             // Assert
-            assertEquals(2, gameManager.getExchange().getWeek());
-            assertEquals(0, STARTING_MONEY.compareTo(gameManager.getPreviousNetWorth()));
-            assertEquals(2, gameManager.getPlayer().getNetWorthHistory().size());
+            assertEquals(2, gameService.getExchange().getWeek());
+            assertEquals(0, STARTING_MONEY.compareTo(gameService.getPreviousNetWorth()));
+            assertEquals(2, gameService.getPlayer().getNetWorthHistory().size());
             assertEquals(1, observer.updateCount);
         }
     }
@@ -413,7 +413,7 @@ class GameManagerTest {
         @DisplayName("Should return starting money for fresh player with empty portfolio")
         void returnsStartingMoneyForFreshPlayer() {
             // Act
-            BigDecimal netWorth = gameManager.getPlayerNetWorth();
+            BigDecimal netWorth = gameService.getPlayerNetWorth();
             // Assert
             assertEquals(0, STARTING_MONEY.compareTo(netWorth));
         }
@@ -422,9 +422,9 @@ class GameManagerTest {
         @DisplayName("Should return same total when shares are bought at current price")
         void returnsSameTotalAfterPurchaseAtCurrentPrice() {
             // Arrange
-            gameManager.buy("EQNR", QUANTITY);
+            gameService.buy("EQNR", QUANTITY);
             // Act
-            BigDecimal netWorth = gameManager.getPlayerNetWorth();
+            BigDecimal netWorth = gameService.getPlayerNetWorth();
             // Assert: cash after purchase plus portfolio market value (5 × 100 NOK)
             assertEquals(0, EXPECTED_NET_WORTH_AFTER_PURCHASE.compareTo(netWorth));
         }
@@ -438,7 +438,7 @@ class GameManagerTest {
         @DisplayName("Should return zero for fresh player")
         void returnsZeroForFreshPlayer() {
             // Act
-            BigDecimal change = gameManager.getPlayerNetWorthChangeSinceStart();
+            BigDecimal change = gameService.getPlayerNetWorthChangeSinceStart();
             // Assert
             assertEquals(0, BigDecimal.ZERO.compareTo(change));
         }
@@ -452,7 +452,7 @@ class GameManagerTest {
         @DisplayName("Should return zero for fresh player")
         void returnsZeroForFreshPlayer() {
             // Act
-            BigDecimal percent = gameManager.getPlayerNetWorthChangePercentSinceStart();
+            BigDecimal percent = gameService.getPlayerNetWorthChangePercentSinceStart();
             // Assert
             assertEquals(0, BigDecimal.ZERO.compareTo(percent));
         }
@@ -466,7 +466,7 @@ class GameManagerTest {
         @DisplayName("Should return null before the first week advance")
         void returnsNullBeforeFirstAdvance() {
             // Act
-            BigDecimal change = gameManager.getPlayerWeeklyNetWorthChange();
+            BigDecimal change = gameService.getPlayerWeeklyNetWorthChange();
             // Assert
             assertNull(change);
         }
@@ -475,9 +475,9 @@ class GameManagerTest {
         @DisplayName("Should return non-null value after a week is advanced")
         void returnsNonNullAfterAdvance() {
             // Arrange
-            gameManager.advanceWeek();
+            gameService.advanceWeek();
             // Act
-            BigDecimal change = gameManager.getPlayerWeeklyNetWorthChange();
+            BigDecimal change = gameService.getPlayerWeeklyNetWorthChange();
             // Assert
             assertNotNull(change);
         }
@@ -491,7 +491,7 @@ class GameManagerTest {
         @DisplayName("Should return null before the first week advance")
         void returnsNullBeforeFirstAdvance() {
             // Act
-            BigDecimal percent = gameManager.getPlayerWeeklyNetWorthChangePercent();
+            BigDecimal percent = gameService.getPlayerWeeklyNetWorthChangePercent();
             // Assert
             assertNull(percent);
         }
@@ -500,9 +500,9 @@ class GameManagerTest {
         @DisplayName("Should return non-null value after a week is advanced")
         void returnsNonNullAfterAdvance() {
             // Arrange
-            gameManager.advanceWeek();
+            gameService.advanceWeek();
             // Act
-            BigDecimal percent = gameManager.getPlayerWeeklyNetWorthChangePercent();
+            BigDecimal percent = gameService.getPlayerWeeklyNetWorthChangePercent();
             // Assert
             assertNotNull(percent);
         }
@@ -516,7 +516,7 @@ class GameManagerTest {
         @DisplayName("Should return NOVICE for fresh player")
         void returnsNoviceForFreshPlayer() {
             // Act
-            PlayerStatusLevel status = gameManager.getPlayerStatus();
+            PlayerStatusLevel status = gameService.getPlayerStatus();
             // Assert
             assertEquals(PlayerStatusLevel.NOVICE, status);
         }
@@ -530,7 +530,7 @@ class GameManagerTest {
         @DisplayName("Should return zero for empty portfolio")
         void returnsZeroForEmptyPortfolio() {
             // Act
-            BigDecimal value = gameManager.getPortfolioValue();
+            BigDecimal value = gameService.getPortfolioValue();
             // Assert
             assertEquals(0, BigDecimal.ZERO.compareTo(value));
         }
@@ -539,9 +539,9 @@ class GameManagerTest {
         @DisplayName("Should return shares times price after purchase")
         void returnsSharesTimesPriceAfterPurchase() {
             // Arrange
-            gameManager.buy("EQNR", QUANTITY);
+            gameService.buy("EQNR", QUANTITY);
             // Act
-            BigDecimal value = gameManager.getPortfolioValue();
+            BigDecimal value = gameService.getPortfolioValue();
             // Assert: 5 shares × 100 NOK = 500 NOK market value (no fees deducted)
             assertEquals(0, EXPECTED_PORTFOLIO_VALUE.compareTo(value));
         }


### PR DESCRIPTION
Summary

- Renames GameManager → GameService and moves it from manager/ to service/, better reflecting its role as an application service
- Extracts PlayerStatsService, PortfolioService, and RealizedReturnsService - three stateless read services that compute derived values from Player and CurrencyConverter without holding any state
- Removes 18 facade query methods from GameService; views now call the relevant read service directly, passing gameService.getPlayer() and gameService.getCurrencyConverter()
- Adds GameService.getCurrencyConverter() shortcut (previously required getExchange().getCurrencyConverter() at every call site)
- Updates docs/SoC.md to document the new layer structure

Motivation

GameManager had grown to ~480 lines by accumulating facade methods for every derived value any view needed. Every new card required a new method on the manager, growing it indefinitely. The three read services follow the same stateless pattern as the existing TransactionPreviewService and give each group of related queries a natural home.

- Removes 18 facade query methods from GameService; views now call the relevant read service directly, passing gameService.getPlayer() and gameService.getCurrencyConverter()
- Adds GameService.getCurrencyConverter() shortcut (previously required getExchange().getCurrencyConverter() at every call site)
- Updates docs/SoC.md to document the new layer structure

Motivation

GameManager had grown to ~480 lines by accumulating facade methods for every derived value any view needed. Every new card required a new method on the manager, growing it indefinitely. The three read services follow the same stateless pattern as the existing TransactionPreviewService and give each group of related queries a natural home.
