### PR TITLE
feat: transactions tab - filters, summary, and activity cards

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/millions/service/TransactionStatsService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/TransactionStatsService.java
@@ -10,10 +10,12 @@ import edu.ntnu.idatt2003.millions.model.transaction.Transaction;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.Currency;
+import java.util.List;
 
 /**
- * Stateless read service that derives the per-transaction values displayed
- * in the transactions table.
+ * Stateless read service that derives the values displayed in the
+ * transactions tab — both per-transaction figures for the history
+ * table and aggregated totals for the summary card.
  *
  * <p>Sits alongside {@code PlayerStatsService}, {@code PortfolioService}
  * and {@code RealizedReturnsService}: like them, it holds no state, takes
@@ -23,7 +25,7 @@ import java.util.Currency;
  * computation crosses {@link Transaction}, {@link Share}, the calculator
  * tied to its subclass, and the active {@link CurrencyConverter}.</p>
  *
- * <p>Two pieces of irregularity are encapsulated here so the table doesn't
+ * <p>Two pieces of irregularity are encapsulated here so the view doesn't
  * have to know about them:</p>
  * <ul>
  *   <li><b>Frozen vs. recomputed values.</b> {@link Sale} freezes its
@@ -61,6 +63,43 @@ public class TransactionStatsService {
             return statsForSale(sale, share, nativeCurrency, converter);
         }
         return statsForPurchase(share, nativeCurrency, converter);
+    }
+
+    /**
+     * Aggregates a list of transactions into Kjøp / Salg / Total figures
+     * in NOK, ready to be rendered in the summary card.
+     *
+     * <p>The aggregation reuses {@link #getStats} per transaction so the
+     * summary stays consistent with the table: a transaction's
+     * {@code amountNok} is already negative for purchases and positive
+     * for sales. The summary therefore exposes {@code purchasesNok} as
+     * a non-positive sum of outflows, {@code salesNok} as a non-negative
+     * sum of inflows, and {@code totalNok} as their sum — i.e. the net
+     * cash flow over the range.</p>
+     *
+     * <p>If the input list is empty all three values are zero. Filtering
+     * by week range is the caller's responsibility; this service holds
+     * no view-state.</p>
+     *
+     * @param transactions the transactions to aggregate
+     * @param converter    the active currency converter
+     * @return summary totals in NOK
+     */
+    public TransactionSummary getSummary(List<Transaction> transactions, CurrencyConverter converter) {
+        BigDecimal purchasesNok = BigDecimal.ZERO;
+        BigDecimal salesNok = BigDecimal.ZERO;
+
+        for (Transaction transaction : transactions) {
+            TransactionStats stats = getStats(transaction, converter);
+            if (transaction instanceof Purchase) {
+                purchasesNok = purchasesNok.add(stats.amountNok());
+            } else {
+                salesNok = salesNok.add(stats.amountNok());
+            }
+        }
+
+        BigDecimal totalNok = purchasesNok.add(salesNok);
+        return new TransactionSummary(purchasesNok, salesNok, totalNok);
     }
 
     /**
@@ -154,5 +193,23 @@ public class TransactionStatsService {
             String nativeCurrencyCode,
             BigDecimal commissionNative,
             BigDecimal taxNative
+    ) {}
+
+    /**
+     * Aggregate totals for the transactions tab summary card.
+     *
+     * <p>{@code purchasesNok} is non-positive (sum of outflows from
+     * purchases), {@code salesNok} is non-negative (sum of inflows
+     * from sales), and {@code totalNok} is simply {@code purchasesNok +
+     * salesNok} — the net cash flow over the aggregated range.</p>
+     *
+     * @param purchasesNok total purchase outflow, NOK (non-positive)
+     * @param salesNok     total sale inflow, NOK (non-negative)
+     * @param totalNok     net cash flow, NOK
+     */
+    public record TransactionSummary(
+            BigDecimal purchasesNok,
+            BigDecimal salesNok,
+            BigDecimal totalNok
     ) {}
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/util/LanguageManager.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/util/LanguageManager.java
@@ -78,6 +78,6 @@ public class LanguageManager {
         Objects.requireNonNull(language, "Language cannot be null");
         currentLanguage = language;
         bundle = ResourceBundle.getBundle("i18n/messages", language.locale);
-        observers.forEach(Runnable::run);
+        List.copyOf(observers).forEach(Runnable::run);
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/DashboardView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/DashboardView.java
@@ -24,6 +24,9 @@ public class DashboardView extends VBox {
     private final Runnable onExploreStocks;
     private final VBox contentArea;
 
+    private PortfolioView portfolioView;
+    private TransactionsView transactionsView;
+
     /**
      * Constructs a new DashboardView with a tab bar.
      *
@@ -63,12 +66,17 @@ public class DashboardView extends VBox {
     }
 
     private void showPortfolio() {
-        contentArea.getChildren().setAll(
-                new PortfolioView(gameService, portfolioController, onExploreStocks));
+        if (portfolioView == null) {
+            portfolioView = new PortfolioView(gameService, portfolioController, onExploreStocks);
+        }
+        contentArea.getChildren().setAll(portfolioView);
     }
 
     private void showTransactions() {
-        contentArea.getChildren().setAll(new TransactionsView(gameService));
+        if (transactionsView == null) {
+            transactionsView = new TransactionsView(gameService);
+        }
+        contentArea.getChildren().setAll(transactionsView);
     }
 
     private void showWatchlist() {

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/TransactionsView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/TransactionsView.java
@@ -1,58 +1,71 @@
 package edu.ntnu.idatt2003.millions.view.dashboard.transactions;
 
 import edu.ntnu.idatt2003.millions.service.GameService;
+import edu.ntnu.idatt2003.millions.view.dashboard.transactions.card.TransactionsActivityCard;
 import edu.ntnu.idatt2003.millions.view.dashboard.transactions.card.TransactionsCard;
 import edu.ntnu.idatt2003.millions.view.dashboard.transactions.card.TransactionsSummaryCard;
 import edu.ntnu.idatt2003.millions.view.dashboard.transactions.component.WeekRangeFilter;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 
 /**
  * The transactions tab view shown under the dashboard.
  *
  * <p>Acts as a thin container for the cards on this tab — a
- * {@link TransactionsCard} with the history table, followed by a
- * {@link TransactionsSummaryCard} with aggregated totals for the
- * same week range. A trading-activity counter card will be placed
- * next to the summary card in a horizontal row once it lands; until
- * then the summary card spans the full width. This mirrors how
- * {@code PortfolioView} stacks its cards.</p>
+ * {@link TransactionsCard} with the history table on top, followed
+ * by a row of two cards: a {@link TransactionsSummaryCard} showing
+ * NOK totals on the left and a {@link TransactionsActivityCard} showing
+ * transaction counts on the right. The two bottom cards share the
+ * full width 50/50 and read as a pair: one tells the user how much
+ * money moved, the other how many trades they made.</p>
  *
  * <p>The view owns a single {@link WeekRangeFilter} instance and
- * hands it to both cards. The summary always reflects what the
- * user sees in the table, which is the natural reading of
- * "summary of transactions" — picking a separate range for the
- * summary would be a confusing UX where the two cards on the same
- * tab show data for different periods. The filter widget itself
- * is rendered inside {@code TransactionsCard}, in its filter row;
- * the summary card only shows the current range as a read-only
- * "Uke {from}-{to}" label, so the same filter visibly drives both
- * cards without being duplicated on screen.</p>
+ * hands it to all three cards. The summary and activity cards
+ * always reflect the period the table shows; picking three
+ * different ranges on one tab would be a confusing UX. The filter
+ * widget itself is rendered inside {@code TransactionsCard}'s
+ * filter row, and the summary and activity cards each show the
+ * current range as a read-only "UKE {from}-{to}" label.</p>
  *
  * <p>The view itself owns no observers: each card it contains is
  * self-sufficient and reacts to game and language changes through
- * its own observer registration. The view forwards game updates to
- * the filter so the spinner's upper bound advances with the game.</p>
+ * its own observer registration.</p>
  */
 public class TransactionsView extends VBox {
 
-    /** Spacing between the two cards on the tab. */
-    private static final int CARD_SPACING = 16;
+    /** Spacing between the table card and the summary row below. */
+    private static final int VERTICAL_SPACING = 16;
+
+    /** Spacing between the two cards in the bottom row. */
+    private static final int HORIZONTAL_SPACING = 16;
 
     /**
      * Constructs a new TransactionsView and wires the shared filter
-     * into both cards.
+     * into all three cards.
      *
      * @param gameService the game manager containing player and exchange
      */
     public TransactionsView(GameService gameService) {
-        setSpacing(CARD_SPACING);
+        setSpacing(VERTICAL_SPACING);
 
         int currentWeek = Math.max(gameService.getExchange().getWeek(), 1);
         WeekRangeFilter sharedFilter = new WeekRangeFilter(1, currentWeek);
 
         TransactionsCard transactionsCard = new TransactionsCard(gameService, sharedFilter);
         TransactionsSummaryCard summaryCard = new TransactionsSummaryCard(gameService, sharedFilter);
+        TransactionsActivityCard activityCard = new TransactionsActivityCard(gameService, sharedFilter);
 
-        getChildren().addAll(transactionsCard, summaryCard);
+        HBox.setHgrow(summaryCard, Priority.ALWAYS);
+        HBox.setHgrow(activityCard, Priority.ALWAYS);
+        // Set minWidth to 0 so the cards can shrink below their preferred
+        // size on narrow viewports without pushing each other off-screen;
+        // Priority.ALWAYS alone keeps them expanded, but not collapsible.
+        summaryCard.setMinWidth(0);
+        activityCard.setMinWidth(0);
+
+        HBox bottomRow = new HBox(HORIZONTAL_SPACING, summaryCard, activityCard);
+
+        getChildren().addAll(transactionsCard, bottomRow);
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/TransactionsView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/TransactionsView.java
@@ -2,33 +2,57 @@ package edu.ntnu.idatt2003.millions.view.dashboard.transactions;
 
 import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.view.dashboard.transactions.card.TransactionsCard;
+import edu.ntnu.idatt2003.millions.view.dashboard.transactions.card.TransactionsSummaryCard;
+import edu.ntnu.idatt2003.millions.view.dashboard.transactions.component.WeekRangeFilter;
 import javafx.scene.layout.VBox;
 
 /**
  * The transactions tab view shown under the dashboard.
  *
- * <p>Acts as a thin container for the cards on this tab — currently a
- * single {@link TransactionsCard}, with room to add more cards (summary
- * widgets, charts, etc.) below it without restructuring the view. This
- * mirrors {@code PortfolioView}, which lays out a stack of cards the
- * same way.</p>
+ * <p>Acts as a thin container for the cards on this tab — a
+ * {@link TransactionsCard} with the history table, followed by a
+ * {@link TransactionsSummaryCard} with aggregated totals for the
+ * same week range. A trading-activity counter card will be placed
+ * next to the summary card in a horizontal row once it lands; until
+ * then the summary card spans the full width. This mirrors how
+ * {@code PortfolioView} stacks its cards.</p>
  *
- * <p>The view itself owns no state and no observers: each card it
- * contains is self-sufficient and reacts to game and language changes
- * through its own observer registration.</p>
+ * <p>The view owns a single {@link WeekRangeFilter} instance and
+ * hands it to both cards. The summary always reflects what the
+ * user sees in the table, which is the natural reading of
+ * "summary of transactions" — picking a separate range for the
+ * summary would be a confusing UX where the two cards on the same
+ * tab show data for different periods. The filter widget itself
+ * is rendered inside {@code TransactionsCard}, in its filter row;
+ * the summary card only shows the current range as a read-only
+ * "Uke {from}-{to}" label, so the same filter visibly drives both
+ * cards without being duplicated on screen.</p>
+ *
+ * <p>The view itself owns no observers: each card it contains is
+ * self-sufficient and reacts to game and language changes through
+ * its own observer registration. The view forwards game updates to
+ * the filter so the spinner's upper bound advances with the game.</p>
  */
 public class TransactionsView extends VBox {
 
+    /** Spacing between the two cards on the tab. */
+    private static final int CARD_SPACING = 16;
+
     /**
-     * Constructs a new TransactionsView and adds its cards.
+     * Constructs a new TransactionsView and wires the shared filter
+     * into both cards.
      *
      * @param gameService the game manager containing player and exchange
      */
     public TransactionsView(GameService gameService) {
-        setSpacing(16);
+        setSpacing(CARD_SPACING);
 
-        TransactionsCard transactionsCard = new TransactionsCard(gameService);
+        int currentWeek = Math.max(gameService.getExchange().getWeek(), 1);
+        WeekRangeFilter sharedFilter = new WeekRangeFilter(1, currentWeek);
 
-        getChildren().add(transactionsCard);
+        TransactionsCard transactionsCard = new TransactionsCard(gameService, sharedFilter);
+        TransactionsSummaryCard summaryCard = new TransactionsSummaryCard(gameService, sharedFilter);
+
+        getChildren().addAll(transactionsCard, summaryCard);
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/card/TransactionsActivityCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/card/TransactionsActivityCard.java
@@ -1,0 +1,227 @@
+package edu.ntnu.idatt2003.millions.view.dashboard.transactions.card;
+
+import edu.ntnu.idatt2003.millions.service.GameService;
+import edu.ntnu.idatt2003.millions.model.transaction.TransactionArchive;
+import edu.ntnu.idatt2003.millions.util.LanguageManager;
+import edu.ntnu.idatt2003.millions.util.TableCells;
+import edu.ntnu.idatt2003.millions.view.component.Card;
+import edu.ntnu.idatt2003.millions.view.component.StyledText;
+import edu.ntnu.idatt2003.millions.view.dashboard.transactions.component.WeekRangeFilter;
+import javafx.geometry.HPos;
+import javafx.geometry.Pos;
+import javafx.scene.control.Label;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
+
+import java.text.MessageFormat;
+
+/**
+ * Dashboard card that counts the user's trading activity over the
+ * week range selected in {@code TransactionsCard}: number of
+ * purchases, number of sales, and their sum.
+ *
+ * <p>Sits beside {@code TransactionsSummaryCard} on the transactions
+ * tab. Where the summary card answers "how much money moved", this
+ * card answers "how often did I trade" — two different questions
+ * over the same period, so the two cards complement each other
+ * rather than overlap.</p>
+ *
+ * <p>Layout mirrors the summary card exactly: section title on the
+ * left, read-only "UKE {from}-{to}" label on the right, then Kjøp /
+ * Salg / Total rows separated by the same divider {@code HoldingsCard}
+ * uses for its total row. Sharing the structure keeps the two cards
+ * reading as a visual family.</p>
+ *
+ * <p>The card does not own a filter widget. It listens to the
+ * {@link WeekRangeFilter} that {@code TransactionsView} created and
+ * handed to all three components on the tab (the table card, the
+ * summary card, and this card), so they always show data for the
+ * same period. The spinner lives in {@code TransactionsCard}; this
+ * card only echoes the current range as a label.</p>
+ *
+ * <p>Counts come straight from {@link TransactionArchive#getPurchases}
+ * and {@link TransactionArchive#getSales}. No conversion or
+ * aggregation service is needed — these are plain list sizes.</p>
+ */
+public class TransactionsActivityCard extends Card {
+
+    /** Spacing between the header row and the value grid. */
+    private static final int CARD_SPACING = 16;
+
+    /** Horizontal gap between label and value columns in the value grid. */
+    private static final int VALUE_HGAP = 20;
+
+    /**
+     * Column widths for the two-column value grid. Left column carries
+     * the label, right column the integer count, right-aligned so
+     * digits stack cleanly across the three rows.
+     */
+    private static final double[] COLUMN_WIDTHS = {50, 50};
+
+    /** Left-aligned labels, right-aligned values. */
+    private static final HPos[] COLUMN_ALIGNMENTS = {HPos.LEFT, HPos.RIGHT};
+
+    private final GameService gameService;
+    private final WeekRangeFilter weekRangeFilter;
+
+    private final StyledText title;
+    private final StyledText weekRangeLabel;
+    private final GridPane grid = new GridPane();
+
+    /**
+     * Constructs a new TradingActivityCard.
+     *
+     * @param gameService     the game manager containing player and exchange
+     * @param weekRangeFilter the shared filter that scopes the table this
+     *                        card counts against; the card listens to it
+     *                        but does not render its spinner widget
+     */
+    public TransactionsActivityCard(GameService gameService, WeekRangeFilter weekRangeFilter) {
+        super(gameService);
+        this.gameService = gameService;
+        this.weekRangeFilter = weekRangeFilter;
+
+        setSpacing(CARD_SPACING);
+
+        title = StyledText.sectionTitle(LanguageManager.get("transactions.activity.title"));
+        weekRangeLabel = StyledText.weekLabel();
+
+        weekRangeFilter.fromWeekProperty().addListener((obs, oldVal, newVal) -> refresh());
+        weekRangeFilter.toWeekProperty().addListener((obs, oldVal, newVal) -> refresh());
+
+        HBox header = buildHeader();
+
+        grid.setHgap(VALUE_HGAP);
+        TableCells.configureColumns(grid, COLUMN_WIDTHS, COLUMN_ALIGNMENTS);
+
+        getChildren().addAll(header, grid);
+        refresh();
+    }
+
+    /**
+     * Builds the title row: section title on the left, a flexible
+     * spacer in the middle, and the read-only "UKE {from}-{to}" label
+     * on the right.
+     *
+     * @return the configured header row
+     */
+    private HBox buildHeader() {
+        Region spacer = new Region();
+        HBox.setHgrow(spacer, Priority.ALWAYS);
+
+        HBox header = new HBox(title, spacer, weekRangeLabel);
+        header.setAlignment(Pos.CENTER_LEFT);
+        return header;
+    }
+
+    /**
+     * Picks up new transactions whenever the model changes. The
+     * filter's upper bound is bumped by {@code TransactionsCard}, so
+     * this card only needs to recount.
+     */
+    @Override
+    public void onGameUpdated() {
+        refresh();
+    }
+
+    /**
+     * Refreshes title, week-range label, and the row contents so
+     * everything follows the active language.
+     */
+    @Override
+    protected void onLanguageChanged() {
+        title.setText(LanguageManager.get("transactions.activity.title"));
+        refresh();
+    }
+
+    /**
+     * Rebuilds the value rows from the current filter selection and
+     * updates the header's week-range label. The three rows (Kjøp,
+     * Salg, Total) follow the same divider pattern {@code HoldingsCard}
+     * uses, so this card reads as part of the same visual family as
+     * the summary card next to it.
+     */
+    private void refresh() {
+        int fromWeek = weekRangeFilter.getFromWeek();
+        int toWeek = weekRangeFilter.getToWeek();
+
+        weekRangeLabel.setText(MessageFormat.format(
+                LanguageManager.get("transactions.summary.weekRange"), fromWeek, toWeek));
+
+        int purchaseCount = countTransactions(fromWeek, toWeek, true);
+        int saleCount = countTransactions(fromWeek, toWeek, false);
+        int total = purchaseCount + saleCount;
+
+        grid.getChildren().clear();
+
+        grid.add(rowLabel(LanguageManager.get("transactions.summary.purchases"), false), 0, 0);
+        grid.add(rowValue(purchaseCount, false), 1, 0);
+
+        grid.add(rowLabel(LanguageManager.get("transactions.summary.sales"), false), 0, 1);
+        grid.add(rowValue(saleCount, false), 1, 1);
+
+        Region divider = new Region();
+        divider.getStyleClass().add("holdings-total-divider");
+        GridPane.setColumnSpan(divider, 2);
+        grid.add(divider, 0, 2);
+
+        grid.add(rowLabel(LanguageManager.get("transactions.summary.total"), true), 0, 3);
+        grid.add(rowValue(total, true), 1, 3);
+    }
+
+    /**
+     * Counts the purchases or sales in the archive within the given
+     * week range (inclusive on both ends).
+     *
+     * @param fromWeek    the first week to include (inclusive)
+     * @param toWeek      the last week to include (inclusive)
+     * @param countBuys   {@code true} to count purchases, {@code false}
+     *                    to count sales
+     * @return the total number of matching transactions in the range
+     */
+    private int countTransactions(int fromWeek, int toWeek, boolean countBuys) {
+        TransactionArchive archive = gameService.getPlayer().getTransactionArchive();
+        int total = 0;
+        for (int week = fromWeek; week <= toWeek; week++) {
+            total += countBuys
+                    ? archive.getPurchases(week).size()
+                    : archive.getSales(week).size();
+        }
+        return total;
+    }
+
+    /**
+     * Creates a label for the leftmost column. Bold variant is used for
+     * the total row to match the {@code HoldingsCard} total-row styling.
+     *
+     * @param text the label text
+     * @param bold whether to apply the bold modifier
+     * @return a styled label
+     */
+    private Label rowLabel(String text, boolean bold) {
+        Label label = TableCells.data(text);
+        if (bold) {
+            label.getStyleClass().add("bold");
+        }
+        return label;
+    }
+
+    /**
+     * Creates a plain integer count label for the rightmost column.
+     * No sign or unit — these are activity counts, not signed amounts,
+     * so they read cleanly as "5", "3", "8" rather than "+5", "+3", "+8".
+     *
+     * @param count the value to render
+     * @param bold  whether to apply the bold modifier
+     * @return a styled label
+     */
+    private Label rowValue(int count, boolean bold) {
+        Label label = TableCells.data(Integer.toString(count));
+        if (bold) {
+            label.getStyleClass().add("bold");
+        }
+        return label;
+    }
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/card/TransactionsActivityCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/card/TransactionsActivityCard.java
@@ -71,7 +71,7 @@ public class TransactionsActivityCard extends Card {
     private final GridPane grid = new GridPane();
 
     /**
-     * Constructs a new TradingActivityCard.
+     * Constructs a new TransactionsActivityCard.
      *
      * @param gameService     the game manager containing player and exchange
      * @param weekRangeFilter the shared filter that scopes the table this

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/card/TransactionsCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/card/TransactionsCard.java
@@ -60,7 +60,7 @@ public class TransactionsCard extends Card {
     private static final int COLUMN_COUNT = 8;
 
     /** Percentage widths for each column; sums to 100. */
-    private static final double[] COLUMN_WIDTHS = {8, 28, 6, 7, 12, 12, 13, 14};
+    private static final double[] COLUMN_WIDTHS = {8, 26, 8, 7, 12, 12, 13, 14};
 
     /**
      * Horizontal alignment per column: text columns (week, company, type)

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/card/TransactionsCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/card/TransactionsCard.java
@@ -35,6 +35,14 @@ import java.util.List;
  * (all / buy / sell) and a {@link WeekRangeFilter}; a search field can
  * be added to the same row later without restructuring the card.</p>
  *
+ * <p>The {@link WeekRangeFilter} is supplied by {@code TransactionsView}
+ * and shared with {@code TransactionsSummaryCard} so both cards on the
+ * tab show data for the same period. This card owns the visible spinner
+ * widget; the summary card only echoes the current range as a read-only
+ * label. The type filter, on the other hand, is local to this card —
+ * the summary's whole purpose is to compare purchases against sales, so
+ * filtering it by type would zero out one of the two rows.</p>
+ *
  * <p>Shares structure and CSS with {@code HoldingsCard} via
  * {@link TableCells} (column setup, header row, cell factories, empty
  * state), {@link ChangeFormatter} (coloured signed amounts) and the
@@ -74,11 +82,14 @@ public class TransactionsCard extends Card {
     /**
      * Constructs a new TransactionsCard.
      *
-     * @param gameService the game manager containing player and exchange
+     * @param gameService     the game manager containing player and exchange
+     * @param weekRangeFilter the shared filter that scopes both this card's
+     *                        table and the summary card's totals
      */
-    public TransactionsCard(GameService gameService) {
+    public TransactionsCard(GameService gameService, WeekRangeFilter weekRangeFilter) {
         super(gameService);
         this.gameService = gameService;
+        this.weekRangeFilter = weekRangeFilter;
 
         setSpacing(16);
 
@@ -87,8 +98,6 @@ public class TransactionsCard extends Card {
         typeFilter = new TransactionTypeFilter();
         typeFilter.selectedTypeProperty().addListener((obs, oldVal, newVal) -> refresh());
 
-        int currentWeek = Math.max(gameService.getExchange().getWeek(), 1);
-        weekRangeFilter = new WeekRangeFilter(1, currentWeek);
         weekRangeFilter.fromWeekProperty().addListener((obs, oldVal, newVal) -> refresh());
         weekRangeFilter.toWeekProperty().addListener((obs, oldVal, newVal) -> refresh());
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/card/TransactionsCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/card/TransactionsCard.java
@@ -150,6 +150,7 @@ public class TransactionsCard extends Card {
      */
     private void refresh() {
         grid.getChildren().clear();
+        if (gameService.getPlayer() == null) return;
         TableCells.addHeaderRow(grid, headerTexts());
 
         TransactionArchive archive = gameService.getPlayer().getTransactionArchive();

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/card/TransactionsCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/card/TransactionsCard.java
@@ -11,6 +11,7 @@ import edu.ntnu.idatt2003.millions.util.LanguageManager;
 import edu.ntnu.idatt2003.millions.util.TableCells;
 import edu.ntnu.idatt2003.millions.view.component.Card;
 import edu.ntnu.idatt2003.millions.view.component.StyledText;
+import edu.ntnu.idatt2003.millions.view.dashboard.transactions.component.TransactionTypeFilter;
 import edu.ntnu.idatt2003.millions.view.dashboard.transactions.component.WeekRangeFilter;
 import javafx.geometry.HPos;
 import javafx.geometry.Pos;
@@ -29,10 +30,10 @@ import java.util.List;
  * Dashboard card for the transactions tab.
  *
  * <p>Renders the section title, a filter row, and a table of every
- * committed transaction within the selected week range, sorted oldest
- * first. The filter row currently holds a {@link WeekRangeFilter}; the
- * search field and type dropdown will be added later in the same row
- * without restructuring the card.</p>
+ * committed transaction within the current filter selection, sorted
+ * oldest first. The filter row holds a {@link TransactionTypeFilter}
+ * (all / buy / sell) and a {@link WeekRangeFilter}; a search field can
+ * be added to the same row later without restructuring the card.</p>
  *
  * <p>Shares structure and CSS with {@code HoldingsCard} via
  * {@link TableCells} (column setup, header row, cell factories, empty
@@ -66,6 +67,7 @@ public class TransactionsCard extends Card {
     private final GameService gameService;
     private final TransactionStatsService statsService = new TransactionStatsService();
     private final StyledText title;
+    private final TransactionTypeFilter typeFilter;
     private final WeekRangeFilter weekRangeFilter;
     private final GridPane grid = new GridPane();
 
@@ -81,6 +83,9 @@ public class TransactionsCard extends Card {
         setSpacing(16);
 
         title = StyledText.sectionTitle(LanguageManager.get("transactions.title"));
+
+        typeFilter = new TransactionTypeFilter();
+        typeFilter.selectedTypeProperty().addListener((obs, oldVal, newVal) -> refresh());
 
         int currentWeek = Math.max(gameService.getExchange().getWeek(), 1);
         weekRangeFilter = new WeekRangeFilter(1, currentWeek);
@@ -99,9 +104,10 @@ public class TransactionsCard extends Card {
     /**
      * Builds the filter row that sits between the title and the table.
      *
-     * <p>The week range filter is pushed to the right edge with a flexible
-     * spacer so future filter controls (search field, type dropdown) can
-     * be inserted on the left without affecting alignment.</p>
+     * <p>Both filters sit together on the left edge with a small gap
+     * between them; a flexible spacer takes up the remaining width so
+     * future filter controls can be inserted next to the existing ones
+     * without disturbing the layout.</p>
      *
      * @return the configured filter row
      */
@@ -109,7 +115,7 @@ public class TransactionsCard extends Card {
         Region spacer = new Region();
         HBox.setHgrow(spacer, Priority.ALWAYS);
 
-        HBox row = new HBox(16, spacer, weekRangeFilter);
+        HBox row = new HBox(36, typeFilter, weekRangeFilter, spacer);
         row.setAlignment(Pos.CENTER_LEFT);
         row.getStyleClass().add("transactions-filter-row");
         return row;
@@ -140,7 +146,7 @@ public class TransactionsCard extends Card {
     /**
      * Rebuilds the table from scratch: clears the grid, adds the header
      * row, then either renders a centered empty-state message or one
-     * row per transaction within the selected week range.
+     * row per transaction that passes the current filters.
      */
     private void refresh() {
         grid.getChildren().clear();
@@ -149,7 +155,11 @@ public class TransactionsCard extends Card {
         TransactionArchive archive = gameService.getPlayer().getTransactionArchive();
         int fromWeek = weekRangeFilter.getFromWeek();
         int toWeek = weekRangeFilter.getToWeek();
-        List<Transaction> transactions = collectRange(archive, fromWeek, toWeek);
+        Class<? extends Transaction> selectedType = typeFilter.getSelectedType();
+
+        List<Transaction> transactions = collectRange(archive, fromWeek, toWeek).stream()
+                .filter(t -> selectedType == null || selectedType.isInstance(t))
+                .toList();
 
         if (transactions.isEmpty()) {
             TableCells.renderEmptyState(

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/card/TransactionsSummaryCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/card/TransactionsSummaryCard.java
@@ -1,0 +1,248 @@
+package edu.ntnu.idatt2003.millions.view.dashboard.transactions.card;
+
+import edu.ntnu.idatt2003.millions.service.GameService;
+import edu.ntnu.idatt2003.millions.service.TransactionStatsService;
+import edu.ntnu.idatt2003.millions.model.transaction.Transaction;
+import edu.ntnu.idatt2003.millions.model.transaction.TransactionArchive;
+import edu.ntnu.idatt2003.millions.util.LanguageManager;
+import edu.ntnu.idatt2003.millions.util.TableCells;
+import edu.ntnu.idatt2003.millions.view.component.Card;
+import edu.ntnu.idatt2003.millions.view.component.StyledText;
+import edu.ntnu.idatt2003.millions.view.dashboard.transactions.component.WeekRangeFilter;
+import javafx.geometry.HPos;
+import javafx.geometry.Pos;
+import javafx.scene.control.Label;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
+
+import java.math.BigDecimal;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Dashboard card that summarises the user's transactions over the
+ * week range selected in {@code TransactionsCard}: total purchase
+ * outflow, total sale inflow, and the net of the two.
+ *
+ * <p>Layout: a header row with the section title on the left and a
+ * read-only "Uke {from}–{to}" label on the right, followed by three
+ * label/value rows (Kjøp, Salg, Total). The Total row is separated
+ * from the others by the same divider {@code HoldingsCard} uses for
+ * its total row, so the two cards read as part of the same visual
+ * family.</p>
+ *
+ * <p>The card does not own a filter widget. It listens to the
+ * {@link WeekRangeFilter} that {@code TransactionsView} created and
+ * handed to both cards on the tab, so the summary always reflects
+ * the same period the table shows. The spinner widget itself lives
+ * inside {@code TransactionsCard}'s filter row; rendering it a
+ * second time here would duplicate a control without adding any
+ * functionality, and letting the summary have its own range would
+ * make two cards on the same tab show data for different periods —
+ * a confusing UX. The card shows the range as a plain "Uke
+ * {from}–{to}" label that updates the moment the user changes the
+ * spinner in the table card above.</p>
+ *
+ * <p>The type filter from the transactions table is intentionally
+ * not applied here either: the whole point of the summary is to
+ * compare purchases against sales, so filtering to one type would
+ * zero out the other row and remove the comparison this card exists
+ * to show.</p>
+ *
+ * <p>All aggregation is delegated to
+ * {@link TransactionStatsService#getSummary} so the card stays a thin
+ * presentation layer over a stateless read service.</p>
+ */
+public class TransactionsSummaryCard extends Card {
+
+    /** Spacing between the header row and the value grid. */
+    private static final int CARD_SPACING = 16;
+
+    /** Horizontal gap between label and value columns in the value grid. */
+    private static final int VALUE_HGAP = 20;
+
+    /**
+     * Column widths for the two-column value grid. Left column carries
+     * the label ("Kjøp" / "Salg" / "Total"), right column the NOK amount
+     * right-aligned to keep digits aligned across the three rows.
+     */
+    private static final double[] COLUMN_WIDTHS = {50, 50};
+
+    /** Left-aligned labels, right-aligned values. */
+    private static final HPos[] COLUMN_ALIGNMENTS = {HPos.LEFT, HPos.RIGHT};
+
+    private final GameService gameService;
+    private final TransactionStatsService statsService = new TransactionStatsService();
+    private final WeekRangeFilter weekRangeFilter;
+
+    private final StyledText title;
+    private final StyledText weekRangeLabel;
+    private final GridPane grid = new GridPane();
+
+    /**
+     * Constructs a new TransactionsSummaryCard.
+     *
+     * @param gameService     the game manager containing player and exchange
+     * @param weekRangeFilter the shared filter that scopes the table this
+     *                        card summarises; the card listens to it but
+     *                        does not render its spinner widget
+     */
+    public TransactionsSummaryCard(GameService gameService, WeekRangeFilter weekRangeFilter) {
+        super(gameService);
+        this.gameService = gameService;
+        this.weekRangeFilter = weekRangeFilter;
+
+        setSpacing(CARD_SPACING);
+
+        title = StyledText.sectionTitle(LanguageManager.get("transactions.summary.title"));
+        weekRangeLabel = StyledText.weekLabel();
+
+        weekRangeFilter.fromWeekProperty().addListener((obs, oldVal, newVal) -> refresh());
+        weekRangeFilter.toWeekProperty().addListener((obs, oldVal, newVal) -> refresh());
+
+        HBox header = buildHeader();
+
+        grid.setHgap(VALUE_HGAP);
+        TableCells.configureColumns(grid, COLUMN_WIDTHS, COLUMN_ALIGNMENTS);
+
+        getChildren().addAll(header, grid);
+        refresh();
+    }
+
+    /**
+     * Builds the title row: section title on the left, a flexible
+     * spacer in the middle, and a read-only "Uke {from}–{to}" label
+     * on the right. The label echoes the spinner that lives in
+     * {@code TransactionsCard} above; it is not interactive itself.
+     *
+     * @return the configured header row
+     */
+    private HBox buildHeader() {
+        Region spacer = new Region();
+        HBox.setHgrow(spacer, Priority.ALWAYS);
+
+        HBox header = new HBox(title, spacer, weekRangeLabel);
+        header.setAlignment(Pos.CENTER_LEFT);
+        return header;
+    }
+
+    /**
+     * Refreshes value rows whenever the model changes — the filter's
+     * upper bound is bumped by {@code TransactionsCard}, so this card
+     * only needs to recompute the totals against the (possibly new)
+     * transactions.
+     */
+    @Override
+    public void onGameUpdated() {
+        refresh();
+    }
+
+    /**
+     * Refreshes the section title, the week-range label, and the row
+     * contents so labels and value formatting follow the active
+     * language.
+     */
+    @Override
+    protected void onLanguageChanged() {
+        title.setText(LanguageManager.get("transactions.summary.title"));
+        refresh();
+    }
+
+    /**
+     * Rebuilds the value rows from the current filter selection and
+     * updates the header's week-range label. The three rows (Kjøp,
+     * Salg, Total) are laid out with the Total row separated by the
+     * same divider {@code HoldingsCard} uses, so the two cards read
+     * as a visual family.
+     */
+    private void refresh() {
+        int fromWeek = weekRangeFilter.getFromWeek();
+        int toWeek = weekRangeFilter.getToWeek();
+
+        weekRangeLabel.setText(MessageFormat.format(
+                LanguageManager.get("transactions.summary.weekRange"), fromWeek, toWeek));
+
+        TransactionArchive archive = gameService.getPlayer().getTransactionArchive();
+        List<Transaction> transactions = collectRange(archive, fromWeek, toWeek);
+        TransactionStatsService.TransactionSummary summary =
+                statsService.getSummary(transactions, gameService.getCurrencyConverter());
+
+        grid.getChildren().clear();
+
+        grid.add(rowLabel(LanguageManager.get("transactions.summary.purchases"), false), 0, 0);
+        grid.add(rowValue(summary.purchasesNok(), false), 1, 0);
+
+        grid.add(rowLabel(LanguageManager.get("transactions.summary.sales"), false), 0, 1);
+        grid.add(rowValue(summary.salesNok(), false), 1, 1);
+
+        Region divider = new Region();
+        divider.getStyleClass().add("holdings-total-divider");
+        GridPane.setColumnSpan(divider, 2);
+        grid.add(divider, 0, 2);
+
+        grid.add(rowLabel(LanguageManager.get("transactions.summary.total"), true), 0, 3);
+        grid.add(rowValue(summary.totalNok(), true), 1, 3);
+    }
+
+    /**
+     * Creates a label for the leftmost column. Bold variant is used for
+     * the total row to match the {@code HoldingsCard} total-row styling.
+     *
+     * @param text the label text
+     * @param bold whether to apply the bold modifier
+     * @return a styled label
+     */
+    private Label rowLabel(String text, boolean bold) {
+        Label label = TableCells.data(text);
+        if (bold) {
+            label.getStyleClass().add("bold");
+        }
+        return label;
+    }
+
+    /**
+     * Creates a signed NOK amount label for the rightmost column. The
+     * positive sign is rendered explicitly so sale inflows display as
+     * {@code +1 234,56 NOK} rather than just {@code 1 234,56 NOK}, which
+     * matches the mockup and the visual cue used elsewhere in the app.
+     * Negative values keep the minus sign produced by
+     * {@link TableCells#NUMBER_FORMAT}; zero is shown without a sign.
+     * Color modifiers are not applied here — the summary card keeps a
+     * neutral palette, only weight distinguishes the total row.
+     *
+     * @param amount the NOK amount to render
+     * @param bold   whether to apply the bold modifier
+     * @return a styled label
+     */
+    private Label rowValue(BigDecimal amount, boolean bold) {
+        String sign = amount.signum() > 0 ? "+" : "";
+        String text = sign + TableCells.NUMBER_FORMAT.format(amount) + " NOK";
+        Label label = TableCells.data(text);
+        if (bold) {
+            label.getStyleClass().add("bold");
+        }
+        return label;
+    }
+
+    /**
+     * Gathers every transaction in the archive within the given week
+     * range (inclusive on both ends). Ordering does not matter for the
+     * summary — only the sum does — so this method skips the sort that
+     * {@code TransactionsCard} performs on the same data.
+     *
+     * @param archive  the archive to read transactions from
+     * @param fromWeek the first week to include (inclusive)
+     * @param toWeek   the last week to include (inclusive)
+     * @return the transactions in the range, in archive order
+     */
+    private List<Transaction> collectRange(TransactionArchive archive, int fromWeek, int toWeek) {
+        List<Transaction> list = new ArrayList<>();
+        for (int week = fromWeek; week <= toWeek; week++) {
+            list.addAll(archive.getTransactions(week));
+        }
+        return list;
+    }
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/component/TransactionTypeFilter.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/component/TransactionTypeFilter.java
@@ -65,7 +65,11 @@ public class TransactionTypeFilter extends ComboBox<TransactionTypeFilter.TypeOp
         // and reassigning the value.
         LanguageManager.addObserver(() -> {
             TypeOption current = getValue();
-            setValue(null);
+            setItems(FXCollections.observableArrayList(
+                    TypeOption.ALL,
+                    TypeOption.BUY,
+                    TypeOption.SELL
+            ));
             setValue(current);
         });
     }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/component/TransactionTypeFilter.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/component/TransactionTypeFilter.java
@@ -1,0 +1,112 @@
+package edu.ntnu.idatt2003.millions.view.dashboard.transactions.component;
+
+import edu.ntnu.idatt2003.millions.model.transaction.Purchase;
+import edu.ntnu.idatt2003.millions.model.transaction.Sale;
+import edu.ntnu.idatt2003.millions.model.transaction.Transaction;
+import edu.ntnu.idatt2003.millions.util.LanguageManager;
+import javafx.beans.value.ObservableValue;
+import javafx.collections.FXCollections;
+import javafx.scene.control.ComboBox;
+import javafx.util.StringConverter;
+
+/**
+ * Dropdown filter that narrows the transactions table to purchases,
+ * sales, or all types.
+ *
+ * <p>Lives in the transactions package because the choice set is
+ * domain-specific (it knows about {@link Purchase} and {@link Sale}).
+ * Mirrors {@code WeekRangeFilter} in shape — extends a JavaFX control,
+ * exposes an observable property the caller listens to, and looks
+ * after its own localization.</p>
+ *
+ * <p>Callers read the active filter through {@link #selectedTypeProperty()}:
+ * the value is the {@link Transaction} subclass to match against, or
+ * {@code null} when no filter is active ("all types"). That lets the
+ * caller use a single {@code isInstance} check without caring which
+ * dropdown option was picked.</p>
+ */
+public class TransactionTypeFilter extends ComboBox<TransactionTypeFilter.TypeOption> {
+
+    /**
+     * Constructs a new type filter with three options — all, buy, sell —
+     * and selects "all" by default so the table starts unfiltered.
+     */
+    public TransactionTypeFilter() {
+        setItems(FXCollections.observableArrayList(
+                TypeOption.ALL,
+                TypeOption.BUY,
+                TypeOption.SELL
+        ));
+        setValue(TypeOption.ALL);
+        getStyleClass().add("type-filter");
+
+        setConverter(new StringConverter<>() {
+            /**
+             * Renders an option as its localized label so the dropdown
+             * reflects the active language without rebuilding the items.
+             */
+            @Override
+            public String toString(TypeOption option) {
+                return option == null ? "" : LanguageManager.get(option.labelKey);
+            }
+
+            /**
+             * Not used — the combo box is not editable, so user input
+             * never needs to be parsed back into an option.
+             */
+            @Override
+            public TypeOption fromString(String s) {
+                return null;
+            }
+        });
+
+        // Force the button cell to re-render its current label when the
+        // language changes. The converter is re-run by briefly clearing
+        // and reassigning the value.
+        LanguageManager.addObserver(() -> {
+            TypeOption current = getValue();
+            setValue(null);
+            setValue(current);
+        });
+    }
+
+    /**
+     * Returns an observable view of the selected transaction subclass.
+     * The value is {@code null} when "all types" is selected.
+     *
+     * @return observable value carrying the active filter class
+     */
+    public ObservableValue<Class<? extends Transaction>> selectedTypeProperty() {
+        return valueProperty().map(option -> option == null ? null : option.type);
+    }
+
+    /**
+     * Returns the currently selected transaction subclass, or
+     * {@code null} when "all types" is selected.
+     *
+     * @return the active filter class, or {@code null}
+     */
+    public Class<? extends Transaction> getSelectedType() {
+        TypeOption value = getValue();
+        return value == null ? null : value.type;
+    }
+
+    /**
+     * Internal enumeration of the three dropdown options. Each option
+     * carries the i18n key for its label and the {@link Transaction}
+     * subclass it filters for ({@code null} for "all types").
+     */
+    enum TypeOption {
+        ALL("transactions.type.all", null),
+        BUY("transactions.type.buy", Purchase.class),
+        SELL("transactions.type.sell", Sale.class);
+
+        private final String labelKey;
+        private final Class<? extends Transaction> type;
+
+        TypeOption(String labelKey, Class<? extends Transaction> type) {
+            this.labelKey = labelKey;
+            this.type = type;
+        }
+    }
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/component/WeekRangeFilter.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/component/WeekRangeFilter.java
@@ -1,7 +1,6 @@
 package edu.ntnu.idatt2003.millions.view.dashboard.transactions.component;
 
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
-import edu.ntnu.idatt2003.millions.view.component.StyledText;
 import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.ReadOnlyIntegerProperty;
 import javafx.beans.property.SimpleIntegerProperty;
@@ -38,7 +37,7 @@ import javafx.scene.layout.HBox;
 public class WeekRangeFilter extends HBox {
 
     /** Preferred width for each spinner, in pixels. */
-    private static final int SPINNER_WIDTH = 72;
+    private static final int SPINNER_WIDTH = 60;
 
     /** Horizontal spacing between the label, spinners and separator. */
     private static final int SPACING = 8;
@@ -47,7 +46,7 @@ public class WeekRangeFilter extends HBox {
     private final IntegerProperty toWeek = new SimpleIntegerProperty();
     private final Spinner<Integer> fromSpinner;
     private final Spinner<Integer> toSpinner;
-    private final StyledText label;
+    private final Label label;
 
     private final int minWeek;
 
@@ -66,7 +65,8 @@ public class WeekRangeFilter extends HBox {
         setAlignment(Pos.CENTER_LEFT);
         getStyleClass().add("week-range-filter");
 
-        label = StyledText.detailLabel(LanguageManager.get("filter.week"));
+        label = new Label(LanguageManager.get("filter.week"));
+        label.getStyleClass().add("filter-label");
 
         fromSpinner = createSpinner(minWeek, maxWeek, minWeek);
         toSpinner = createSpinner(minWeek, maxWeek, maxWeek);

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/component/WeekRangeFilter.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/component/WeekRangeFilter.java
@@ -123,14 +123,8 @@ public class WeekRangeFilter extends HBox {
     }
 
     /**
-     * Raises the upper bound of both spinners so the user can pick
-     * higher weeks.
-     *
-     * <p>If the to-spinner is currently sitting at the old maximum,
-     * its value is advanced to the new maximum — interpreting that
-     * state as "show all weeks" and keeping it so. If the user has
-     * picked a smaller upper bound, the value is left untouched;
-     * only the ceiling moves.</p>
+     * Raises the upper bound of both spinners and advances the to-spinner
+     * value to {@code newMax} so that newly added weeks are always visible.
      *
      * <p>Typically called from a parent view's {@code onGameUpdated()}
      * hook whenever the game advances to a new week.</p>
@@ -148,16 +142,10 @@ public class WeekRangeFilter extends HBox {
         SpinnerValueFactory.IntegerSpinnerValueFactory fromFactory =
                 (SpinnerValueFactory.IntegerSpinnerValueFactory) fromSpinner.getValueFactory();
 
-        // "Show all" intent is preserved by bumping the to-spinner's
-        // value forward when it was pinned to the old ceiling.
-        boolean wasAtCeiling = toSpinner.getValue() == toFactory.getMax();
-
         fromFactory.setMax(newMax);
         toFactory.setMax(newMax);
-
-        if (wasAtCeiling) {
-            toFactory.setValue(newMax);
-        }
+        fromFactory.setValue(minWeek);
+        toFactory.setValue(newMax);
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/component/WeekRangeFilter.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/component/WeekRangeFilter.java
@@ -1,6 +1,7 @@
 package edu.ntnu.idatt2003.millions.view.dashboard.transactions.component;
 
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
+import edu.ntnu.idatt2003.millions.view.component.StyledText;
 import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.ReadOnlyIntegerProperty;
 import javafx.beans.property.SimpleIntegerProperty;
@@ -46,7 +47,7 @@ public class WeekRangeFilter extends HBox {
     private final IntegerProperty toWeek = new SimpleIntegerProperty();
     private final Spinner<Integer> fromSpinner;
     private final Spinner<Integer> toSpinner;
-    private final Label label;
+    private final StyledText label;
 
     private final int minWeek;
 
@@ -65,8 +66,7 @@ public class WeekRangeFilter extends HBox {
         setAlignment(Pos.CENTER_LEFT);
         getStyleClass().add("week-range-filter");
 
-        label = new Label(LanguageManager.get("filter.week"));
-        label.getStyleClass().add("filter-label");
+        label = StyledText.detailLabel(LanguageManager.get("filter.week"));
 
         fromSpinner = createSpinner(minWeek, maxWeek, minWeek);
         toSpinner = createSpinner(minWeek, maxWeek, maxWeek);

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/component/WeekRangeFilter.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/component/WeekRangeFilter.java
@@ -124,8 +124,13 @@ public class WeekRangeFilter extends HBox {
 
     /**
      * Raises the upper bound of both spinners so the user can pick
-     * higher weeks. The currently selected range is preserved; only
-     * the maximum selectable value moves.
+     * higher weeks.
+     *
+     * <p>If the to-spinner is currently sitting at the old maximum,
+     * its value is advanced to the new maximum — interpreting that
+     * state as "show all weeks" and keeping it so. If the user has
+     * picked a smaller upper bound, the value is left untouched;
+     * only the ceiling moves.</p>
      *
      * <p>Typically called from a parent view's {@code onGameUpdated()}
      * hook whenever the game advances to a new week.</p>
@@ -137,10 +142,22 @@ public class WeekRangeFilter extends HBox {
         if (newMax < minWeek) {
             return;
         }
-        ((SpinnerValueFactory.IntegerSpinnerValueFactory)
-                fromSpinner.getValueFactory()).setMax(newMax);
-        ((SpinnerValueFactory.IntegerSpinnerValueFactory)
-                toSpinner.getValueFactory()).setMax(newMax);
+
+        SpinnerValueFactory.IntegerSpinnerValueFactory toFactory =
+                (SpinnerValueFactory.IntegerSpinnerValueFactory) toSpinner.getValueFactory();
+        SpinnerValueFactory.IntegerSpinnerValueFactory fromFactory =
+                (SpinnerValueFactory.IntegerSpinnerValueFactory) fromSpinner.getValueFactory();
+
+        // "Show all" intent is preserved by bumping the to-spinner's
+        // value forward when it was pinned to the old ceiling.
+        boolean wasAtCeiling = toSpinner.getValue() == toFactory.getMax();
+
+        fromFactory.setMax(newMax);
+        toFactory.setMax(newMax);
+
+        if (wasAtCeiling) {
+            toFactory.setValue(newMax);
+        }
     }
 
     /**

--- a/src/main/resources/css/filters.css
+++ b/src/main/resources/css/filters.css
@@ -1,3 +1,9 @@
+.filter-label {
+    -fx-font-size: 13;
+    -fx-text-fill: -text-primary;
+    -fx-padding: 0 8 0 0;
+}
+
 .filter-separator {
     -fx-font-size: 14px;
     -fx-text-fill: -text-muted;

--- a/src/main/resources/css/filters.css
+++ b/src/main/resources/css/filters.css
@@ -9,21 +9,54 @@
     -fx-padding: 0 2 0 2;
 }
 
+.transactions-filter-row {
+    -fx-padding: 8 0 8 0;
+}
+
 .week-spinner {
     -fx-font-size: 13px;
+    -fx-background-color: #888888, #ffffff;
+    -fx-background-insets: 0, 1;
+    -fx-background-radius: 6, 5;
+}
+
+.week-spinner:focused {
+    -fx-background-color: #2563eb, #ffffff;
 }
 
 .week-spinner .text-field {
-    -fx-background-color: surface;
-    -fx-border-color: border;
-    -fx-border-radius: 4;
-    -fx-background-radius: 4;
+    -fx-background-color: transparent;
+    -fx-border-color: transparent;
     -fx-padding: 4 6 4 6;
-    -fx-text-fill: text-primary;
+    -fx-alignment: center;
+    -fx-text-fill: #111111;
+}
+
+.week-spinner .text-field:focused {
+    -fx-background-color: transparent;
 }
 
 .week-spinner .increment-arrow-button,
 .week-spinner .decrement-arrow-button {
-    -fx-background-color: surface-alt;
-    -fx-border-color: border;
+    -fx-background-color: #888888, #f3f3f3;
+    -fx-background-insets: 0, 0 0 0 1;
+    -fx-padding: 2 6 2 6;
+}
+
+.week-spinner .increment-arrow-button:hover,
+.week-spinner .decrement-arrow-button:hover {
+    -fx-background-color: #888888, #e5e5e5;
+}
+
+.week-spinner .increment-arrow-button {
+    -fx-background-radius: 0 5 0 0;
+}
+
+.week-spinner .decrement-arrow-button {
+    -fx-background-radius: 0 0 5 0;
+}
+
+.week-spinner .increment-arrow,
+.week-spinner .decrement-arrow {
+    -fx-background-color: #555555;
 }

--- a/src/main/resources/css/filters.css
+++ b/src/main/resources/css/filters.css
@@ -1,8 +1,3 @@
-.filter-label {
-    -fx-font-size: 13px;
-    -fx-text-fill: -text-secondary;
-}
-
 .filter-separator {
     -fx-font-size: 14px;
     -fx-text-fill: -text-muted;

--- a/src/main/resources/css/filters.css
+++ b/src/main/resources/css/filters.css
@@ -1,11 +1,11 @@
 .filter-label {
     -fx-font-size: 13px;
-    -fx-text-fill: text-secondary;
+    -fx-text-fill: -text-secondary;
 }
 
 .filter-separator {
     -fx-font-size: 14px;
-    -fx-text-fill: text-muted;
+    -fx-text-fill: -text-muted;
     -fx-padding: 0 2 0 2;
 }
 
@@ -15,13 +15,13 @@
 
 .week-spinner {
     -fx-font-size: 13px;
-    -fx-background-color: #888888, #ffffff;
+    -fx-background-color: -border-strong, -surface;
     -fx-background-insets: 0, 1;
     -fx-background-radius: 6, 5;
 }
 
 .week-spinner:focused {
-    -fx-background-color: #2563eb, #ffffff;
+    -fx-background-color: -primary, -surface;
 }
 
 .week-spinner .text-field {
@@ -29,7 +29,7 @@
     -fx-border-color: transparent;
     -fx-padding: 2 6 2 6;
     -fx-alignment: center;
-    -fx-text-fill: #111111;
+    -fx-text-fill: -text-primary;
 }
 
 .week-spinner .text-field:focused {
@@ -38,7 +38,7 @@
 
 .week-spinner .increment-arrow-button,
 .week-spinner .decrement-arrow-button {
-    -fx-background-color: #888888, #f3f3f3;
+    -fx-background-color: -border-strong, -surface-alt;
     -fx-background-insets: 0, 0 0 0 1;
     -fx-background-radius: 0;
     -fx-padding: 0 6 0 6;
@@ -46,7 +46,7 @@
 
 .week-spinner .increment-arrow-button:hover,
 .week-spinner .decrement-arrow-button:hover {
-    -fx-background-color: #888888, #e5e5e5;
+    -fx-background-color: -border-strong, -border-light;
 }
 
 .week-spinner .increment-arrow-button {
@@ -59,60 +59,58 @@
 
 .week-spinner .increment-arrow,
 .week-spinner .decrement-arrow {
-    -fx-background-color: #555555;
+    -fx-background-color: -text-muted;
 }
 
 .type-filter {
     -fx-font-size: 13px;
-    -fx-background-color: #888888, #ffffff;
+    -fx-background-color: -border-strong, -surface;
     -fx-background-insets: 0, 1;
     -fx-background-radius: 6, 5;
     -fx-padding: 0;
 }
 
 .type-filter:focused {
-    -fx-background-color: #2563eb, #ffffff;
+    -fx-background-color: -primary, -surface;
 }
 
 .type-filter .list-cell {
     -fx-background-color: transparent;
     -fx-padding: 4 8 4 8;
-    -fx-text-fill: #111111;
+    -fx-text-fill: -text-primary;
 }
 
-/* Arrow button on the right edge of the closed combo box. */
-
 .type-filter .arrow-button {
-    -fx-background-color: #888888, #f3f3f3;
+    -fx-background-color: -border-strong, -surface-alt;
     -fx-background-insets: 0, 0 0 0 1;
     -fx-background-radius: 0 5 5 0;
     -fx-padding: 0 6 0 6;
 }
 
 .type-filter .arrow-button:hover {
-    -fx-background-color: #888888, #e5e5e5;
+    -fx-background-color: -border-strong, -border-light;
 }
 
 .type-filter .arrow-button .arrow {
-    -fx-background-color: #555555;
+    -fx-background-color: -text-muted;
 }
 
 .type-filter .combo-box-popup .list-view {
-    -fx-background-color: #888888, #ffffff;
+    -fx-background-color: -border-strong, -surface;
     -fx-background-insets: 0, 1;
     -fx-background-radius: 6, 5;
 }
 
 .type-filter .combo-box-popup .list-view .list-cell {
     -fx-padding: 6 12 6 12;
-    -fx-text-fill: #111111;
+    -fx-text-fill: -text-primary;
 }
 
 .type-filter .combo-box-popup .list-view .list-cell:filled:hover {
-    -fx-background-color: #f3f3f3;
+    -fx-background-color: -surface-alt;
 }
 
 .type-filter .combo-box-popup .list-view .list-cell:filled:selected {
-    -fx-background-color: #2563eb;
-    -fx-text-fill: #ffffff;
+    -fx-background-color: -primary;
+    -fx-text-fill: -surface;
 }

--- a/src/main/resources/css/filters.css
+++ b/src/main/resources/css/filters.css
@@ -27,7 +27,7 @@
 .week-spinner .text-field {
     -fx-background-color: transparent;
     -fx-border-color: transparent;
-    -fx-padding: 4 6 4 6;
+    -fx-padding: 2 6 2 6;
     -fx-alignment: center;
     -fx-text-fill: #111111;
 }
@@ -40,7 +40,8 @@
 .week-spinner .decrement-arrow-button {
     -fx-background-color: #888888, #f3f3f3;
     -fx-background-insets: 0, 0 0 0 1;
-    -fx-padding: 2 6 2 6;
+    -fx-background-radius: 0;
+    -fx-padding: 0 6 0 6;
 }
 
 .week-spinner .increment-arrow-button:hover,
@@ -59,4 +60,59 @@
 .week-spinner .increment-arrow,
 .week-spinner .decrement-arrow {
     -fx-background-color: #555555;
+}
+
+.type-filter {
+    -fx-font-size: 13px;
+    -fx-background-color: #888888, #ffffff;
+    -fx-background-insets: 0, 1;
+    -fx-background-radius: 6, 5;
+    -fx-padding: 0;
+}
+
+.type-filter:focused {
+    -fx-background-color: #2563eb, #ffffff;
+}
+
+.type-filter .list-cell {
+    -fx-background-color: transparent;
+    -fx-padding: 4 8 4 8;
+    -fx-text-fill: #111111;
+}
+
+/* Arrow button on the right edge of the closed combo box. */
+
+.type-filter .arrow-button {
+    -fx-background-color: #888888, #f3f3f3;
+    -fx-background-insets: 0, 0 0 0 1;
+    -fx-background-radius: 0 5 5 0;
+    -fx-padding: 0 6 0 6;
+}
+
+.type-filter .arrow-button:hover {
+    -fx-background-color: #888888, #e5e5e5;
+}
+
+.type-filter .arrow-button .arrow {
+    -fx-background-color: #555555;
+}
+
+.type-filter .combo-box-popup .list-view {
+    -fx-background-color: #888888, #ffffff;
+    -fx-background-insets: 0, 1;
+    -fx-background-radius: 6, 5;
+}
+
+.type-filter .combo-box-popup .list-view .list-cell {
+    -fx-padding: 6 12 6 12;
+    -fx-text-fill: #111111;
+}
+
+.type-filter .combo-box-popup .list-view .list-cell:filled:hover {
+    -fx-background-color: #f3f3f3;
+}
+
+.type-filter .combo-box-popup .list-view .list-cell:filled:selected {
+    -fx-background-color: #2563eb;
+    -fx-text-fill: #ffffff;
 }

--- a/src/main/resources/css/style.css
+++ b/src/main/resources/css/style.css
@@ -5,6 +5,7 @@
 @import "chart.css";
 @import "holdings.css";
 @import "portfolio.css";
+@import "transactions.css";
 @import "modal.css";
 @import "utilities.css";
 @import "tooltip.css";

--- a/src/main/resources/css/tokens.css
+++ b/src/main/resources/css/tokens.css
@@ -1,4 +1,4 @@
-/* === Design Tokens === */
+/* Design Tokens */
 .root {
     -primary:          #2980b9;
     -primary-dark:     #1f6391;
@@ -12,6 +12,10 @@
     -success-bg:       #EAF3DE;
     -success-text:     #2E5A0E;
     -success-border:   #C4DDA0;
+
+    -info-bg:          #E3EEF7;
+    -info-text:        #1F4E79;
+    -info-border:      #B4CCE3;
 
     -text-primary:     #333333;
     -text-secondary:   #888888;

--- a/src/main/resources/css/transactions.css
+++ b/src/main/resources/css/transactions.css
@@ -1,0 +1,21 @@
+.transaction-type-badge {
+    -fx-font-size: 11;
+    -fx-font-weight: bold;
+    -fx-padding: 2 10 2 10;
+    -fx-background-radius: 10;
+    -fx-border-radius: 10;
+    -fx-border-width: 1;
+    -fx-alignment: center;
+}
+
+.badge-buy {
+    -fx-background-color: -info-bg;
+    -fx-text-fill: -info-text;
+    -fx-border-color: -info-border;
+}
+
+.badge-sell {
+    -fx-background-color: -success-bg;
+    -fx-text-fill: -success-text;
+    -fx-border-color: -success-border;
+}

--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -190,5 +190,10 @@ transactions.col.amount=Amount
 transactions.weekValue=Week {0}
 transactions.empty=No transactions yet
 transactions.type.all=All types
+transactions.summary.title=Transaction summary
+transactions.summary.purchases=Purchases
+transactions.summary.sales=Sales
+transactions.summary.total=Total
+transactions.summary.weekRange=WEEK {0}-{1}
 filter.week=Week
 

--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -195,5 +195,6 @@ transactions.summary.purchases=Purchases
 transactions.summary.sales=Sales
 transactions.summary.total=Total
 transactions.summary.weekRange=WEEK {0}-{1}
+transactions.activity.title=Trading activity
 filter.week=Week
 

--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -157,7 +157,7 @@ tooltip.dashboard.weeklyChange=Change in equity since last week.
 tooltip.dashboard.portfolioValue=Market value of all your shares, converted to NOK. Tax and commission are not deducted.
 tooltip.dashboard.status=Novice: starting level. Investor: traded 10+ weeks and grown 20%. Speculator: traded 20+ weeks and doubled equity.
 # Tooltips - Holdings table column headers
-tooltip.holdings.valueNok=Market value in NOK (latest price × quantity, converted via exchange rate). Tax and commission are not deducted.
+tooltip.holdings.valueNok=Market value in NOK (latest price ï¿½ quantity, converted via exchange rate). Tax and commission are not deducted.
 # Tooltips - Realized returns
 tooltip.realized.gain=Sum of profit from all sales you made a gain on (tax and commission deducted), converted to NOK.
 tooltip.realized.loss=Sum of losses from all sales you made a loss on (commission deducted), converted to NOK.
@@ -169,7 +169,7 @@ tooltip.details.gav=Average purchase price per share: total cost divided by tota
 tooltip.details.liquidation=What you would actually receive in NOK if you sold the entire position now. Commission (1%) and tax on gain (30%) are already deducted.
 tooltip.details.returnNative=Gain or loss in the stock's native currency: market value minus purchase cost.
 tooltip.details.return=Gain or loss: market value minus purchase cost.
-tooltip.details.marketValue=What the position is worth now based on today's stock price (latest price × quantity). A theoretical value before fees ? see liquidation value for what you actually receive when selling.
+tooltip.details.marketValue=What the position is worth now based on today's stock price (latest price ï¿½ quantity). A theoretical value before fees ? see liquidation value for what you actually receive when selling.
 tooltip.details.marketValueNok=The same market value converted to NOK at today's exchange rate.
 # Tooltips - Shared (used in multiple places)
 tooltip.shared.weeklyChange=Percentage change in the stock price since last week.
@@ -177,8 +177,8 @@ tooltip.shared.returnPct=Gain or loss as a percentage: (market value ? purchase 
 tooltip.shared.returnNok=Market value minus purchase cost for your current position, converted to NOK.
 # Transactions
 transactions.title=Transactions
-transactions.type.buy=BUY
-transactions.type.sell=SELL
+transactions.type.buy=PURCHASE
+transactions.type.sell=SALE
 transactions.col.week=Week
 transactions.col.company=Company
 transactions.col.type=Type

--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -189,6 +189,6 @@ transactions.col.tax=Tax
 transactions.col.amount=Amount
 transactions.weekValue=Week {0}
 transactions.empty=No transactions yet
-
+transactions.type.all=All types
 filter.week=Week
 

--- a/src/main/resources/i18n/messages_no.properties
+++ b/src/main/resources/i18n/messages_no.properties
@@ -190,4 +190,11 @@ transactions.col.amount=Beløp
 transactions.weekValue=Uke {0}
 transactions.empty=Ingen transaksjoner enda
 transactions.type.all=Alle typer
+transactions.summary.title=Summering av transaksjoner
+transactions.summary.purchases=Kjøp
+transactions.summary.sales=Salg
+transactions.summary.total=Total
+transactions.summary.weekRange=UKE {0}-{1}
+
 filter.week=Uke
+

--- a/src/main/resources/i18n/messages_no.properties
+++ b/src/main/resources/i18n/messages_no.properties
@@ -195,6 +195,6 @@ transactions.summary.purchases=Kjøp
 transactions.summary.sales=Salg
 transactions.summary.total=Total
 transactions.summary.weekRange=UKE {0}-{1}
-
+transactions.activity.title=Handelsaktivitet
 filter.week=Uke
 

--- a/src/main/resources/i18n/messages_no.properties
+++ b/src/main/resources/i18n/messages_no.properties
@@ -189,6 +189,5 @@ transactions.col.tax=Skatt
 transactions.col.amount=Beløp
 transactions.weekValue=Uke {0}
 transactions.empty=Ingen transaksjoner enda
-
+transactions.type.all=Alle typer
 filter.week=Uke
-


### PR DESCRIPTION
## Summary

Builds out the transactions tab from a plain table to a complete view with filters, totals, and activity counts. Adds two new cards beside the table - `TransactionsSummaryCard` (NOK totals) and `TransactionsActivityCard` (transaction counts) - and polishes the existing `WeekRangeFilter` and `TransactionTypeFilter` so they share a consistent design.

The two new cards complement each other: one answers "how much money moved", the other "how many trades did I make", both scoped by the same week range as the table above.

## What changed

### Filter components

- `WeekRangeFilter` - final design pass: cleaner spinner styling, label refactored to use `StyledText`, and a fix for the upper bound not advancing when the game week advances. Also resets the selected range to "all weeks" on each week advance, since the previous range usually no longer matches what the user wants to see after time passes.
- `TransactionTypeFilter` - matched styling to the week filter so the two controls read as a pair in the filter row.
- Transaction type badges now have proper styling (light-blue for purchases, light-green for sales).
- Fixed a language-change bug in `TransactionsCard` where the type filter dropdown didn't refresh its button cell on language switch.
- Adjusted the type column width to fit the English "Purchase" label without truncation.
- Reworded the English translations of "Kjøp"/"Salg" to more natural alternatives than literal "Buy"/"Sell" for the badge labels.

### New cards

- **`TransactionsSummaryCard`** - three rows (Kjøp, Salg, Total) with NOK amounts. Sale inflows render as `+1 234,56 NOK`, purchase outflows as `-8 658,11 NOK`, and the total is bold with a divider above it matching `HoldingsCard`'s total-row styling.
- **`TransactionsActivityCard`** - same structure, but with plain integer counts (number of purchases, number of sales, sum). Reads as "5 / 3 / 8" rather than "+5 / +3 / +8" since these are activity counts, not signed amounts.

Both cards show the current range as a read-only "UKE {from}-{to}" label in the top right, styled to match the "UKE" indicator in `ViewHeader`. The label uses `StyledText.weekLabel()` so the visual style stays in one place.

### Layout

`TransactionsView` now owns a single `WeekRangeFilter` instance and hands it to all three cards (table, summary, activity). The spinner widget itself lives inside `TransactionsCard`'s filter row; the two bottom cards only echo the current range as a label. Picking three different ranges on one tab would have been confusing UX - every card scopes to the same period.

The two bottom cards sit side-by-side in an `HBox` with `Priority.ALWAYS` and `setMinWidth(0)` so they share width 50/50 and shrink gracefully on narrow viewports.

## Design decisions

- **Why not extract a shared base class for the two new cards?** They are structurally similar (header row + three-row grid + divider), but two callers is too early to abstract. Two concrete classes read top-to-bottom more easily than one base plus two subclasses. If a third similar card lands (watchlist, perhaps), that's the moment to extract.
- **Why a shared filter instead of one per card?** UX. The summary and activity cards exist to answer questions about the period the user sees in the table - letting them drift apart breaks that relationship.
- **Why does type-filter not apply to the summary/activity cards?** The whole point of the summary is to compare purchases against sales. Filtering to one type would zero out the other row and remove the comparison the card exists to show.
