### PR TITLE
feat: create footer with info and progress bar

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/millions/service/PlayerStatsService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/PlayerStatsService.java
@@ -48,4 +48,38 @@ public class PlayerStatsService {
     public PlayerStatusLevel getStatus(Player player, CurrencyConverter converter) {
         return player.getStatus(converter);
     }
+
+    /**
+     * Returns the player's progress toward the next status level as a value
+     * between 0.0 and 1.0 (inclusive).
+     *
+     * <p>Progress is computed as the average of two sub-scores, each capped at 1.0:
+     * <ul>
+     *   <li>weeks-traded score: {@code weeksTraded / weeksThreshold}</li>
+     *   <li>growth score: {@code growthPercent / growthThreshold}</li>
+     * </ul>
+     *
+     * <p>For {@link PlayerStatusLevel#NOVICE}, thresholds are 10 weeks and 20% growth.
+     * For {@link PlayerStatusLevel#INVESTOR}, thresholds are 20 weeks and 100% growth.
+     * For {@link PlayerStatusLevel#SPECULATOR}, always returns 1.0 (top level reached).
+     *
+     * @param player    the player to evaluate
+     * @param converter the currency converter used to compute the current net worth
+     * @return progress toward the next status, in {@code [0.0, 1.0]}
+     */
+    public double getProgressToNextStatus(Player player, CurrencyConverter converter) {
+        PlayerStatusLevel status = getStatus(player, converter);
+        if (status == PlayerStatusLevel.SPECULATOR) return 1.0;
+
+        int weeksTraded = player.getTransactionArchive().countDistinctWeeks();
+        double growthPercent = player.getNetWorthChangePercentSinceStart(converter).doubleValue();
+
+        double weeksThreshold = (status == PlayerStatusLevel.NOVICE) ? 10.0 : 20.0;
+        double growthThreshold = (status == PlayerStatusLevel.NOVICE) ? 20.0 : 100.0;
+
+        double weeksScore = Math.min(1.0, weeksTraded / weeksThreshold);
+        double growthScore = Math.min(1.0, Math.max(0.0, growthPercent / growthThreshold));
+
+        return (weeksScore + growthScore) / 2.0;
+    }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/MainView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/MainView.java
@@ -3,6 +3,7 @@ package edu.ntnu.idatt2003.millions.view;
 import edu.ntnu.idatt2003.millions.controller.PortfolioController;
 import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.view.component.Header;
+import edu.ntnu.idatt2003.millions.view.component.StatusFooter;
 import edu.ntnu.idatt2003.millions.view.component.TitleBar;
 import edu.ntnu.idatt2003.millions.view.component.WeekBar;
 import edu.ntnu.idatt2003.millions.view.dashboard.DashboardView;
@@ -30,6 +31,7 @@ public class MainView {
     private final BorderPane root;
     private final Header header;
     private final WeekBar weekBar;
+    private final StatusFooter footer;
 
     /**
      * Constructs a new MainView with a custom title bar, header, and dashboard
@@ -56,9 +58,11 @@ public class MainView {
                 onSaveGame,
                 onExitGame
         );
+        this.footer = new StatusFooter(gameService);
         this.root = new BorderPane();
         root.getStyleClass().add("main-root");
         root.setTop(new VBox(new TitleBar(stage), header));
+        root.setBottom(footer);
 
         // Clip all children to the rounded corner shape so no child
         // background bleeds into the transparent corner areas.

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/StatusFooter.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/StatusFooter.java
@@ -1,0 +1,173 @@
+package edu.ntnu.idatt2003.millions.view.component;
+
+import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
+import edu.ntnu.idatt2003.millions.model.player.Player;
+import edu.ntnu.idatt2003.millions.model.player.PlayerStatusLevel;
+import edu.ntnu.idatt2003.millions.observer.GameObserver;
+import edu.ntnu.idatt2003.millions.service.GameService;
+import edu.ntnu.idatt2003.millions.service.PlayerStatsService;
+import edu.ntnu.idatt2003.millions.util.CurrencyFormatter;
+import edu.ntnu.idatt2003.millions.util.LanguageManager;
+import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.SimpleDoubleProperty;
+import javafx.geometry.Pos;
+import javafx.scene.control.Label;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.StackPane;
+
+/**
+ * Persistent footer bar shown at the bottom of {@link edu.ntnu.idatt2003.millions.view.MainView}.
+ * Displays the player's name and status progress on the left, and equity / available
+ * funds on the right. Updates whenever the game state or active language changes.
+ */
+public class StatusFooter extends HBox implements GameObserver {
+
+    private final GameService gameService;
+    private final PlayerStatsService statsService = new PlayerStatsService();
+
+    // Drives fill width reactively — updated via progressProp.set() in refresh()
+    private final DoubleProperty progressProp = new SimpleDoubleProperty(0.0);
+
+    private final Label playerLabel = new Label();
+    private final Label playerValue = new Label();
+    private final Label equityLabel = new Label();
+    private final Label equityValue = new Label();
+    private final Label availableLabel = new Label();
+    private final Label availableValue = new Label();
+
+    // Status row nodes — built once, kept alive, visibility-toggled between modes
+    private final Label leftStatusLabel = new Label();
+    private final Label rightStatusLabel = new Label();
+    private final Region fill = new Region();
+    private HBox progressRow;
+    private HBox speculatorBadge;
+    private Label speculatorLabel;
+
+    public StatusFooter(GameService gameService) {
+        this.gameService = gameService;
+        getStyleClass().add("status-footer");
+        gameService.addObserver(this);
+        LanguageManager.addObserver(this::onLanguageChanged);
+        buildLayout();
+        onLanguageChanged();
+    }
+
+    private void buildLayout() {
+        // Player name group
+        playerLabel.getStyleClass().add("status-footer-label");
+        playerValue.getStyleClass().add("status-footer-value");
+        HBox playerGroup = new HBox(10, playerLabel, playerValue);
+        playerGroup.setAlignment(Pos.CENTER_LEFT);
+
+        // Progress bar — track fills the StackPane, fill is capped at progress fraction
+        leftStatusLabel.getStyleClass().add("status-footer-label");
+        rightStatusLabel.getStyleClass().add("status-footer-label");
+
+        Region track = new Region();
+        track.getStyleClass().add("status-footer-progress-track");
+        track.setMaxWidth(Double.MAX_VALUE);
+
+        fill.getStyleClass().addAll("status-footer-progress-fill", "status-footer-progress-fill-novice");
+        fill.prefWidthProperty().bind(track.widthProperty().multiply(progressProp));
+        fill.maxWidthProperty().bind(track.widthProperty().multiply(progressProp));
+        StackPane.setAlignment(fill, Pos.CENTER_LEFT);
+
+        StackPane barContainer = new StackPane(track, fill);
+        barContainer.setMinWidth(120);
+        HBox.setHgrow(barContainer, Priority.ALWAYS);
+
+        progressRow = new HBox(8, leftStatusLabel, barContainer, rightStatusLabel);
+        progressRow.setAlignment(Pos.CENTER_LEFT);
+        HBox.setHgrow(progressRow, Priority.ALWAYS);
+
+        // Speculator badge — hidden by default, shown when SPECULATOR
+        Label crown = new Label("♔");
+        crown.getStyleClass().add("status-footer-speculator-icon");
+        speculatorLabel = new Label();
+        speculatorLabel.getStyleClass().add("status-footer-speculator-label");
+        speculatorBadge = new HBox(8, crown, speculatorLabel);
+        speculatorBadge.getStyleClass().add("status-footer-speculator-badge");
+        speculatorBadge.setAlignment(Pos.CENTER_LEFT);
+        speculatorBadge.setVisible(false);
+        speculatorBadge.setManaged(false);
+
+        // Left side: player group + whichever status widget is active
+        HBox leftSide = new HBox(38, playerGroup, progressRow, speculatorBadge);
+        leftSide.setAlignment(Pos.CENTER_LEFT);
+
+        Region spacer = new Region();
+        HBox.setHgrow(spacer, Priority.ALWAYS);
+
+        Region divider = new Region();
+        divider.getStyleClass().add("status-footer-divider");
+
+        equityLabel.getStyleClass().add("status-footer-label");
+        equityValue.getStyleClass().add("status-footer-value");
+        HBox equityGroup = new HBox(10, equityLabel, equityValue);
+        equityGroup.setAlignment(Pos.CENTER_LEFT);
+
+        availableLabel.getStyleClass().add("status-footer-label");
+        availableValue.getStyleClass().add("status-footer-value");
+        HBox availableGroup = new HBox(10, availableLabel, availableValue);
+        availableGroup.setAlignment(Pos.CENTER_LEFT);
+
+        getChildren().addAll(leftSide, spacer, divider, equityGroup, availableGroup);
+    }
+
+    private void onLanguageChanged() {
+        playerLabel.setText(LanguageManager.get("footer.player"));
+        equityLabel.setText(LanguageManager.get("footer.equity"));
+        availableLabel.setText(LanguageManager.get("footer.available"));
+        refresh();
+    }
+
+    private void refresh() {
+        Player player = gameService.getPlayer();
+        CurrencyConverter converter = gameService.getCurrencyConverter();
+
+        playerValue.setText(player.getName());
+        equityValue.setText(CurrencyFormatter.format(statsService.getNetWorth(player, converter)));
+        availableValue.setText(CurrencyFormatter.format(player.getMoney()));
+
+        PlayerStatusLevel status = statsService.getStatus(player, converter);
+        double progress = statsService.getProgressToNextStatus(player, converter);
+        renderStatusRow(status, progress);
+    }
+
+    private void renderStatusRow(PlayerStatusLevel status, double progress) {
+        progressProp.set(progress);
+
+        if (status == PlayerStatusLevel.SPECULATOR) {
+            progressRow.setVisible(false);
+            progressRow.setManaged(false);
+            speculatorBadge.setVisible(true);
+            speculatorBadge.setManaged(true);
+            speculatorLabel.setText(LanguageManager.get("status.speculator").toUpperCase());
+        } else {
+            speculatorBadge.setVisible(false);
+            speculatorBadge.setManaged(false);
+            progressRow.setVisible(true);
+            progressRow.setManaged(true);
+
+            leftStatusLabel.setText(LanguageManager.get(
+                    status == PlayerStatusLevel.NOVICE ? "status.novice" : "status.investor"));
+            rightStatusLabel.setText(LanguageManager.get(
+                    status == PlayerStatusLevel.NOVICE ? "status.investor" : "status.speculator"));
+
+            String fillClass = status == PlayerStatusLevel.NOVICE
+                    ? "status-footer-progress-fill-novice"
+                    : "status-footer-progress-fill-investor";
+            fill.getStyleClass().removeIf(c ->
+                    c.equals("status-footer-progress-fill-novice")
+                    || c.equals("status-footer-progress-fill-investor"));
+            fill.getStyleClass().add(fillClass);
+        }
+    }
+
+    @Override
+    public void onGameUpdated() {
+        refresh();
+    }
+}

--- a/src/main/resources/css/footer.css
+++ b/src/main/resources/css/footer.css
@@ -1,0 +1,68 @@
+.status-footer {
+    -fx-background-color: -footer-bg;
+    -fx-padding: 13 32 13 32;
+    -fx-alignment: center-left;
+    -fx-spacing: 24;
+}
+
+.status-footer-label {
+    -fx-font-size: 13;
+    -fx-text-fill: -footer-label;
+}
+
+.status-footer-value {
+    -fx-font-size: 13;
+    -fx-font-weight: 500;
+    -fx-text-fill: -footer-text;
+}
+
+.status-footer-divider {
+    -fx-background-color: -footer-divider;
+    -fx-pref-width: 1;
+    -fx-min-width: 1;
+    -fx-max-width: 1;
+}
+
+/* Progress bar built from two regions in an HBox */
+.status-footer-progress-track {
+    -fx-background-color: -footer-track;
+    -fx-background-radius: 2;
+    -fx-pref-height: 4;
+    -fx-min-height: 4;
+    -fx-max-height: 4;
+}
+
+.status-footer-progress-fill {
+    -fx-background-radius: 2;
+    -fx-pref-height: 4;
+    -fx-min-height: 4;
+    -fx-max-height: 4;
+}
+
+.status-footer-progress-fill-novice {
+    -fx-background-color: -status-novice;
+}
+
+.status-footer-progress-fill-investor {
+    -fx-background-color: -status-investor;
+}
+
+/* Speculator pill badge (replaces progress bar) */
+.status-footer-speculator-badge {
+    -fx-background-color: -status-speculator-bg;
+    -fx-background-radius: 14;
+    -fx-padding: 4 14 4 14;
+    -fx-spacing: 8;
+    -fx-alignment: center-left;
+}
+
+.status-footer-speculator-label {
+    -fx-font-size: 12;
+    -fx-font-weight: 500;
+    -fx-text-fill: -status-speculator;
+}
+
+.status-footer-speculator-icon {
+    -fx-font-size: 14;
+    -fx-text-fill: -status-speculator;
+}

--- a/src/main/resources/css/style.css
+++ b/src/main/resources/css/style.css
@@ -7,6 +7,7 @@
 @import "holdings.css";
 @import "portfolio.css";
 @import "transactions.css";
+@import "footer.css";
 @import "modal.css";
 @import "utilities.css";
 @import "tooltip.css";

--- a/src/main/resources/css/tokens.css
+++ b/src/main/resources/css/tokens.css
@@ -27,4 +27,17 @@
 
     -surface:          white;
     -surface-alt:      #f5f5f5;
+
+    /* Status colors */
+    -status-novice:          #4ade80;
+    -status-investor:        #fbbf24;
+    -status-speculator:      #a78bfa;
+    -status-speculator-bg:   rgba(167, 139, 250, 0.15);
+
+    /* Footer-specific surface */
+    -footer-bg:      #1a1a1a;
+    -footer-text:    white;
+    -footer-label:   rgba(255, 255, 255, 0.5);
+    -footer-divider: rgba(255, 255, 255, 0.12);
+    -footer-track:   rgba(255, 255, 255, 0.1);
 }

--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -83,6 +83,10 @@ exit.cancel=Cancel
 status.novice=Novice
 status.investor=Investor
 status.speculator=Speculator
+# Footer
+footer.player=Player
+footer.equity=Equity
+footer.available=Available
 # Dashboard - Portfolio dialogs
 dialog.buy.title=Buy shares
 dialog.sell.title=Sell shares
@@ -135,7 +139,7 @@ receipt.button.close=Close
 # Dashboard - Share details modal
 details.title=Details on your share
 details.stock.label=Stock
-details.stock.hint=Traded in {0} · Share price: {1} {0}
+details.stock.hint=Traded in {0} ï¿½ Share price: {1} {0}
 details.section.position=Your position
 details.section.now=Value now
 details.section.return=Return
@@ -159,7 +163,7 @@ tooltip.dashboard.weeklyChange=Change in equity since last week.
 tooltip.dashboard.portfolioValue=Market value of all your shares, converted to NOK. Tax and commission are not deducted.
 tooltip.dashboard.status=Novice: starting level. Investor: traded 10+ weeks and grown 20%. Speculator: traded 20+ weeks and doubled equity.
 # Tooltips - Holdings table column headers
-tooltip.holdings.valueNok=Market value in NOK (latest price × quantity, converted via exchange rate). Tax and commission are not deducted.
+tooltip.holdings.valueNok=Market value in NOK (latest price ï¿½ quantity, converted via exchange rate). Tax and commission are not deducted.
 # Tooltips - Realized returns
 tooltip.realized.gain=Sum of profit from all sales you made a gain on (tax and commission deducted), converted to NOK.
 tooltip.realized.loss=Sum of losses from all sales you made a loss on (commission deducted), converted to NOK.
@@ -171,7 +175,7 @@ tooltip.details.gav=Average purchase price per share: total cost divided by tota
 tooltip.details.liquidation=What you would actually receive in NOK if you sold the entire position now. Commission (1%) and tax on gain (30%) are already deducted.
 tooltip.details.returnNative=Gain or loss in the stock's native currency: market value minus purchase cost.
 tooltip.details.return=Gain or loss: market value minus purchase cost.
-tooltip.details.marketValue=What the position is worth now based on today's stock price (latest price × quantity). A theoretical value before fees - see liquidation value for what you actually receive when selling.
+tooltip.details.marketValue=What the position is worth now based on today's stock price (latest price ï¿½ quantity). A theoretical value before fees - see liquidation value for what you actually receive when selling.
 tooltip.details.marketValueNok=The same market value converted to NOK at today's exchange rate.
 # Tooltips - Shared (used in multiple places)
 tooltip.shared.weeklyChange=Percentage change in the stock price since last week.

--- a/src/main/resources/i18n/messages_no.properties
+++ b/src/main/resources/i18n/messages_no.properties
@@ -83,6 +83,10 @@ exit.cancel=Avbryt
 status.novice=Nybegynner
 status.investor=Investor
 status.speculator=Spekulant
+# Footer
+footer.player=Spiller
+footer.equity=Egenkapital
+footer.available=Tilgjengelig
 # Dashboard - Portfolio dialogs
 dialog.buy.title=Kjøp aksjer
 dialog.sell.title=Selg aksjer

--- a/src/test/java/edu/ntnu/idatt2003/millions/service/PlayerStatsServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/service/PlayerStatsServiceTest.java
@@ -1,0 +1,141 @@
+package edu.ntnu.idatt2003.millions.service;
+
+import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
+import edu.ntnu.idatt2003.millions.model.currency.FixedRateCurrencyConverter;
+import edu.ntnu.idatt2003.millions.model.player.Player;
+import edu.ntnu.idatt2003.millions.model.stock.Share;
+import edu.ntnu.idatt2003.millions.model.stock.Stock;
+import edu.ntnu.idatt2003.millions.model.transaction.Purchase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link PlayerStatsService#getProgressToNextStatus}.
+ */
+class PlayerStatsServiceTest {
+
+    private PlayerStatsService service;
+    private CurrencyConverter converter;
+
+    @BeforeEach
+    void setUp() {
+        service = new PlayerStatsService();
+        converter = new FixedRateCurrencyConverter();
+    }
+
+    private static Player playerWith(String startingMoney) {
+        return new Player("Test", new BigDecimal(startingMoney));
+    }
+
+    /**
+     * Adds {@code weeks} distinct-week transactions to the player's archive.
+     * Transactions are not committed so the player's money is unaffected.
+     */
+    private static void addWeeks(Player player, int weeks) {
+        Stock stock = new Stock("TST", "Test Co.", List.of(BigDecimal.ONE));
+        for (int week = 1; week <= weeks; week++) {
+            Share share = new Share(stock, BigDecimal.ONE, BigDecimal.ONE);
+            player.getTransactionArchive().add(new Purchase(share, week));
+        }
+    }
+
+    @Nested
+    @DisplayName("getProgressToNextStatus()")
+    class GetProgressToNextStatus {
+
+        @Test
+        @DisplayName("Novice with 0 weeks and 0% growth returns 0.0")
+        void noviceZeroWeeksZeroGrowth() {
+            // Arrange
+            Player p = playerWith("100");
+            // Act
+            double progress = service.getProgressToNextStatus(p, converter);
+            // Assert
+            assertEquals(0.0, progress);
+        }
+
+        @Test
+        @DisplayName("Novice with 10 weeks and 10% growth returns 0.75")
+        void noviceTenWeeksTenPercentGrowth() {
+            // Arrange — 10 weeks, +10 money: growth = 10%, net worth 110 < 120 threshold → NOVICE
+            Player p = playerWith("100");
+            addWeeks(p, 10);
+            p.addMoney(new BigDecimal("10"));
+            // Act
+            double progress = service.getProgressToNextStatus(p, converter);
+            // Assert — weeksScore=1.0, growthScore=0.5, avg=0.75
+            assertEquals(0.75, progress);
+        }
+
+        @Test
+        @DisplayName("Novice with 10 weeks and 20% growth (rounded) returns 1.0")
+        void noviceTenWeeksTwentyPercentGrowth() {
+            // Arrange — addMoney(19.95): actual growth 19.95% rounds to 20.0%, but net worth 119.95 < 120 → NOVICE
+            Player p = playerWith("100");
+            addWeeks(p, 10);
+            p.addMoney(new BigDecimal("19.95"));
+            // Act
+            double progress = service.getProgressToNextStatus(p, converter);
+            // Assert — weeksScore=1.0, growthScore=1.0, avg=1.0
+            assertEquals(1.0, progress);
+        }
+
+        @Test
+        @DisplayName("Novice with 5 weeks and 30% growth returns 0.75 (growth capped at 1.0)")
+        void noviceFiveWeeksThirtyPercentGrowthCapped() {
+            // Arrange — 5 weeks (<10) so still NOVICE despite 30% growth exceeding 20% threshold
+            Player p = playerWith("100");
+            addWeeks(p, 5);
+            p.addMoney(new BigDecimal("30"));
+            // Act
+            double progress = service.getProgressToNextStatus(p, converter);
+            // Assert — weeksScore=0.5, growthScore=min(1.0,1.5)=1.0, avg=0.75
+            assertEquals(0.75, progress);
+        }
+
+        @Test
+        @DisplayName("Investor with 15 weeks and 50% growth returns 0.625")
+        void investorFifteenWeeksFiftyPercentGrowth() {
+            // Arrange — 15 weeks, +50% growth: net worth 150 >= 120 and 15 >= 10 → INVESTOR
+            Player p = playerWith("100");
+            addWeeks(p, 15);
+            p.addMoney(new BigDecimal("50"));
+            // Act
+            double progress = service.getProgressToNextStatus(p, converter);
+            // Assert — INVESTOR thresholds: weeksScore=15/20=0.75, growthScore=50/100=0.5, avg=0.625
+            assertEquals(0.625, progress);
+        }
+
+        @Test
+        @DisplayName("Speculator returns 1.0 regardless of values")
+        void speculatorAlwaysReturnsOne() {
+            // Arrange — 20 weeks, +100% growth: net worth 200 = 200 threshold and 20 weeks → SPECULATOR
+            Player p = playerWith("100");
+            addWeeks(p, 20);
+            p.addMoney(new BigDecimal("100"));
+            // Act
+            double progress = service.getProgressToNextStatus(p, converter);
+            // Assert
+            assertEquals(1.0, progress);
+        }
+
+        @Test
+        @DisplayName("Negative growth does not produce a negative result")
+        void negativeGrowthClampedToZero() {
+            // Arrange — withdraw half starting money so net worth drops below start → negative growth
+            Player p = playerWith("1000");
+            p.withdrawMoney(new BigDecimal("500"));
+            // Act
+            double progress = service.getProgressToNextStatus(p, converter);
+            // Assert — growth sub-score must be clamped to 0, not go negative
+            assertEquals(0.0, progress);
+        }
+    }
+}


### PR DESCRIPTION
# Persistent StatusFooter across all tabs
 
Adds a footer to `MainView` that's visible across all tabs and shows the
player's name, progress towards the next status level, equity, and available
cash. Reflects state in real time via the existing observer pattern.
 
## What it looks like
 
Single row, dark background, mounted at the bottom of `MainView`:
 
```
Spiller: Alva   Nybegynner [=====        ] Investor   |   Egenkapital: 105 000 NOK   Tilgjengelig: 45 200 NOK
```
 
When the player reaches Speculator, the progress bar is replaced by a
purple `<crown> SPEKULANT` badge in the same slot.
 
## Progress bar logic
 
The bar uses three modes depending on the player's current status:
 
- **Novice -> Investor** (green): fills as the player approaches the
  Investor requirements (10 weeks traded AND 20% growth)
- **Investor -> Speculator** (yellow): fills towards the Speculator
  requirements (20 weeks traded AND 100% growth)
- **Speculator** (purple badge): the bar is replaced by a status badge
Status is dynamic: if growth falls below the Speculator threshold, the
footer drops back to the yellow Investor bar. The weeks-traded component is
monotonic (only goes up), but the growth component reacts to current net
worth.
 
## Progress calculation
 
Added to `PlayerStatsService`:
 
```java
public double getProgressToNextStatus(Player player, CurrencyConverter converter)
```
 
Returns 0.0-1.0. Arithmetic mean of two sub-scores, each capped at 1.0:
 
- weeks score: `min(weeksTraded, threshold) / threshold`
- growth score: `min(growth, targetGrowth) / targetGrowth`
Thresholds are 10 weeks / 20% growth for Novice -> Investor, 20 weeks / 100%
growth for Investor -> Speculator. Negative growth is clamped to 0.
Speculator returns 1.0 (drives badge mode).
 
Stateless per SoC.md - takes `Player` and `CurrencyConverter` as parameters
on every call, holds no fields. Views read it from their `refreshDisplay()`
methods.
