### PR TITLE
feat: transactions tab with history table and week filter

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/millions/service/TransactionStatsService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/TransactionStatsService.java
@@ -1,0 +1,158 @@
+package edu.ntnu.idatt2003.millions.service;
+
+import edu.ntnu.idatt2003.millions.model.calculator.PurchaseCalculator;
+import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
+import edu.ntnu.idatt2003.millions.model.stock.Share;
+import edu.ntnu.idatt2003.millions.model.transaction.Purchase;
+import edu.ntnu.idatt2003.millions.model.transaction.Sale;
+import edu.ntnu.idatt2003.millions.model.transaction.Transaction;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Currency;
+
+/**
+ * Stateless read service that derives the per-transaction values displayed
+ * in the transactions table.
+ *
+ * <p>Sits alongside {@code PlayerStatsService}, {@code PortfolioService}
+ * and {@code RealizedReturnsService}: like them, it holds no state, takes
+ * the model objects it needs as method arguments, and returns plain values
+ * the view can render. This is the pattern SoC.md prescribes for derived
+ * values that don't naturally live on a single domain object — the
+ * computation crosses {@link Transaction}, {@link Share}, the calculator
+ * tied to its subclass, and the active {@link CurrencyConverter}.</p>
+ *
+ * <p>Two pieces of irregularity are encapsulated here so the table doesn't
+ * have to know about them:</p>
+ * <ul>
+ *   <li><b>Frozen vs. recomputed values.</b> {@link Sale} freezes its
+ *       financial figures at construction so they survive serialisation,
+ *       while {@link Purchase} keeps its {@code calculator} as a transient
+ *       field which is null after loading a saved game. A fresh
+ *       {@link PurchaseCalculator} is built from the share to recover
+ *       commission and total for purchases.</li>
+ *   <li><b>Currency conversion.</b> Native-currency values are converted
+ *       to NOK so the table can stay denominated in one currency. Both
+ *       the native and the NOK value are returned so views can show NOK
+ *       in the main cell and the native amount in a tooltip.</li>
+ * </ul>
+ */
+public class TransactionStatsService {
+
+    /** Currency every NOK-denominated value is converted to. */
+    private static final Currency NOK = Currency.getInstance("NOK");
+
+    /** Scale used when dividing gross by quantity to recover per-share price. */
+    private static final int PRICE_SCALE = 4;
+
+    /**
+     * Computes the display values for a single transaction row.
+     *
+     * @param transaction the transaction to derive values from
+     * @param converter   the active currency converter
+     * @return computed values ready to be rendered in the transactions table
+     */
+    public TransactionStats getStats(Transaction transaction, CurrencyConverter converter) {
+        Share share = transaction.getShare();
+        Currency nativeCurrency = share.getStock().getCurrency();
+
+        if (transaction instanceof Sale sale) {
+            return statsForSale(sale, share, nativeCurrency, converter);
+        }
+        return statsForPurchase(share, nativeCurrency, converter);
+    }
+
+    /**
+     * Builds the stats record for a sale, reading the frozen gross,
+     * commission, tax and total directly off the sale.
+     *
+     * @param sale            the sale to read values from
+     * @param share           the underlying share, used for quantity
+     * @param nativeCurrency  the stock's native currency
+     * @param converter       the active currency converter
+     * @return populated stats record
+     */
+    private TransactionStats statsForSale(Sale sale, Share share,
+                                          Currency nativeCurrency,
+                                          CurrencyConverter converter) {
+        BigDecimal pricePerShare = sale.getGross()
+                .divide(share.getQuantity(), PRICE_SCALE, RoundingMode.HALF_UP);
+        BigDecimal commissionNok = converter.convert(sale.getCommission(), nativeCurrency, NOK);
+        BigDecimal taxNok = converter.convert(sale.getTax(), nativeCurrency, NOK);
+        BigDecimal amountNok = converter.convert(sale.getTotal(), nativeCurrency, NOK);
+
+        return new TransactionStats(
+                share.getQuantity(),
+                pricePerShare,
+                commissionNok,
+                taxNok,
+                amountNok,
+                nativeCurrency.getCurrencyCode(),
+                sale.getCommission(),
+                sale.getTax());
+    }
+
+    /**
+     * Builds the stats record for a purchase, reconstructing commission
+     * and total from a fresh {@link PurchaseCalculator} since the
+     * transaction's own calculator is transient and may be null after
+     * a saved game is loaded. Tax is always zero for purchases, and the
+     * NOK amount is negated to signal an outflow.
+     *
+     * @param share          the share that was purchased
+     * @param nativeCurrency the stock's native currency
+     * @param converter      the active currency converter
+     * @return populated stats record
+     */
+    private TransactionStats statsForPurchase(Share share,
+                                              Currency nativeCurrency,
+                                              CurrencyConverter converter) {
+        PurchaseCalculator calculator = new PurchaseCalculator(share);
+        BigDecimal commissionNative = calculator.calculateCommission();
+        BigDecimal totalNative = calculator.calculateTotal();
+
+        BigDecimal commissionNok = converter.convert(commissionNative, nativeCurrency, NOK);
+        BigDecimal amountNok = converter.convert(totalNative, nativeCurrency, NOK).negate();
+
+        return new TransactionStats(
+                share.getQuantity(),
+                share.getPurchasePrice(),
+                commissionNok,
+                BigDecimal.ZERO,
+                amountNok,
+                nativeCurrency.getCurrencyCode(),
+                commissionNative,
+                BigDecimal.ZERO);
+    }
+
+    /**
+     * Display values for one transaction row.
+     *
+     * <p>Carries both NOK and native-currency figures for commission and
+     * tax so the view can render NOK in the cell and the native amount
+     * in a tooltip without recomputing or rounding twice.</p>
+     *
+     * @param quantity            shares bought or sold
+     * @param pricePerShare       per-share price at transaction time,
+     *                            in native currency
+     * @param commissionNok       commission converted to NOK
+     * @param taxNok              tax converted to NOK; zero for purchases
+     * @param amountNok           signed net amount in NOK — negative for
+     *                            purchases, positive for sales
+     * @param nativeCurrencyCode  ISO code of the stock's native currency
+     * @param commissionNative    commission in native currency, for tooltips
+     * @param taxNative           tax in native currency, for tooltips;
+     *                            zero for purchases
+     */
+    public record TransactionStats(
+            BigDecimal quantity,
+            BigDecimal pricePerShare,
+            BigDecimal commissionNok,
+            BigDecimal taxNok,
+            BigDecimal amountNok,
+            String nativeCurrencyCode,
+            BigDecimal commissionNative,
+            BigDecimal taxNative
+    ) {}
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/util/TableCells.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/util/TableCells.java
@@ -1,0 +1,155 @@
+package edu.ntnu.idatt2003.millions.util;
+
+import edu.ntnu.idatt2003.millions.view.component.StyledText;
+import javafx.geometry.HPos;
+import javafx.scene.control.Label;
+import javafx.scene.layout.ColumnConstraints;
+import javafx.scene.layout.GridPane;
+
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
+
+/**
+ * Stateless helper that builds the table primitives shared by every
+ * dashboard table card.
+ *
+ * <p>Covers two levels:</p>
+ * <ul>
+ *   <li><b>Cell factories</b> — {@link #header}, {@link #data} and
+ *       {@link #empty} return individual styled labels. Callers compose
+ *       them into rows themselves, so anything that needs a one-off cell
+ *       (a row with a tooltip, a custom badge, a colored amount) gets the
+ *       same look without going through a generic row builder.</li>
+ *   <li><b>Grid helpers</b> — {@link #configureColumns}, {@link #addHeaderRow}
+ *       and {@link #renderEmptyState} write directly to a {@link GridPane}.
+ *       They encapsulate the small loops that every table would otherwise
+ *       duplicate, so each table's {@code refresh()} reads top-to-bottom
+ *       without boilerplate.</li>
+ * </ul>
+ *
+ * <p>What is intentionally <b>not</b> here: a full table render pipeline.
+ * Cards still own their own {@code refresh()} and choose what to do for
+ * each row, which keeps the abstraction shallow and easy to follow. If a
+ * third tabular card later shows that every table runs the same
+ * {@code clear → header → empty-check → loop} skeleton, that's the right
+ * moment to promote the skeleton into a {@code TableCard<T>} base class.</p>
+ *
+ * <p>Specialised cells — colored amount cells, badges, action buttons —
+ * are intentionally outside this class: they belong to
+ * {@code ChangeFormatter}, {@code TransactionTypeBadge} and the owning
+ * table respectively, since their styling is more than just a typography
+ * class.</p>
+ */
+public final class TableCells {
+
+    /**
+     * Number format shared by every table in the dashboard.
+     * Norwegian locale gives comma decimal separator and space thousands
+     * separator (e.g. {@code 1 234,56}).
+     */
+    public static final DecimalFormat NUMBER_FORMAT;
+
+    static {
+        DecimalFormatSymbols symbols = new DecimalFormatSymbols(Locale.forLanguageTag("nb-NO"));
+        NUMBER_FORMAT = new DecimalFormat("#,##0.00", symbols);
+    }
+
+    private TableCells() {
+        // Utility class — should not be instantiated.
+    }
+
+    // ----- Cell factories ---------------------------------------------------
+
+    /**
+     * Creates a header cell with the shared {@code holdings-header} CSS class.
+     *
+     * @param text the header text
+     * @return a styled header label
+     */
+    public static Label header(String text) {
+        Label label = new Label(text);
+        label.getStyleClass().add("holdings-header");
+        return label;
+    }
+
+    /**
+     * Creates a plain data cell with the shared {@code holdings-cell} CSS class.
+     *
+     * @param text the cell text
+     * @return a styled data label
+     */
+    public static Label data(String text) {
+        Label label = new Label(text);
+        label.getStyleClass().add("holdings-cell");
+        return label;
+    }
+
+    /**
+     * Creates the centered empty-state label used when a table has no rows
+     * to display. Returned as a {@link StyledText} so callers can apply
+     * {@code GridPane.setColumnSpan} and {@code GridPane.setHalignment} on it.
+     *
+     * @param text the empty-state message
+     * @return a styled empty-state label
+     */
+    public static StyledText empty(String text) {
+        StyledText label = StyledText.widgetLabel(text);
+        label.getStyleClass().add("holdings-empty");
+        return label;
+    }
+
+    // ----- Grid helpers -----------------------------------------------------
+
+    /**
+     * Configures a grid's columns from parallel arrays of widths (as
+     * percentages summing to about 100) and horizontal alignments.
+     *
+     * <p>Length of the two arrays must match; this is the table's
+     * responsibility, not the helper's. Existing column constraints are
+     * not cleared — call this once during construction.</p>
+     *
+     * @param grid       the grid to configure
+     * @param widths     percentage width per column
+     * @param alignments horizontal alignment per column
+     */
+    public static void configureColumns(GridPane grid, double[] widths, HPos[] alignments) {
+        for (int i = 0; i < widths.length; i++) {
+            ColumnConstraints col = new ColumnConstraints();
+            col.setHalignment(alignments[i]);
+            col.setPercentWidth(widths[i]);
+            grid.getColumnConstraints().add(col);
+        }
+    }
+
+    /**
+     * Writes a header row to row 0 of the given grid, with one
+     * {@link #header} cell per provided label.
+     *
+     * <p>Does not clear the grid first — callers typically call
+     * {@code grid.getChildren().clear()} themselves before refreshing.</p>
+     *
+     * @param grid    the grid to write to
+     * @param headers the header texts, one per column
+     */
+    public static void addHeaderRow(GridPane grid, String[] headers) {
+        for (int i = 0; i < headers.length; i++) {
+            grid.add(header(headers[i]), i, 0);
+        }
+    }
+
+    /**
+     * Renders a centered empty-state message spanning the full width of
+     * the table on row 1 (immediately below the header row).
+     *
+     * @param grid        the grid to write to
+     * @param message     the empty-state text
+     * @param columnCount the total number of columns to span across
+     */
+    public static void renderEmptyState(GridPane grid, String message, int columnCount) {
+        StyledText label = empty(message);
+        GridPane.setColumnSpan(label, columnCount);
+        GridPane.setHalignment(label, HPos.CENTER);
+        grid.add(label, 0, 1);
+    }
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/DashboardView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/DashboardView.java
@@ -5,6 +5,7 @@ import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.view.component.ViewHeader;
 import edu.ntnu.idatt2003.millions.view.component.WeekBar;
 import edu.ntnu.idatt2003.millions.view.dashboard.portfolio.PortfolioView;
+import edu.ntnu.idatt2003.millions.view.dashboard.transactions.TransactionsView;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 
@@ -67,8 +68,7 @@ public class DashboardView extends VBox {
     }
 
     private void showTransactions() {
-        contentArea.getChildren().clear(); // remove this when implementing setAll
-        // contentArea.getChildren().setAll(new TransactionsView(gameService));
+        contentArea.getChildren().setAll(new TransactionsView(gameService));
     }
 
     private void showWatchlist() {

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/HoldingsCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/HoldingsCard.java
@@ -8,6 +8,7 @@ import edu.ntnu.idatt2003.millions.model.stock.Share;
 import edu.ntnu.idatt2003.millions.model.stock.Stock;
 import edu.ntnu.idatt2003.millions.util.ChangeFormatter;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
+import edu.ntnu.idatt2003.millions.util.TableCells;
 import edu.ntnu.idatt2003.millions.view.component.Card;
 import edu.ntnu.idatt2003.millions.view.component.InfoTooltip;
 import edu.ntnu.idatt2003.millions.view.component.StyledText;
@@ -15,16 +16,12 @@ import javafx.geometry.HPos;
 import javafx.geometry.Pos;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
-import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 
 import java.math.BigDecimal;
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
 import java.util.List;
-import java.util.Locale;
 
 /**
  * Card displaying the player's holdings (shares owned), with action buttons
@@ -36,13 +33,6 @@ import java.util.Locale;
  * pending.</p>
  */
 public class HoldingsCard extends Card {
-
-    private static final DecimalFormat NUMBER_FORMAT;
-
-    static {
-        DecimalFormatSymbols symbols = new DecimalFormatSymbols(Locale.forLanguageTag("nb-NO"));
-        NUMBER_FORMAT = new DecimalFormat("#,##0.00", symbols);
-    }
 
     private final GameService gameService;
     private final PortfolioService portfolioService = new PortfolioService();
@@ -64,24 +54,13 @@ public class HoldingsCard extends Card {
         setSpacing(16);
 
         grid.setHgap(20);
-        configureColumns();
+        TableCells.configureColumns(grid,
+                new double[]{18, 22, 10, 12, 12, 10, 11, 5},
+                new HPos[]{HPos.LEFT, HPos.LEFT, HPos.RIGHT, HPos.RIGHT,
+                        HPos.RIGHT, HPos.RIGHT, HPos.RIGHT, HPos.CENTER});
 
         getChildren().addAll(title, grid);
         refresh();
-    }
-
-    private void configureColumns() {
-        double[] widths = {18, 22, 10, 12, 12, 10, 11, 5};
-        HPos[] alignments = {
-                HPos.LEFT, HPos.LEFT, HPos.RIGHT, HPos.RIGHT,
-                HPos.RIGHT, HPos.RIGHT, HPos.RIGHT, HPos.CENTER
-        };
-        for (int i = 0; i < widths.length; i++) {
-            ColumnConstraints col = new ColumnConstraints();
-            col.setHalignment(alignments[i]);
-            col.setPercentWidth(widths[i]);
-            grid.getColumnConstraints().add(col);
-        }
     }
 
     /**
@@ -114,11 +93,7 @@ public class HoldingsCard extends Card {
         addHeaderRow();
 
         if (shares.isEmpty()) {
-            StyledText empty = StyledText.widgetLabel(LanguageManager.get("dashboard.portfolio.empty"));
-            empty.getStyleClass().add("holdings-empty");
-            GridPane.setColumnSpan(empty, 8);
-            GridPane.setHalignment(empty, HPos.CENTER);
-            grid.add(empty, 0, 1);
+            TableCells.renderEmptyState(grid, LanguageManager.get("dashboard.portfolio.empty"), 8);
             return;
         }
 
@@ -150,8 +125,7 @@ public class HoldingsCard extends Card {
                 null
         };
         for (int i = 0; i < headers.length; i++) {
-            Label label = new Label(headers[i]);
-            label.getStyleClass().add("holdings-header");
+            Label label = TableCells.header(headers[i]);
             if (tooltipKeys[i] != null) {
                 InfoTooltip icon = new InfoTooltip(tooltipKeys[i]);
                 icon.getStyleClass().add("holdings-header-icon");
@@ -169,10 +143,10 @@ public class HoldingsCard extends Card {
     private void addDataRow(int row, Share share) {
         Stock stock = share.getStock();
         grid.add(buildActionButtons(share), 0, row);
-        grid.add(cell(stock.getSymbol() + ", " + stock.getCompany()), 1, row);
-        grid.add(cell(NUMBER_FORMAT.format(share.getQuantity())), 2, row);
+        grid.add(TableCells.data(stock.getSymbol() + ", " + stock.getCompany()), 1, row);
+        grid.add(TableCells.data(TableCells.NUMBER_FORMAT.format(share.getQuantity())), 2, row);
         grid.add(coloredPercentCell(stock.getWeeklyChangePercent()), 3, row);
-        grid.add(cell(NUMBER_FORMAT.format(portfolioService.getShareValueInNok(share, gameService.getCurrencyConverter()))), 4, row);
+        grid.add(TableCells.data(TableCells.NUMBER_FORMAT.format(portfolioService.getShareValueInNok(share, gameService.getCurrencyConverter()))), 4, row);
         grid.add(coloredPercentCell(share.getReturnPercent()), 5, row);
         grid.add(coloredAmountCell(portfolioService.getShareReturnInNok(share, gameService.getCurrencyConverter())), 6, row);
         grid.add(buildDetailsButton(share), 7, row);
@@ -190,7 +164,7 @@ public class HoldingsCard extends Card {
         totalLabel.getStyleClass().addAll("holdings-cell", "bold");
         grid.add(totalLabel, 1, dataRow);
 
-        Label valueNok = new Label(NUMBER_FORMAT.format(portfolioService.getValue(gameService.getPlayer(), gameService.getCurrencyConverter())));
+        Label valueNok = new Label(TableCells.NUMBER_FORMAT.format(portfolioService.getValue(gameService.getPlayer(), gameService.getCurrencyConverter())));
         valueNok.getStyleClass().addAll("holdings-cell", "bold");
         grid.add(valueNok, 4, dataRow);
 
@@ -226,12 +200,6 @@ public class HoldingsCard extends Card {
         Button b = new Button(text);
         b.getStyleClass().addAll("holdings-action-link", colorClass);
         return b;
-    }
-
-    private Label cell(String text) {
-        Label label = new Label(text);
-        label.getStyleClass().add("holdings-cell");
-        return label;
     }
 
     private Label coloredPercentCell(BigDecimal value) {

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/TransactionsView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/TransactionsView.java
@@ -1,0 +1,34 @@
+package edu.ntnu.idatt2003.millions.view.dashboard.transactions;
+
+import edu.ntnu.idatt2003.millions.service.GameService;
+import edu.ntnu.idatt2003.millions.view.dashboard.transactions.card.TransactionsCard;
+import javafx.scene.layout.VBox;
+
+/**
+ * The transactions tab view shown under the dashboard.
+ *
+ * <p>Acts as a thin container for the cards on this tab — currently a
+ * single {@link TransactionsCard}, with room to add more cards (summary
+ * widgets, charts, etc.) below it without restructuring the view. This
+ * mirrors {@code PortfolioView}, which lays out a stack of cards the
+ * same way.</p>
+ *
+ * <p>The view itself owns no state and no observers: each card it
+ * contains is self-sufficient and reacts to game and language changes
+ * through its own observer registration.</p>
+ */
+public class TransactionsView extends VBox {
+
+    /**
+     * Constructs a new TransactionsView and adds its cards.
+     *
+     * @param gameService the game manager containing player and exchange
+     */
+    public TransactionsView(GameService gameService) {
+        setSpacing(16);
+
+        TransactionsCard transactionsCard = new TransactionsCard(gameService);
+
+        getChildren().add(transactionsCard);
+    }
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/card/TransactionsCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/card/TransactionsCard.java
@@ -11,9 +11,14 @@ import edu.ntnu.idatt2003.millions.util.LanguageManager;
 import edu.ntnu.idatt2003.millions.util.TableCells;
 import edu.ntnu.idatt2003.millions.view.component.Card;
 import edu.ntnu.idatt2003.millions.view.component.StyledText;
+import edu.ntnu.idatt2003.millions.view.dashboard.transactions.component.WeekRangeFilter;
 import javafx.geometry.HPos;
+import javafx.geometry.Pos;
 import javafx.scene.control.Label;
 import javafx.scene.layout.GridPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
 
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -23,11 +28,11 @@ import java.util.List;
 /**
  * Dashboard card for the transactions tab.
  *
- * <p>Renders the section title and a table of every committed transaction
- * from week 1 up to and including the current game week, sorted oldest
- * first. Filter controls (search, type, week range) are deliberately not
- * yet wired up — they will be layered on top in a follow-up change and
- * will only narrow which rows are rendered, not how a row is rendered.</p>
+ * <p>Renders the section title, a filter row, and a table of every
+ * committed transaction within the selected week range, sorted oldest
+ * first. The filter row currently holds a {@link WeekRangeFilter}; the
+ * search field and type dropdown will be added later in the same row
+ * without restructuring the card.</p>
  *
  * <p>Shares structure and CSS with {@code HoldingsCard} via
  * {@link TableCells} (column setup, header row, cell factories, empty
@@ -61,6 +66,7 @@ public class TransactionsCard extends Card {
     private final GameService gameService;
     private final TransactionStatsService statsService = new TransactionStatsService();
     private final StyledText title;
+    private final WeekRangeFilter weekRangeFilter;
     private final GridPane grid = new GridPane();
 
     /**
@@ -76,19 +82,47 @@ public class TransactionsCard extends Card {
 
         title = StyledText.sectionTitle(LanguageManager.get("transactions.title"));
 
+        int currentWeek = Math.max(gameService.getExchange().getWeek(), 1);
+        weekRangeFilter = new WeekRangeFilter(1, currentWeek);
+        weekRangeFilter.fromWeekProperty().addListener((obs, oldVal, newVal) -> refresh());
+        weekRangeFilter.toWeekProperty().addListener((obs, oldVal, newVal) -> refresh());
+
+        HBox filterRow = buildFilterRow();
+
         grid.setHgap(20);
         TableCells.configureColumns(grid, COLUMN_WIDTHS, COLUMN_ALIGNMENTS);
 
-        getChildren().addAll(title, grid);
+        getChildren().addAll(title, filterRow, grid);
         refresh();
     }
 
     /**
+     * Builds the filter row that sits between the title and the table.
+     *
+     * <p>The week range filter is pushed to the right edge with a flexible
+     * spacer so future filter controls (search field, type dropdown) can
+     * be inserted on the left without affecting alignment.</p>
+     *
+     * @return the configured filter row
+     */
+    private HBox buildFilterRow() {
+        Region spacer = new Region();
+        HBox.setHgrow(spacer, Priority.ALWAYS);
+
+        HBox row = new HBox(16, spacer, weekRangeFilter);
+        row.setAlignment(Pos.CENTER_LEFT);
+        row.getStyleClass().add("transactions-filter-row");
+        return row;
+    }
+
+    /**
      * Picks up new transactions and the new current week whenever the
-     * model changes.
+     * model changes. Also extends the week range filter's upper bound
+     * so the player can include the new week in the filter.
      */
     @Override
     public void onGameUpdated() {
+        weekRangeFilter.setMaxWeek(Math.max(gameService.getExchange().getWeek(), 1));
         refresh();
     }
 
@@ -106,15 +140,16 @@ public class TransactionsCard extends Card {
     /**
      * Rebuilds the table from scratch: clears the grid, adds the header
      * row, then either renders a centered empty-state message or one
-     * row per transaction.
+     * row per transaction within the selected week range.
      */
     private void refresh() {
         grid.getChildren().clear();
         TableCells.addHeaderRow(grid, headerTexts());
 
         TransactionArchive archive = gameService.getPlayer().getTransactionArchive();
-        int currentWeek = gameService.getExchange().getWeek();
-        List<Transaction> transactions = collectAll(archive, currentWeek);
+        int fromWeek = weekRangeFilter.getFromWeek();
+        int toWeek = weekRangeFilter.getToWeek();
+        List<Transaction> transactions = collectRange(archive, fromWeek, toWeek);
 
         if (transactions.isEmpty()) {
             TableCells.renderEmptyState(
@@ -148,17 +183,18 @@ public class TransactionsCard extends Card {
     }
 
     /**
-     * Gathers every transaction in the archive from week 1 up to and
-     * including the current week, then sorts them oldest first so the
-     * table reads chronologically from top to bottom.
+     * Gathers every transaction in the archive within the given week
+     * range (inclusive on both ends), then sorts them oldest first so
+     * the table reads chronologically from top to bottom.
      *
-     * @param archive     the archive to read transactions from
-     * @param currentWeek the current game week (inclusive upper bound)
-     * @return a chronologically sorted list of all transactions
+     * @param archive  the archive to read transactions from
+     * @param fromWeek the first week to include (inclusive)
+     * @param toWeek   the last week to include (inclusive)
+     * @return a chronologically sorted list of transactions in the range
      */
-    private List<Transaction> collectAll(TransactionArchive archive, int currentWeek) {
+    private List<Transaction> collectRange(TransactionArchive archive, int fromWeek, int toWeek) {
         List<Transaction> list = new ArrayList<>();
-        for (int week = 1; week <= currentWeek; week++) {
+        for (int week = fromWeek; week <= toWeek; week++) {
             list.addAll(archive.getTransactions(week));
         }
         list.sort(Comparator.comparingInt(Transaction::getWeek));

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/card/TransactionsCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/card/TransactionsCard.java
@@ -1,22 +1,67 @@
 package edu.ntnu.idatt2003.millions.view.dashboard.transactions.card;
 
 import edu.ntnu.idatt2003.millions.service.GameService;
+import edu.ntnu.idatt2003.millions.service.TransactionStatsService;
+import edu.ntnu.idatt2003.millions.model.stock.Stock;
+import edu.ntnu.idatt2003.millions.model.transaction.Purchase;
+import edu.ntnu.idatt2003.millions.model.transaction.Transaction;
+import edu.ntnu.idatt2003.millions.model.transaction.TransactionArchive;
+import edu.ntnu.idatt2003.millions.util.ChangeFormatter;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
+import edu.ntnu.idatt2003.millions.util.TableCells;
 import edu.ntnu.idatt2003.millions.view.component.Card;
 import edu.ntnu.idatt2003.millions.view.component.StyledText;
+import javafx.geometry.HPos;
+import javafx.scene.control.Label;
+import javafx.scene.layout.GridPane;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 
 /**
  * Dashboard card for the transactions tab.
  *
- * <p>Currently only renders the section title; filter controls, the table
- * and per-row interactions will be layered on in follow-up changes. The
- * card already registers itself as a game and language observer via the
- * {@link Card} base class, so the scaffolding is in place even though
- * {@link #onGameUpdated()} has nothing to update yet.</p>
+ * <p>Renders the section title and a table of every committed transaction
+ * from week 1 up to and including the current game week, sorted oldest
+ * first. Filter controls (search, type, week range) are deliberately not
+ * yet wired up — they will be layered on top in a follow-up change and
+ * will only narrow which rows are rendered, not how a row is rendered.</p>
+ *
+ * <p>Shares structure and CSS with {@code HoldingsCard} via
+ * {@link TableCells} (column setup, header row, cell factories, empty
+ * state), {@link ChangeFormatter} (coloured signed amounts) and the
+ * {@code holdings-*} CSS classes, so both dashboard tables look like
+ * part of the same family.</p>
+ *
+ * <p>The type column uses a pill-shaped badge with its own colour scheme
+ * (light blue for buys, light green for sales); the helper that builds
+ * the badge will be extracted into a reusable {@code TransactionTypeBadge}
+ * component once we have a second caller for it.</p>
  */
 public class TransactionsCard extends Card {
 
+    /** Number of columns in the table — used for empty-state column span. */
+    private static final int COLUMN_COUNT = 8;
+
+    /** Percentage widths for each column; sums to 100. */
+    private static final double[] COLUMN_WIDTHS = {8, 28, 10, 10, 12, 12, 10, 10};
+
+    /**
+     * Horizontal alignment per column: text columns (week, company, type)
+     * align left so labels read naturally; numeric columns align right so
+     * digits line up cleanly.
+     */
+    private static final HPos[] COLUMN_ALIGNMENTS = {
+            HPos.LEFT, HPos.LEFT, HPos.LEFT, HPos.RIGHT,
+            HPos.RIGHT, HPos.RIGHT, HPos.RIGHT, HPos.RIGHT
+    };
+
+    private final GameService gameService;
+    private final TransactionStatsService statsService = new TransactionStatsService();
     private final StyledText title;
+    private final GridPane grid = new GridPane();
 
     /**
      * Constructs a new TransactionsCard.
@@ -25,28 +70,157 @@ public class TransactionsCard extends Card {
      */
     public TransactionsCard(GameService gameService) {
         super(gameService);
+        this.gameService = gameService;
 
         setSpacing(16);
 
         title = StyledText.sectionTitle(LanguageManager.get("transactions.title"));
 
-        getChildren().add(title);
+        grid.setHgap(20);
+        TableCells.configureColumns(grid, COLUMN_WIDTHS, COLUMN_ALIGNMENTS);
+
+        getChildren().addAll(title, grid);
+        refresh();
     }
 
     /**
-     * Will be used to re-render the transaction list when buys, sales or
-     * week advances change the underlying model. No state to refresh yet.
+     * Picks up new transactions and the new current week whenever the
+     * model changes.
      */
     @Override
     public void onGameUpdated() {
-        // No-op until the table is added.
+        refresh();
     }
 
     /**
-     * Refreshes the section title when the active language changes.
+     * Refreshes the section title and rebuilds the table so column
+     * headers, badge labels and the empty-state message follow the
+     * active language.
      */
     @Override
     protected void onLanguageChanged() {
         title.setText(LanguageManager.get("transactions.title"));
+        refresh();
+    }
+
+    /**
+     * Rebuilds the table from scratch: clears the grid, adds the header
+     * row, then either renders a centered empty-state message or one
+     * row per transaction.
+     */
+    private void refresh() {
+        grid.getChildren().clear();
+        TableCells.addHeaderRow(grid, headerTexts());
+
+        TransactionArchive archive = gameService.getPlayer().getTransactionArchive();
+        int currentWeek = gameService.getExchange().getWeek();
+        List<Transaction> transactions = collectAll(archive, currentWeek);
+
+        if (transactions.isEmpty()) {
+            TableCells.renderEmptyState(
+                    grid, LanguageManager.get("transactions.empty"), COLUMN_COUNT);
+            return;
+        }
+
+        int row = 1;
+        for (Transaction transaction : transactions) {
+            addDataRow(row++, transaction);
+        }
+    }
+
+    /**
+     * Resolves the localized header text for each column. Returns a fresh
+     * array on every call so a language switch picks up new translations.
+     *
+     * @return one localized string per column
+     */
+    private String[] headerTexts() {
+        return new String[] {
+                LanguageManager.get("transactions.col.week"),
+                LanguageManager.get("transactions.col.company"),
+                LanguageManager.get("transactions.col.type"),
+                LanguageManager.get("transactions.col.quantity"),
+                LanguageManager.get("transactions.col.price"),
+                LanguageManager.get("transactions.col.commission"),
+                LanguageManager.get("transactions.col.tax"),
+                LanguageManager.get("transactions.col.amount")
+        };
+    }
+
+    /**
+     * Gathers every transaction in the archive from week 1 up to and
+     * including the current week, then sorts them oldest first so the
+     * table reads chronologically from top to bottom.
+     *
+     * @param archive     the archive to read transactions from
+     * @param currentWeek the current game week (inclusive upper bound)
+     * @return a chronologically sorted list of all transactions
+     */
+    private List<Transaction> collectAll(TransactionArchive archive, int currentWeek) {
+        List<Transaction> list = new ArrayList<>();
+        for (int week = 1; week <= currentWeek; week++) {
+            list.addAll(archive.getTransactions(week));
+        }
+        list.sort(Comparator.comparingInt(Transaction::getWeek));
+        return list;
+    }
+
+    /**
+     * Renders one transaction as a row in the table. Delegates value
+     * computation to {@link TransactionStatsService#getStats} so this method
+     * only deals with cell placement and formatting.
+     *
+     * @param row         the grid row index to write to
+     * @param transaction the transaction to render
+     */
+    private void addDataRow(int row, Transaction transaction) {
+        Stock stock = transaction.getShare().getStock();
+        TransactionStatsService.TransactionStats stats =
+                statsService.getStats(transaction, gameService.getCurrencyConverter());
+
+        grid.add(TableCells.data(MessageFormat.format(
+                LanguageManager.get("transactions.weekValue"), transaction.getWeek())), 0, row);
+        grid.add(TableCells.data(stock.getSymbol() + ", " + stock.getCompany()), 1, row);
+        grid.add(typeBadge(transaction), 2, row);
+        grid.add(TableCells.data(TableCells.NUMBER_FORMAT.format(stats.quantity())), 3, row);
+        grid.add(TableCells.data(TableCells.NUMBER_FORMAT.format(stats.pricePerShare())
+                + " " + stats.nativeCurrencyCode()), 4, row);
+        grid.add(TableCells.data(TableCells.NUMBER_FORMAT.format(stats.commissionNok()) + " NOK"), 5, row);
+        grid.add(taxCell(stats), 6, row);
+        grid.add(ChangeFormatter.styledAmount(stats.amountNok(), "holdings-cell"), 7, row);
+    }
+
+    /**
+     * Creates the pill-shaped type badge for a transaction. KJØP gets
+     * a light-blue colour scheme, SALG a light-green one.
+     *
+     * <p>Lives as a private helper for now; will be extracted into a
+     * reusable {@code TransactionTypeBadge} component once a second
+     * caller (receipts, details modal) needs it.</p>
+     *
+     * @param transaction the transaction to label
+     * @return a styled badge label
+     */
+    private Label typeBadge(Transaction transaction) {
+        boolean isPurchase = transaction instanceof Purchase;
+        String key = isPurchase ? "transactions.type.buy" : "transactions.type.sell";
+        Label badge = new Label(LanguageManager.get(key));
+        badge.getStyleClass().add("transaction-type-badge");
+        badge.getStyleClass().add(isPurchase ? "badge-buy" : "badge-sell");
+        return badge;
+    }
+
+    /**
+     * Renders the tax cell. Purchases have no tax, so the column shows
+     * an en-dash for visual cleanliness instead of "0,00 NOK".
+     *
+     * @param stats the row stats supplying the NOK tax amount
+     * @return a styled cell label
+     */
+    private Label taxCell(TransactionStatsService.TransactionStats stats) {
+        if (stats.taxNok().signum() == 0) {
+            return TableCells.data("–");
+        }
+        return TableCells.data(TableCells.NUMBER_FORMAT.format(stats.taxNok()) + " NOK");
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/card/TransactionsCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/card/TransactionsCard.java
@@ -46,7 +46,7 @@ public class TransactionsCard extends Card {
     private static final int COLUMN_COUNT = 8;
 
     /** Percentage widths for each column; sums to 100. */
-    private static final double[] COLUMN_WIDTHS = {8, 28, 10, 10, 12, 12, 10, 10};
+    private static final double[] COLUMN_WIDTHS = {8, 28, 6, 7, 12, 12, 13, 14};
 
     /**
      * Horizontal alignment per column: text columns (week, company, type)

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/card/TransactionsCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/card/TransactionsCard.java
@@ -1,0 +1,52 @@
+package edu.ntnu.idatt2003.millions.view.dashboard.transactions.card;
+
+import edu.ntnu.idatt2003.millions.service.GameService;
+import edu.ntnu.idatt2003.millions.util.LanguageManager;
+import edu.ntnu.idatt2003.millions.view.component.Card;
+import edu.ntnu.idatt2003.millions.view.component.StyledText;
+
+/**
+ * Dashboard card for the transactions tab.
+ *
+ * <p>Currently only renders the section title; filter controls, the table
+ * and per-row interactions will be layered on in follow-up changes. The
+ * card already registers itself as a game and language observer via the
+ * {@link Card} base class, so the scaffolding is in place even though
+ * {@link #onGameUpdated()} has nothing to update yet.</p>
+ */
+public class TransactionsCard extends Card {
+
+    private final StyledText title;
+
+    /**
+     * Constructs a new TransactionsCard.
+     *
+     * @param gameService the game manager containing player and exchange
+     */
+    public TransactionsCard(GameService gameService) {
+        super(gameService);
+
+        setSpacing(16);
+
+        title = StyledText.sectionTitle(LanguageManager.get("transactions.title"));
+
+        getChildren().add(title);
+    }
+
+    /**
+     * Will be used to re-render the transaction list when buys, sales or
+     * week advances change the underlying model. No state to refresh yet.
+     */
+    @Override
+    public void onGameUpdated() {
+        // No-op until the table is added.
+    }
+
+    /**
+     * Refreshes the section title when the active language changes.
+     */
+    @Override
+    protected void onLanguageChanged() {
+        title.setText(LanguageManager.get("transactions.title"));
+    }
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/component/WeekRangeFilter.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/component/WeekRangeFilter.java
@@ -1,0 +1,173 @@
+package edu.ntnu.idatt2003.millions.view.dashboard.transactions.component;
+
+import edu.ntnu.idatt2003.millions.util.LanguageManager;
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.ReadOnlyIntegerProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.geometry.Pos;
+import javafx.scene.control.Label;
+import javafx.scene.control.Spinner;
+import javafx.scene.control.SpinnerValueFactory;
+import javafx.scene.layout.HBox;
+
+/**
+ * Reusable inline week-range filter rendered as "Uke [from] – [to]".
+ *
+ * <p>The component owns two spinners — one for the start of the range
+ * and one for the (inclusive) end — and enforces {@code from <= to} by
+ * adjusting each spinner's bounds when the other side changes. That
+ * makes invalid ranges unreachable in the UI; callers never have to
+ * validate the values they read back.</p>
+ *
+ * <p>Communication with callers happens through two observable
+ * {@link IntegerProperty} values, the same pattern used elsewhere in
+ * the app (see {@code SearchField.textProperty()}). Callers register
+ * listeners on {@link #fromWeekProperty()} and {@link #toWeekProperty()}
+ * and read the current values via {@link #getFromWeek()} and
+ * {@link #getToWeek()} when they rebuild their filter predicate.</p>
+ *
+ * <p>The upper bound is dynamic: callers call {@link #setMaxWeek(int)}
+ * from their {@code onGameUpdated()} hook so that as the game advances,
+ * the user can pick weeks up to the new current week. The currently
+ * selected range is preserved; only the maximum selectable value moves.</p>
+ *
+ * <p>Designed first for the transactions tab, with reuse in mind for the
+ * watchlist and analysis views where week-based filtering also applies.</p>
+ */
+public class WeekRangeFilter extends HBox {
+
+    /** Preferred width for each spinner, in pixels. */
+    private static final int SPINNER_WIDTH = 72;
+
+    /** Horizontal spacing between the label, spinners and separator. */
+    private static final int SPACING = 8;
+
+    private final IntegerProperty fromWeek = new SimpleIntegerProperty();
+    private final IntegerProperty toWeek = new SimpleIntegerProperty();
+    private final Spinner<Integer> fromSpinner;
+    private final Spinner<Integer> toSpinner;
+    private final Label label;
+
+    private final int minWeek;
+
+    /**
+     * Constructs a new week range filter with the given absolute bounds.
+     * The initial selection covers the full range, i.e. {@code from = minWeek}
+     * and {@code to = maxWeek}, which represents "all weeks".
+     *
+     * @param minWeek the smallest selectable week (typically 1)
+     * @param maxWeek the largest selectable week (typically the current game week)
+     */
+    public WeekRangeFilter(int minWeek, int maxWeek) {
+        this.minWeek = minWeek;
+
+        setSpacing(SPACING);
+        setAlignment(Pos.CENTER_LEFT);
+        getStyleClass().add("week-range-filter");
+
+        label = new Label(LanguageManager.get("filter.week"));
+        label.getStyleClass().add("filter-label");
+
+        fromSpinner = createSpinner(minWeek, maxWeek, minWeek);
+        toSpinner = createSpinner(minWeek, maxWeek, maxWeek);
+
+        Label separator = new Label("–");
+        separator.getStyleClass().add("filter-separator");
+
+        wireSpinnerListeners();
+
+        // Initialise the exposed properties to match the spinners' starting
+        // values so callers can read them immediately after construction.
+        fromWeek.set(minWeek);
+        toWeek.set(maxWeek);
+
+        getChildren().addAll(label, fromSpinner, separator, toSpinner);
+
+        LanguageManager.addObserver(() -> label.setText(LanguageManager.get("filter.week")));
+    }
+
+    /**
+     * Creates a configured spinner with the given bounds and initial value.
+     *
+     * @param min     minimum selectable value
+     * @param max     maximum selectable value
+     * @param initial starting value
+     * @return a configured spinner with a fixed preferred width
+     */
+    private Spinner<Integer> createSpinner(int min, int max, int initial) {
+        Spinner<Integer> spinner = new Spinner<>(min, max, initial);
+        spinner.getStyleClass().add("week-spinner");
+        spinner.setEditable(true);
+        spinner.setPrefWidth(SPINNER_WIDTH);
+        return spinner;
+    }
+
+    /**
+     * Wires the two-way constraint that keeps {@code from <= to}.
+     *
+     * <p>When the user changes one endpoint, the opposite spinner's bound
+     * shifts so the new selection cannot create an invalid range. The
+     * exposed properties are updated to mirror the spinner values.</p>
+     */
+    private void wireSpinnerListeners() {
+        fromSpinner.valueProperty().addListener((obs, oldVal, newVal) -> {
+            fromWeek.set(newVal);
+            ((SpinnerValueFactory.IntegerSpinnerValueFactory)
+                    toSpinner.getValueFactory()).setMin(newVal);
+        });
+        toSpinner.valueProperty().addListener((obs, oldVal, newVal) -> {
+            toWeek.set(newVal);
+            ((SpinnerValueFactory.IntegerSpinnerValueFactory)
+                    fromSpinner.getValueFactory()).setMax(newVal);
+        });
+    }
+
+    /**
+     * Raises the upper bound of both spinners so the user can pick
+     * higher weeks. The currently selected range is preserved; only
+     * the maximum selectable value moves.
+     *
+     * <p>Typically called from a parent view's {@code onGameUpdated()}
+     * hook whenever the game advances to a new week.</p>
+     *
+     * @param newMax the new upper bound; ignored if smaller than the
+     *               configured minimum
+     */
+    public void setMaxWeek(int newMax) {
+        if (newMax < minWeek) {
+            return;
+        }
+        ((SpinnerValueFactory.IntegerSpinnerValueFactory)
+                fromSpinner.getValueFactory()).setMax(newMax);
+        ((SpinnerValueFactory.IntegerSpinnerValueFactory)
+                toSpinner.getValueFactory()).setMax(newMax);
+    }
+
+    /**
+     * @return observable property holding the start of the range
+     */
+    public ReadOnlyIntegerProperty fromWeekProperty() {
+        return fromWeek;
+    }
+
+    /**
+     * @return observable property holding the end of the range (inclusive)
+     */
+    public ReadOnlyIntegerProperty toWeekProperty() {
+        return toWeek;
+    }
+
+    /**
+     * @return the currently selected start week
+     */
+    public int getFromWeek() {
+        return fromWeek.get();
+    }
+
+    /**
+     * @return the currently selected end week (inclusive)
+     */
+    public int getToWeek() {
+        return toWeek.get();
+    }
+}

--- a/src/main/resources/css/filters.css
+++ b/src/main/resources/css/filters.css
@@ -1,0 +1,29 @@
+.filter-label {
+    -fx-font-size: 13px;
+    -fx-text-fill: text-secondary;
+}
+
+.filter-separator {
+    -fx-font-size: 14px;
+    -fx-text-fill: text-muted;
+    -fx-padding: 0 2 0 2;
+}
+
+.week-spinner {
+    -fx-font-size: 13px;
+}
+
+.week-spinner .text-field {
+    -fx-background-color: surface;
+    -fx-border-color: border;
+    -fx-border-radius: 4;
+    -fx-background-radius: 4;
+    -fx-padding: 4 6 4 6;
+    -fx-text-fill: text-primary;
+}
+
+.week-spinner .increment-arrow-button,
+.week-spinner .decrement-arrow-button {
+    -fx-background-color: surface-alt;
+    -fx-border-color: border;
+}

--- a/src/main/resources/css/style.css
+++ b/src/main/resources/css/style.css
@@ -8,3 +8,4 @@
 @import "modal.css";
 @import "utilities.css";
 @import "tooltip.css";
+@import "filters.css";

--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -189,3 +189,6 @@ transactions.col.tax=Tax
 transactions.col.amount=Amount
 transactions.weekValue=Week {0}
 transactions.empty=No transactions yet
+
+filter.week=Week
+

--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -175,3 +175,5 @@ tooltip.details.marketValueNok=The same market value converted to NOK at today's
 tooltip.shared.weeklyChange=Percentage change in the stock price since last week.
 tooltip.shared.returnPct=Gain or loss as a percentage: (market value ? purchase cost) / purchase cost. Based on average price (GAV) if you have bought the stock multiple times.
 tooltip.shared.returnNok=Market value minus purchase cost for your current position, converted to NOK.
+# Transactions
+transactions.title=Transactions

--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -177,3 +177,15 @@ tooltip.shared.returnPct=Gain or loss as a percentage: (market value ? purchase 
 tooltip.shared.returnNok=Market value minus purchase cost for your current position, converted to NOK.
 # Transactions
 transactions.title=Transactions
+transactions.type.buy=BUY
+transactions.type.sell=SELL
+transactions.col.week=Week
+transactions.col.company=Company
+transactions.col.type=Type
+transactions.col.quantity=Quantity
+transactions.col.price=Price
+transactions.col.commission=Commission
+transactions.col.tax=Tax
+transactions.col.amount=Amount
+transactions.weekValue=Week {0}
+transactions.empty=No transactions yet

--- a/src/main/resources/i18n/messages_no.properties
+++ b/src/main/resources/i18n/messages_no.properties
@@ -175,3 +175,5 @@ tooltip.details.marketValueNok=Samme markedsverdi omregnet til NOK via dagens va
 tooltip.shared.weeklyChange=Prosentvis endring i aksjekursen siden forrige uke.
 tooltip.shared.returnPct=Gevinst eller tap i prosent: (markedsverdi ? kjøpskostnad) / kjøpskostnad. Basert på snittpris (GAV) hvis du har kjøpt aksjen flere ganger.
 tooltip.shared.returnNok=Markedsverdi minus kjøpskostnad for din nåværende posisjon, omregnet til NOK.
+# Transactions
+transactions.title=Transaksjoner

--- a/src/main/resources/i18n/messages_no.properties
+++ b/src/main/resources/i18n/messages_no.properties
@@ -177,3 +177,15 @@ tooltip.shared.returnPct=Gevinst eller tap i prosent: (markedsverdi ? kjøpskostn
 tooltip.shared.returnNok=Markedsverdi minus kjøpskostnad for din nåværende posisjon, omregnet til NOK.
 # Transactions
 transactions.title=Transaksjoner
+transactions.type.buy=KJØP
+transactions.type.sell=SALG
+transactions.col.week=Uke
+transactions.col.company=Selskap
+transactions.col.type=Type
+transactions.col.quantity=Antall
+transactions.col.price=Kurs
+transactions.col.commission=Kurtasje
+transactions.col.tax=Skatt
+transactions.col.amount=Beløp
+transactions.weekValue=Uke {0}
+transactions.empty=Ingen transaksjoner enda

--- a/src/main/resources/i18n/messages_no.properties
+++ b/src/main/resources/i18n/messages_no.properties
@@ -189,3 +189,6 @@ transactions.col.tax=Skatt
 transactions.col.amount=Beløp
 transactions.weekValue=Uke {0}
 transactions.empty=Ingen transaksjoner enda
+
+filter.week=Uke
+


### PR DESCRIPTION
## What
Builds out the Transactions tab in the dashboard with a transaction history table and a week-range filter. Also includes a small refactor of `HoldingsCard` to share table helpers.

## Changes

### New tab: Transactions
- `TransactionsView` - thin container for the cards on this tab (mirrors `PortfolioView`)
- `TransactionsCard` - shows the title, filter row and a table of every transaction within the selected week range
- `TransactionStatsService` - stateless read service that derives the per-row values (quantity, price, commission, tax, amount). Lives in `service/` alongside `PlayerStatsService` and `PortfolioService`. Exposes a `TransactionStats` record.
  - Handles `Purchase.calculator` being transient (reconstructs via `PurchaseCalculator(share)` after load)
  - Converts native-currency values to NOK via `CurrencyConverter`

### Reusable component: WeekRangeFilter
- Located in `view/component/`
- "Uke [from] - [to]" with two spinners; enforces `from <= to` internally
- Exposes `fromWeekProperty()` and `toWeekProperty()` so callers can listen for changes
- `setMaxWeek(int)` lets the parent view raise the upper bound when the game advances
- Uses `Card` typography and listens to language changes itself

### Reusable utility: TableCells
- Located in `util/` next to `ChangeFormatter` (same pattern: stateless helper that produces styled `Label` nodes)
- Three cell factories: `header(text)`, `data(text)`, `empty(text)`
- Three grid helpers: `configureColumns(grid, widths, alignments)`, `addHeaderRow(grid, headers)`, `renderEmptyState(grid, message, columnCount)`
- Shared `NUMBER_FORMAT` (Norwegian locale, `#,##0.00`)

### Refactor: HoldingsCard
- Now uses `TableCells` for column setup, header row, cell factories and empty state
- Removes duplicated boilerplate while keeping the same visual output