### PR TITLE
feat: complete the Loans tab with widget cards and debt history

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/millions/model/player/Player.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/player/Player.java
@@ -34,6 +34,7 @@ public class Player {
 
     private BigDecimal previousNetWorth;
     private List<BigDecimal> netWorthHistory;
+    private List<BigDecimal> totalDebtHistory = new ArrayList<>();
 
     /**
      * Constructs a new Player with the specified name and starting balance.
@@ -220,6 +221,27 @@ public class Player {
         return activeLoansInternal().stream()
                 .map(Loan::principal)
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    /**
+     * Records the player's current total debt in the history.
+     * Called by {@link edu.ntnu.idatt2003.millions.service.GameService}
+     * before advancing the week.
+     */
+    public void recordTotalDebt() {
+        if (totalDebtHistory == null) totalDebtHistory = new ArrayList<>();
+        totalDebtHistory.add(getTotalDebt());
+    }
+
+    /**
+     * Returns a list of all recorded total-debt snapshots over time.
+     * Each entry corresponds to the debt at the end of a week.
+     *
+     * @return a defensive copy of the debt history
+     */
+    public List<BigDecimal> getTotalDebtHistory() {
+        if (totalDebtHistory == null) return List.of();
+        return new ArrayList<>(totalDebtHistory);
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/player/Player.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/player/Player.java
@@ -147,7 +147,7 @@ public class Player {
      */
     public BigDecimal getNetWorth(CurrencyConverter converter) {
         Objects.requireNonNull(converter, "Converter cannot be null");
-        return money.add(portfolio.getNetWorth(converter));
+        return money.add(portfolio.getNetWorth(converter)).subtract(getTotalDebt());
     }
 
     /**
@@ -233,7 +233,8 @@ public class Player {
     public BigDecimal getLoanCapacity(CurrencyConverter converter) {
         return getNetWorth(converter)
                 .multiply(MAX_DEBT_RATIO)
-                .setScale(2, RoundingMode.HALF_UP);
+                .setScale(2, RoundingMode.HALF_UP)
+                .max(BigDecimal.ZERO);
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/GameService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/GameService.java
@@ -257,6 +257,7 @@ public class GameService {
         exchange.advance();
         player.collectWeeklyInterest(); // TODO: handle shortfall with forced share sales
         player.recordNetWorth(converter);
+        player.recordTotalDebt();
         notifyObservers();
     }
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/StyledText.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/StyledText.java
@@ -73,6 +73,12 @@ public class StyledText extends Label {
     /** @return a label styled as widget-change */
     public static StyledText widgetChange(String text) { return new StyledText(text, "widget-change"); }
 
+    /** @return an empty label styled as widget-subtitle (muted secondary line below a widget value) */
+    public static StyledText widgetSubtitle() { return new StyledText("widget-subtitle"); }
+
+    /** @return a label styled as widget-subtitle */
+    public static StyledText widgetSubtitle(String text) { return new StyledText(text, "widget-subtitle"); }
+
     /** @return an empty label styled as detail-label */
     public static StyledText detailLabel() { return new StyledText("detail-label"); }
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/LoansView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/LoansView.java
@@ -7,6 +7,7 @@ import edu.ntnu.idatt2003.millions.view.dashboard.loans.card.AverageInterestRate
 import edu.ntnu.idatt2003.millions.view.dashboard.loans.card.AvailableLoansCard;
 import edu.ntnu.idatt2003.millions.view.dashboard.loans.card.DebtRatioCard;
 import edu.ntnu.idatt2003.millions.view.dashboard.loans.card.LoanCapacityCard;
+import edu.ntnu.idatt2003.millions.view.dashboard.loans.card.TotalDebtCard;
 import edu.ntnu.idatt2003.millions.view.dashboard.loans.card.WeeklyInterestCostCard;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
@@ -42,8 +43,16 @@ public class LoansView extends VBox {
         availableLoansCard = new AvailableLoansCard(gameService);
         activeLoansCard = new ActiveLoansCard(gameService, loanController);
 
-        VBox leftCards = new VBox(VERTICAL_SPACING, activeLoansCard, availableLoansCard);
-        HBox.setHgrow(leftCards, Priority.ALWAYS);
+        HBox topRow = buildTopRow(gameService);
+
+        getChildren().addAll(availableLoansCard, topRow, activeLoansCard);
+    }
+
+    private HBox buildTopRow(GameService gameService) {
+        HBox row = new HBox(VERTICAL_SPACING);
+
+        TotalDebtCard totalDebtCard = new TotalDebtCard(gameService);
+        HBox.setHgrow(totalDebtCard, Priority.ALWAYS);
 
         VBox rightCards = new VBox(12,
                 new WeeklyInterestCostCard(gameService),
@@ -54,7 +63,11 @@ public class LoansView extends VBox {
         rightCards.setMinWidth(220);
         rightCards.setMaxWidth(260);
 
-        getChildren().add(new HBox(VERTICAL_SPACING, leftCards, rightCards));
+        totalDebtCard.prefHeightProperty().bind(rightCards.heightProperty());
+        totalDebtCard.maxHeightProperty().bind(rightCards.heightProperty());
+
+        row.getChildren().addAll(totalDebtCard, rightCards);
+        return row;
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/LoansView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/LoansView.java
@@ -3,7 +3,13 @@ package edu.ntnu.idatt2003.millions.view.dashboard.loans;
 import edu.ntnu.idatt2003.millions.controller.LoanController;
 import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.view.dashboard.loans.card.ActiveLoansCard;
+import edu.ntnu.idatt2003.millions.view.dashboard.loans.card.AverageInterestRateCard;
 import edu.ntnu.idatt2003.millions.view.dashboard.loans.card.AvailableLoansCard;
+import edu.ntnu.idatt2003.millions.view.dashboard.loans.card.DebtRatioCard;
+import edu.ntnu.idatt2003.millions.view.dashboard.loans.card.LoanCapacityCard;
+import edu.ntnu.idatt2003.millions.view.dashboard.loans.card.WeeklyInterestCostCard;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 
 /**
@@ -36,7 +42,19 @@ public class LoansView extends VBox {
         availableLoansCard = new AvailableLoansCard(gameService);
         activeLoansCard = new ActiveLoansCard(gameService, loanController);
 
-        getChildren().addAll(activeLoansCard, availableLoansCard);
+        VBox leftCards = new VBox(VERTICAL_SPACING, activeLoansCard, availableLoansCard);
+        HBox.setHgrow(leftCards, Priority.ALWAYS);
+
+        VBox rightCards = new VBox(12,
+                new WeeklyInterestCostCard(gameService),
+                new AverageInterestRateCard(gameService),
+                new LoanCapacityCard(gameService),
+                new DebtRatioCard(gameService)
+        );
+        rightCards.setMinWidth(220);
+        rightCards.setMaxWidth(260);
+
+        getChildren().add(new HBox(VERTICAL_SPACING, leftCards, rightCards));
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/card/ActiveLoansCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/card/ActiveLoansCard.java
@@ -5,7 +5,7 @@ import edu.ntnu.idatt2003.millions.model.loan.Loan;
 import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
 import edu.ntnu.idatt2003.millions.util.TableCells;
-import edu.ntnu.idatt2003.millions.view.component.Card;
+import edu.ntnu.idatt2003.millions.view.component.card.Card;
 import edu.ntnu.idatt2003.millions.view.component.StyledText;
 import javafx.geometry.HPos;
 import javafx.geometry.Pos;

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/card/AvailableLoansCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/card/AvailableLoansCard.java
@@ -7,7 +7,7 @@ import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.util.CurrencyFormatter;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
 import edu.ntnu.idatt2003.millions.util.TableCells;
-import edu.ntnu.idatt2003.millions.view.component.Card;
+import edu.ntnu.idatt2003.millions.view.component.card.Card;
 import edu.ntnu.idatt2003.millions.view.component.StyledText;
 import javafx.event.EventHandler;
 import javafx.geometry.Pos;

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/card/AverageInterestRateCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/card/AverageInterestRateCard.java
@@ -1,0 +1,57 @@
+package edu.ntnu.idatt2003.millions.view.dashboard.loans.card;
+
+import edu.ntnu.idatt2003.millions.model.loan.Loan;
+import edu.ntnu.idatt2003.millions.service.GameService;
+import edu.ntnu.idatt2003.millions.util.TableCells;
+import edu.ntnu.idatt2003.millions.view.component.InfoTooltip;
+import edu.ntnu.idatt2003.millions.view.component.StyledText;
+import edu.ntnu.idatt2003.millions.view.component.card.WidgetCard;
+import javafx.geometry.Pos;
+import javafx.scene.layout.HBox;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+
+/**
+ * Widget card showing the weighted average annual interest rate across active loans,
+ * weighted by outstanding principal. Displays "–" when there are no active loans.
+ */
+public class AverageInterestRateCard extends WidgetCard {
+
+    private final GameService gameService;
+    private final StyledText valueLabel = StyledText.widgetValue();
+
+    public AverageInterestRateCard(GameService gameService) {
+        super(gameService, "dashboard.loans.averageRate");
+        this.gameService = gameService;
+        InfoTooltip tooltip = new InfoTooltip("tooltip.loans.averageRate");
+        HBox titleRow = new HBox(5, titleLabel, tooltip);
+        titleRow.setAlignment(Pos.CENTER_LEFT);
+        tooltip.attachToParent(titleRow);
+        getChildren().addAll(titleRow, valueLabel);
+        refreshDisplay();
+    }
+
+    @Override
+    protected void refreshDisplay() {
+        List<Loan> loans = gameService.getPlayer().getActiveLoans();
+        if (loans.isEmpty()) {
+            valueLabel.setText("–");
+            return;
+        }
+        // Weighted average weekly rate: sum(principal_i * weeklyRate_i) / sum(principal_i)
+        BigDecimal totalPrincipal = BigDecimal.ZERO;
+        BigDecimal weightedSum = BigDecimal.ZERO;
+        for (Loan loan : loans) {
+            weightedSum = weightedSum.add(
+                    loan.principal().multiply(loan.offer().weeklyInterestRate()));
+            totalPrincipal = totalPrincipal.add(loan.principal());
+        }
+        BigDecimal avgWeeklyRate = weightedSum
+                .divide(totalPrincipal, 4, RoundingMode.HALF_UP)
+                .multiply(BigDecimal.valueOf(100))
+                .setScale(2, RoundingMode.HALF_UP);
+        valueLabel.setText(TableCells.NUMBER_FORMAT.format(avgWeeklyRate) + " %");
+    }
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/card/DebtRatioCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/card/DebtRatioCard.java
@@ -1,0 +1,68 @@
+package edu.ntnu.idatt2003.millions.view.dashboard.loans.card;
+
+import edu.ntnu.idatt2003.millions.model.player.Player;
+import edu.ntnu.idatt2003.millions.service.GameService;
+import edu.ntnu.idatt2003.millions.view.component.InfoTooltip;
+import edu.ntnu.idatt2003.millions.view.component.StyledText;
+import edu.ntnu.idatt2003.millions.view.component.card.WidgetCard;
+import javafx.geometry.Pos;
+import javafx.scene.control.ProgressBar;
+import javafx.scene.layout.HBox;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+/**
+ * Widget card showing the fraction of loan capacity in use, with a
+ * colour-coded progress bar: green below 60%, amber 60–85%, red above 85%.
+ */
+public class DebtRatioCard extends WidgetCard {
+
+    private final GameService gameService;
+    private final StyledText valueLabel = StyledText.widgetValue();
+    private final ProgressBar progressBar = new ProgressBar(0);
+
+    public DebtRatioCard(GameService gameService) {
+        super(gameService, "dashboard.loans.debtRatio");
+        this.gameService = gameService;
+        InfoTooltip tooltip = new InfoTooltip("tooltip.loans.debtRatio");
+        HBox titleRow = new HBox(5, titleLabel, tooltip);
+        titleRow.setAlignment(Pos.CENTER_LEFT);
+        tooltip.attachToParent(titleRow);
+        progressBar.getStyleClass().add("debt-ratio-bar");
+        progressBar.setMaxWidth(Double.MAX_VALUE);
+        getChildren().addAll(titleRow, valueLabel, progressBar);
+        refreshDisplay();
+    }
+
+    @Override
+    protected void refreshDisplay() {
+        Player player = gameService.getPlayer();
+        BigDecimal capacity = player.getLoanCapacity(gameService.getCurrencyConverter());
+        BigDecimal debt = player.getTotalDebt();
+
+        if (capacity.compareTo(BigDecimal.ZERO) == 0 || debt.compareTo(BigDecimal.ZERO) == 0) {
+            valueLabel.setText("0 %");
+            progressBar.setProgress(0);
+            applyBarColour(0.0);
+            return;
+        }
+
+        double ratio = debt.divide(capacity, 4, RoundingMode.HALF_UP).doubleValue();
+        int pct = (int) Math.round(ratio * 100);
+        valueLabel.setText(pct + " %");
+        progressBar.setProgress(Math.min(1.0, ratio));
+        applyBarColour(ratio);
+    }
+
+    private void applyBarColour(double ratio) {
+        progressBar.getStyleClass().removeAll("debt-bar-ok", "debt-bar-warning", "debt-bar-danger");
+        if (ratio < 0.60) {
+            progressBar.getStyleClass().add("debt-bar-ok");
+        } else if (ratio < 0.85) {
+            progressBar.getStyleClass().add("debt-bar-warning");
+        } else {
+            progressBar.getStyleClass().add("debt-bar-danger");
+        }
+    }
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/card/LoanCapacityCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/card/LoanCapacityCard.java
@@ -1,0 +1,42 @@
+package edu.ntnu.idatt2003.millions.view.dashboard.loans.card;
+
+import edu.ntnu.idatt2003.millions.service.GameService;
+import edu.ntnu.idatt2003.millions.util.CurrencyFormatter;
+import edu.ntnu.idatt2003.millions.util.LanguageManager;
+import edu.ntnu.idatt2003.millions.view.component.InfoTooltip;
+import edu.ntnu.idatt2003.millions.view.component.StyledText;
+import edu.ntnu.idatt2003.millions.view.component.card.WidgetCard;
+import javafx.geometry.Pos;
+import javafx.scene.layout.HBox;
+
+/**
+ * Widget card showing the player's total loan capacity (50% of net worth).
+ *
+ * <p>The subtitle text ("Maks 50% av nettoverdi") is editorial copy that
+ * intentionally mirrors {@code Player.MAX_DEBT_RATIO}. If that constant
+ * changes, update {@code dashboard.loans.capacity.subtitle} in both i18n files.
+ */
+public class LoanCapacityCard extends WidgetCard {
+
+    private final GameService gameService;
+    private final StyledText valueLabel = StyledText.widgetValue();
+    private final StyledText subtitleLabel = StyledText.widgetSubtitle();
+
+    public LoanCapacityCard(GameService gameService) {
+        super(gameService, "dashboard.loans.capacity");
+        this.gameService = gameService;
+        InfoTooltip tooltip = new InfoTooltip("tooltip.loans.capacity");
+        HBox titleRow = new HBox(5, titleLabel, tooltip);
+        titleRow.setAlignment(Pos.CENTER_LEFT);
+        tooltip.attachToParent(titleRow);
+        getChildren().addAll(titleRow, valueLabel, subtitleLabel);
+        refreshDisplay();
+    }
+
+    @Override
+    protected void refreshDisplay() {
+        valueLabel.setText(CurrencyFormatter.format(
+                gameService.getPlayer().getLoanCapacity(gameService.getCurrencyConverter())));
+        subtitleLabel.setText(LanguageManager.get("dashboard.loans.capacity.subtitle"));
+    }
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/card/TotalDebtCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/card/TotalDebtCard.java
@@ -1,0 +1,168 @@
+package edu.ntnu.idatt2003.millions.view.dashboard.loans.card;
+
+import edu.ntnu.idatt2003.millions.service.GameService;
+import edu.ntnu.idatt2003.millions.util.ChangeFormatter;
+import edu.ntnu.idatt2003.millions.util.CurrencyFormatter;
+import edu.ntnu.idatt2003.millions.util.LanguageManager;
+import edu.ntnu.idatt2003.millions.view.component.InfoTooltip;
+import edu.ntnu.idatt2003.millions.view.component.StyledText;
+import edu.ntnu.idatt2003.millions.view.component.card.Card;
+import javafx.collections.ListChangeListener;
+import javafx.geometry.Pos;
+import javafx.scene.chart.BarChart;
+import javafx.scene.chart.CategoryAxis;
+import javafx.scene.chart.NumberAxis;
+import javafx.scene.chart.XYChart;
+import javafx.scene.control.Tooltip;
+import javafx.scene.layout.HBox;
+import javafx.util.StringConverter;
+
+import java.math.BigDecimal;
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Large card on the Loans tab showing total outstanding debt and its
+ * week-by-week history as a bar chart.
+ *
+ * <p>Extends {@link Card} directly (not {@link edu.ntnu.idatt2003.millions.view.component.card.WidgetCard})
+ * because it owns a chart and lifecycle logic beyond a single number tile,
+ * mirroring how {@code NetWorthCard} is structured on the Portfolio tab.</p>
+ *
+ * <p>The change line uses INVERTED colour semantics: debt increasing is bad
+ * (red), debt decreasing is good (green). This is the opposite of NetWorthCard.</p>
+ */
+public class TotalDebtCard extends Card {
+
+    private final GameService gameService;
+
+    private final StyledText titleLabel  = StyledText.widgetLabel();
+    private final StyledText valueLabel  = StyledText.widgetValue();
+    private final StyledText changeLabel = StyledText.widgetChange();
+
+    private final XYChart.Series<String, Number> series = new XYChart.Series<>();
+
+    public TotalDebtCard(GameService gameService) {
+        super(gameService);
+        this.gameService = gameService;
+
+        setSpacing(4);
+
+        CategoryAxis xAxis = new CategoryAxis();
+        xAxis.setLabel(LanguageManager.get("app.week"));
+
+        NumberAxis yAxis = new NumberAxis();
+        yAxis.setAutoRanging(true);
+        yAxis.setForceZeroInRange(true);
+        yAxis.setTickLabelFormatter(new StringConverter<>() {
+            @Override
+            public String toString(Number n) {
+                return String.format(Locale.of("no"), "%,.0f", n.doubleValue());
+            }
+            @Override
+            public Number fromString(String s) { return null; }
+        });
+
+        // Install hover tooltips on each bar as it is added to the series.
+        series.getData().addListener((ListChangeListener<XYChart.Data<String, Number>>) change -> {
+            while (change.next()) {
+                change.getAddedSubList().forEach(d -> {
+                    if (d.getNode() != null) installBarTooltip(d);
+                    // Node may not be ready yet; listen for it on the property.
+                    else d.nodeProperty().addListener((obs, old, node) -> {
+                        if (node != null) installBarTooltip(d);
+                    });
+                });
+            }
+        });
+
+        BarChart<String, Number> chart = new BarChart<>(xAxis, yAxis);
+        chart.getData().add(series);
+        chart.setLegendVisible(false);
+        chart.setAnimated(false);
+        chart.getStyleClass().add("debt-bar-chart");
+
+        InfoTooltip infoTooltip = new InfoTooltip("tooltip.loans.totalDebt");
+        HBox titleRow = new HBox(5, titleLabel, infoTooltip);
+        titleRow.setAlignment(Pos.CENTER_LEFT);
+        infoTooltip.attachToParent(titleRow);
+
+        getChildren().addAll(titleRow, valueLabel, changeLabel, chart);
+
+        loadHistory();
+        refreshDisplay();
+    }
+
+    private void loadHistory() {
+        List<BigDecimal> history = gameService.getPlayer().getTotalDebtHistory();
+        for (int i = 0; i < history.size(); i++) {
+            series.getData().add(new XYChart.Data<>(String.valueOf(i + 1), history.get(i).doubleValue()));
+        }
+    }
+
+    private void installBarTooltip(XYChart.Data<String, Number> d) {
+        String weekLabel = d.getXValue();
+        String amount = CurrencyFormatter.format(
+                new BigDecimal(d.getYValue().toString()).setScale(2, java.math.RoundingMode.HALF_UP));
+        String text = MessageFormat.format(
+                LanguageManager.get("loans.debtChart.barTooltip"), weekLabel, amount);
+        Tooltip tooltip = new Tooltip(text);
+        Tooltip.install(d.getNode(), tooltip);
+    }
+
+    private void refreshDisplay() {
+        titleLabel.setText(LanguageManager.get("dashboard.loans.totalDebt"));
+
+        BigDecimal debt = gameService.getPlayer().getTotalDebt();
+        valueLabel.setText(CurrencyFormatter.format(debt));
+
+        List<BigDecimal> history = gameService.getPlayer().getTotalDebtHistory();
+        if (history.size() < 2) {
+            changeLabel.setText("–");
+            changeLabel.getStyleClass().removeAll("positive", "negative");
+        } else {
+            BigDecimal prev = history.get(history.size() - 2);
+            BigDecimal curr = history.getLast();
+            BigDecimal delta = curr.subtract(prev);
+
+            String arrow = delta.compareTo(BigDecimal.ZERO) >= 0 ? "↗" : "↘";
+            String sign  = delta.compareTo(BigDecimal.ZERO) >= 0 ? "+" : "";
+
+            BigDecimal pct = prev.compareTo(BigDecimal.ZERO) == 0
+                    ? BigDecimal.ZERO
+                    : delta.multiply(BigDecimal.valueOf(100))
+                            .divide(prev, 1, java.math.RoundingMode.HALF_UP);
+
+            changeLabel.setText(arrow + " " + ChangeFormatter.formatSignedPercent(pct)
+                    + "  " + sign + CurrencyFormatter.format(delta.abs()));
+
+            // Debt semantics are inverted: an increase is bad (red), a decrease is good (green).
+            // ColourChange.applyChangeStyle would colour debt-increase green — the opposite of what
+            // we want — so we apply the modifier classes manually here.
+            changeLabel.getStyleClass().removeAll("positive", "negative");
+            if (delta.compareTo(BigDecimal.ZERO) > 0) {
+                changeLabel.getStyleClass().add("negative"); // debt went up → red
+            } else if (delta.compareTo(BigDecimal.ZERO) < 0) {
+                changeLabel.getStyleClass().add("positive"); // debt went down → green
+            }
+        }
+
+    }
+
+    @Override
+    public void onGameUpdated() {
+        List<BigDecimal> history = gameService.getPlayer().getTotalDebtHistory();
+        if (!history.isEmpty()) {
+            int week = history.size();
+            double debtValue = history.getLast().doubleValue();
+            series.getData().add(new XYChart.Data<>(String.valueOf(week), debtValue));
+        }
+        refreshDisplay();
+    }
+
+    @Override
+    protected void onLanguageChanged() {
+        refreshDisplay();
+    }
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/card/WeeklyInterestCostCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/card/WeeklyInterestCostCard.java
@@ -1,0 +1,45 @@
+package edu.ntnu.idatt2003.millions.view.dashboard.loans.card;
+
+import edu.ntnu.idatt2003.millions.model.loan.Loan;
+import edu.ntnu.idatt2003.millions.service.GameService;
+import edu.ntnu.idatt2003.millions.util.CurrencyFormatter;
+import edu.ntnu.idatt2003.millions.view.component.InfoTooltip;
+import edu.ntnu.idatt2003.millions.view.component.StyledText;
+import edu.ntnu.idatt2003.millions.view.component.card.WidgetCard;
+import javafx.geometry.Pos;
+import javafx.scene.layout.HBox;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+
+/**
+ * Widget card showing the total weekly interest cost across all active loans.
+ */
+public class WeeklyInterestCostCard extends WidgetCard {
+
+    private final GameService gameService;
+    private final StyledText valueLabel = StyledText.widgetValue();
+
+    public WeeklyInterestCostCard(GameService gameService) {
+        super(gameService, "dashboard.loans.weeklyCost");
+        this.gameService = gameService;
+        InfoTooltip tooltip = new InfoTooltip("tooltip.loans.weeklyCost");
+        HBox titleRow = new HBox(5, titleLabel, tooltip);
+        titleRow.setAlignment(Pos.CENTER_LEFT);
+        tooltip.attachToParent(titleRow);
+        getChildren().addAll(titleRow, valueLabel);
+        refreshDisplay();
+    }
+
+    @Override
+    protected void refreshDisplay() {
+        List<Loan> loans = gameService.getPlayer().getActiveLoans();
+        BigDecimal total = loans.stream()
+                .map(l -> l.principal()
+                        .multiply(l.offer().weeklyInterestRate())
+                        .setScale(2, RoundingMode.HALF_UP))
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        valueLabel.setText(CurrencyFormatter.format(total));
+    }
+}

--- a/src/main/resources/css/loans.css
+++ b/src/main/resources/css/loans.css
@@ -43,3 +43,24 @@
     -fx-text-fill: -danger-text;
     -fx-border-color: -danger-border;
 }
+
+/* Debt ratio progress bar */
+.debt-ratio-bar {
+    -fx-max-width: infinity;
+    -fx-pref-height: 8;
+}
+
+.debt-ratio-bar > .track {
+    -fx-background-color: -border-light;
+    -fx-background-insets: 0;
+    -fx-background-radius: 4;
+}
+
+.debt-ratio-bar > .bar {
+    -fx-background-insets: 0;
+    -fx-background-radius: 4;
+}
+
+.debt-ratio-bar.debt-bar-ok > .bar      { -fx-background-color: -success; }
+.debt-ratio-bar.debt-bar-warning > .bar { -fx-background-color: -warning; }
+.debt-ratio-bar.debt-bar-danger > .bar  { -fx-background-color: -danger; }

--- a/src/main/resources/css/loans.css
+++ b/src/main/resources/css/loans.css
@@ -64,3 +64,19 @@
 .debt-ratio-bar.debt-bar-ok > .bar      { -fx-background-color: -success; }
 .debt-ratio-bar.debt-bar-warning > .bar { -fx-background-color: -warning; }
 .debt-ratio-bar.debt-bar-danger > .bar  { -fx-background-color: -danger; }
+
+/* Debt history bar chart */
+.debt-bar-chart {
+    -fx-background-color: transparent;
+}
+.debt-bar-chart .chart-plot-background {
+    -fx-background-color: transparent;
+}
+.debt-bar-chart .chart-vertical-grid-lines,
+.debt-bar-chart .chart-horizontal-grid-lines {
+    -fx-stroke: transparent;
+}
+.debt-bar-chart .chart-bar {
+    -fx-bar-fill: -warning;
+    -fx-background-radius: 2 2 0 0;
+}

--- a/src/main/resources/css/tokens.css
+++ b/src/main/resources/css/tokens.css
@@ -14,6 +14,7 @@
     -success-text:     #2E5A0E;
     -success-border:   #C4DDA0;
 
+    -warning:          #e67e22;
     -warning-bg:       #FAEEDA;
     -warning-text:     #854F0B;
     -warning-border:   #F2D89C;

--- a/src/main/resources/css/typography.css
+++ b/src/main/resources/css/typography.css
@@ -11,3 +11,6 @@
 /* Detail rows in modals, dialogs, and receipts */
 .detail-label  { -fx-font-size: 13; -fx-text-fill: -text-secondary; }
 .detail-value  { -fx-font-size: 13; -fx-text-fill: -text-primary; }
+
+/* Muted secondary line below a widget value */
+.widget-subtitle { -fx-font-size: 12; -fx-text-fill: -text-secondary; }

--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -75,6 +75,37 @@ exchange.overview.roseThisWeek=Rose this week (+)
 exchange.overview.fellThisWeek=Fell this week (-)
 exchange.overview.weeklyWinners=Top winners
 exchange.overview.weeklyLosers=Top losers
+# Exchange - Stocks tab
+exchange.stocks.portfolio=Your portfolio
+exchange.stocks.portfolio.sub=Starting capital
+exchange.stocks.available=Available
+exchange.stocks.available.sub=After purchase
+exchange.stocks.invested=Invested
+exchange.stocks.invested.positions={0} positions
+exchange.stocks.unrealized=Unrealized gain
+exchange.stocks.unrealized.sub=Since purchase
+exchange.stocks.search.placeholder=Search by ticker or company...
+exchange.stocks.sort.clear=Clear sort
+exchange.stocks.status=Showing {0} of {1} stocks. Price data updates at end of week
+exchange.stocks.col.ticker=Ticker
+exchange.stocks.col.company=Company
+exchange.stocks.col.priceUSD=Price in USD
+exchange.stocks.col.priceNOK=Price in NOK
+exchange.stocks.col.changeKr=+/- NOK
+exchange.stocks.col.changePct=+/- %
+exchange.stocks.col.highLow4=4w H/L
+exchange.stocks.col.trend=Trend
+exchange.stocks.col.trade=Trade
+exchange.stocks.badge.owner=Owner
+exchange.stocks.buy=Buy
+exchange.stocks.sell=Sell
+exchange.stocks.no.data=0
+exchange.stocks.empty=No stocks found
+exchange.stocks.empty.search=No stocks found for "{0}"
+# Pagination
+pagination.prev=< Previous
+pagination.next=Next >
+pagination.pages={0} / {1} pages
 # Exit dialog
 exit.confirmHeader=Are you sure you want to exit?
 exit.confirmContent=You can save the game before exiting.
@@ -85,6 +116,10 @@ exit.cancel=Cancel
 status.novice=Novice
 status.investor=Investor
 status.speculator=Speculator
+# Footer
+footer.player=Player
+footer.equity=Equity
+footer.available=Available
 # Dashboard - Portfolio dialogs
 dialog.buy.title=Buy shares
 dialog.sell.title=Sell shares
@@ -107,6 +142,8 @@ dialog.balance.available=Available now
 dialog.balance.afterBuy=After purchase
 dialog.balance.afterSell=After sale
 dialog.error.insufficientFunds=You don't have enough money for this purchase.
+dialog.error.tooManyDecimals=Quantity may have at most 4 decimal places.
+dialog.error.belowMinimumValue=Order value must be at least 1.00 NOK.
 dialog.profit.gain=Gain on this sale
 dialog.profit.loss=Loss on this sale
 dialog.button.cancel=Cancel
@@ -159,7 +196,7 @@ tooltip.dashboard.weeklyChange=Change in equity since last week.
 tooltip.dashboard.portfolioValue=Market value of all your shares, converted to NOK. Tax and commission are not deducted.
 tooltip.dashboard.status=Novice: starting level. Investor: traded 10+ weeks and grown 20%. Speculator: traded 20+ weeks and doubled equity.
 # Tooltips - Holdings table column headers
-tooltip.holdings.valueNok=Market value in NOK (latest price � quantity, converted via exchange rate). Tax and commission are not deducted.
+tooltip.holdings.valueNok=Market value in NOK (latest price x quantity, converted via exchange rate). Tax and commission are not deducted.
 # Tooltips - Realized returns
 tooltip.realized.gain=Sum of profit from all sales you made a gain on (tax and commission deducted), converted to NOK.
 tooltip.realized.loss=Sum of losses from all sales you made a loss on (commission deducted), converted to NOK.
@@ -171,7 +208,7 @@ tooltip.details.gav=Average purchase price per share: total cost divided by tota
 tooltip.details.liquidation=What you would actually receive in NOK if you sold the entire position now. Commission (1%) and tax on gain (30%) are already deducted.
 tooltip.details.returnNative=Gain or loss in the stock's native currency: market value minus purchase cost.
 tooltip.details.return=Gain or loss: market value minus purchase cost.
-tooltip.details.marketValue=What the position is worth now based on today's stock price (latest price � quantity). A theoretical value before fees - see liquidation value for what you actually receive when selling.
+tooltip.details.marketValue=What the position is worth now based on today's stock price (latest price x quantity). A theoretical value before fees - see liquidation value for what you actually receive when selling.
 tooltip.details.marketValueNok=The same market value converted to NOK at today's exchange rate.
 # Tooltips - Shared (used in multiple places)
 tooltip.shared.weeklyChange=Percentage change in the stock price since last week.
@@ -200,6 +237,13 @@ transactions.summary.weekRange=WEEK {0}-{1}
 transactions.activity.title=Trading activity
 filter.week=Week
 dashboard.loans.available.title=Available loans
+dashboard.loans.totalDebt=Total debt
+dashboard.loans.debtHistory=Debt history - week {0}-{1}
+dashboard.loans.weeklyCost=Weekly interest cost
+dashboard.loans.averageRate=Average interest rate
+dashboard.loans.capacity=Loan capacity
+dashboard.loans.capacity.subtitle=Max 50% of net worth
+dashboard.loans.debtRatio=Debt ratio
 
 loans.risk.low=LOW RISK
 loans.risk.medium=MEDIUM RISK
@@ -277,3 +321,10 @@ loans.details.cost.remaining=Remaining interest
 loans.details.cost.total=Total cost
 loans.details.button.repay=Repay loan
 receipt.button.close=Close
+# Loan widget card tooltips
+tooltip.loans.totalDebt=The sum of outstanding principal across all active loans.
+loans.debtChart.barTooltip=Week {0}: {1}
+tooltip.loans.weeklyCost=The sum of weekly interest you pay on all active loans, based on outstanding balance.
+tooltip.loans.averageRate=Weighted average weekly interest rate on your active loans, weighted by outstanding balance.
+tooltip.loans.capacity=You can have outstanding loans for up to 50% of your net worth. This limit updates as your net worth changes.
+tooltip.loans.debtRatio=How much of your loan capacity is in use. Try to stay below 60% to have room for new loans.

--- a/src/main/resources/i18n/messages_no.properties
+++ b/src/main/resources/i18n/messages_no.properties
@@ -172,7 +172,7 @@ receipt.button.close=Lukk
 # Dashboard - Share details modal
 details.title=Detaljer om din andel
 details.stock.label=Aksje
-details.stock.hint=Handlet i {0} ? Aksjekurs: {1} {0}
+details.stock.hint=Handlet i {0} - Aksjekurs: {1} {0}
 details.section.position=Din posisjon
 details.section.now=Verdi nå
 details.section.return=Avkastning
@@ -196,7 +196,7 @@ tooltip.dashboard.weeklyChange=Endring i egenkapital siden forrige uke.
 tooltip.dashboard.portfolioValue=Markedsverdi av alle dine andeler omregnet til NOK. Skatt og kurtasje er ikke trukket fra.
 tooltip.dashboard.status=Novice: startnivå. Investor: 10+ uker handlet og 20% vekst. Speculator: 20+ uker handlet og doblet egenkapital.
 # Tooltips - Holdings table column headers
-tooltip.holdings.valueNok=Markedsverdi i NOK (siste pris × antall, omregnet via valutakurs). Skatt og kurtasje er ikke trukket fra.
+tooltip.holdings.valueNok=Markedsverdi i NOK (siste pris x antall, omregnet via valutakurs). Skatt og kurtasje er ikke trukket fra.
 # Tooltips - Realized returns
 tooltip.realized.gain=Sum av profitt fra alle salg du har gått i pluss på (skatt og kurtasje trukket fra), omregnet til NOK.
 tooltip.realized.loss=Sum av tap fra alle salg du har gått i minus på (kurtasje trukket fra), omregnet til NOK.
@@ -208,7 +208,7 @@ tooltip.details.gav=Gjennomsnittlig kjøpspris per andel: total kostnad delt på t
 tooltip.details.liquidation=Hva du faktisk får utbetalt i NOK hvis du selger hele posisjonen nå. Kurtasje (1%) og skatt på gevinst (30%) er allerede trukket fra.
 tooltip.details.returnNative=Gevinst eller tap i aksjens egen valuta: markedsverdi minus kjøpskostnad.
 tooltip.details.return=Gevinst eller tap: markedsverdi minus kjøpskostnad.
-tooltip.details.marketValue=Det posisjonen er verdt nå basert på dagens aksjekurs (siste pris × antall). Dette er en teoretisk verdi før gebyrer - se likviditetsverdi for hva du faktisk får ved salg.
+tooltip.details.marketValue=Det posisjonen er verdt nå basert på dagens aksjekurs (siste pris x antall). Dette er en teoretisk verdi før gebyrer - se likviditetsverdi for hva du faktisk får ved salg.
 tooltip.details.marketValueNok=Samme markedsverdi omregnet til NOK via dagens valutakurs.
 # Tooltips - Shared (used in multiple places)
 tooltip.shared.weeklyChange=Prosentvis endring i aksjekursen siden forrige uke.
@@ -237,6 +237,13 @@ transactions.summary.weekRange=UKE {0}-{1}
 transactions.activity.title=Handelsaktivitet
 filter.week=Uke
 dashboard.loans.available.title=Tilgjengelige lån
+dashboard.loans.totalDebt=Total gjeld
+dashboard.loans.debtHistory=Gjeldsutvikling - uke {0}-{1}
+dashboard.loans.weeklyCost=Ukentlig rentekostnad
+dashboard.loans.averageRate=Gj.snittlig rente
+dashboard.loans.capacity=Lånekapasitet
+dashboard.loans.capacity.subtitle=Maks 50% av nettoverdi
+dashboard.loans.debtRatio=Gjeldsgrad
 
 loans.risk.low=LAV RISIKO
 loans.risk.medium=MEDIUM RISIKO
@@ -313,3 +320,10 @@ loans.details.cost.paid=Rente betalt så langt
 loans.details.cost.remaining=Gjenværende rente
 loans.details.cost.total=Total kostnad
 loans.details.button.repay=Innfri lån
+# Loan widget card tooltips
+tooltip.loans.totalDebt=Summen av gjenstående hovedstol på alle aktive lån.
+loans.debtChart.barTooltip=Uke {0}: {1}
+tooltip.loans.weeklyCost=Summen av ukentlig rente du betaler på alle aktive lån, basert på gjenstående saldo.
+tooltip.loans.averageRate=Vektet gjennomsnittlig ukentlig rente på dine aktive lån, vektet etter gjenstående saldo.
+tooltip.loans.capacity=Du kan ha utestående lån for inntil 50% av nettoverdien din. Denne grensen oppdateres når nettoverdien endrer seg.
+tooltip.loans.debtRatio=Hvor mye av din lånekapasitet som er brukt. Holder seg gjerne under 60% for å ha rom til nye lån.

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/PlayerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/PlayerTest.java
@@ -391,6 +391,99 @@ class PlayerTest {
     }
 
     @Nested
+    @DisplayName("recordTotalDebt()")
+    class RecordTotalDebt {
+
+        @Test
+        @DisplayName("Should append current total debt to history")
+        void appendsCurrentTotalDebtToHistory() {
+            // Arrange
+            int initialSize = player.getTotalDebtHistory().size();
+            // Act
+            player.recordTotalDebt();
+            // Assert
+            assertEquals(initialSize + 1, player.getTotalDebtHistory().size());
+        }
+
+        @Test
+        @DisplayName("Should record matching value as getTotalDebt")
+        void recordsMatchingValue() {
+            // Arrange
+            BigDecimal expected = player.getTotalDebt();
+            // Act
+            player.recordTotalDebt();
+            // Assert
+            BigDecimal recorded = player.getTotalDebtHistory().getLast();
+            assertEquals(0, expected.compareTo(recorded));
+        }
+
+        @Test
+        @DisplayName("Should record zero debt when no loans are active")
+        void recordsZeroWhenNoLoans() {
+            // Act
+            player.recordTotalDebt();
+            // Assert
+            assertEquals(0, BigDecimal.ZERO.compareTo(player.getTotalDebtHistory().getLast()));
+        }
+
+        @Test
+        @DisplayName("Should support multiple recordings in order")
+        void supportsMultipleRecordings() {
+            // Arrange
+            LoanOffer offer = new LoanOffer("test", new BigDecimal("0.01"), 10,
+                    new BigDecimal("50000.00"), LoanRiskLevel.LOW);
+            player.recordTotalDebt(); // debt = 0
+            player.takeLoan(new Loan(offer, new BigDecimal("200.00"), 0), converter);
+            player.recordTotalDebt(); // debt = 200
+            // Act
+            List<BigDecimal> history = player.getTotalDebtHistory();
+            // Assert: two recordings
+            assertEquals(2, history.size());
+            assertTrue(history.getLast().compareTo(history.getFirst()) > 0);
+        }
+    }
+
+    @Nested
+    @DisplayName("getTotalDebtHistory()")
+    class GetTotalDebtHistory {
+
+        @Test
+        @DisplayName("Should start empty before any recording")
+        void startsEmpty() {
+            assertTrue(player.getTotalDebtHistory().isEmpty());
+        }
+
+        @Test
+        @DisplayName("Should return a copy that does not affect the internal list")
+        void returnsCopy() {
+            // Arrange
+            player.recordTotalDebt();
+            List<BigDecimal> history = player.getTotalDebtHistory();
+            // Act
+            history.clear();
+            // Assert
+            assertFalse(player.getTotalDebtHistory().isEmpty());
+        }
+
+        @Test
+        @DisplayName("Should reflect every recordTotalDebt call in order")
+        void reflectsRecordingsInOrder() {
+            // Arrange
+            LoanOffer offer = new LoanOffer("test", new BigDecimal("0.01"), 10,
+                    new BigDecimal("50000.00"), LoanRiskLevel.LOW);
+            player.recordTotalDebt(); // 0
+            player.takeLoan(new Loan(offer, new BigDecimal("100.00"), 0), converter);
+            player.recordTotalDebt(); // 100
+            // Act
+            List<BigDecimal> history = player.getTotalDebtHistory();
+            // Assert
+            assertEquals(2, history.size());
+            assertEquals(0, BigDecimal.ZERO.compareTo(history.getFirst()));
+            assertEquals(0, new BigDecimal("100.00").compareTo(history.getLast()));
+        }
+    }
+
+    @Nested
     @DisplayName("getStatus()")
     class GetStatus {
 

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/PlayerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/PlayerTest.java
@@ -608,9 +608,9 @@ class PlayerTest {
         @Test
         @DisplayName("getTotalDebt() sums principals of multiple loans")
         void getTotalDebtSumsMultipleLoans() {
-            // Arrange — player starts with 1000, capacity = 500
+            // Arrange — player starts with 1000, net worth=1000, capacity=500
             player.takeLoan(new Loan(offer, new BigDecimal("200.00"), 0), converter);
-            // After first loan: money=1200, capacity=600, available=400
+            // After first loan: money=1200, debt=200, net worth=1000, capacity=500, available=300
             player.takeLoan(new Loan(offer, new BigDecimal("150.00"), 0), converter);
             // Assert
             assertEquals(0, new BigDecimal("350.00").compareTo(player.getTotalDebt()));
@@ -748,6 +748,76 @@ class PlayerTest {
             Loan loan = new Loan(offer, new BigDecimal("200.00"), 0);
             // Act & Assert — loan never taken, so not in active list
             assertThrows(IllegalArgumentException.class, () -> player.repayLoan(loan));
+        }
+
+        @Test
+        @DisplayName("getNetWorth() subtracts outstanding debt")
+        void getNetWorthSubtractsDebt() {
+            // Arrange — player starts with 1000 cash
+            BigDecimal principal = new BigDecimal("300.00");
+            player.takeLoan(new Loan(offer, principal, 0), converter);
+            // money = 1300, debt = 300 → net worth = 1300 - 300 = 1000
+            assertEquals(0, new BigDecimal("1000.00").compareTo(player.getNetWorth(converter)));
+        }
+
+        @Test
+        @DisplayName("Taking a loan does not change net worth")
+        void takingLoanDoesNotChangeNetWorth() {
+            // Arrange
+            BigDecimal before = player.getNetWorth(converter);
+            // Act
+            player.takeLoan(new Loan(offer, new BigDecimal("300.00"), 0), converter);
+            // Assert — cash up by 300, debt up by 300: net effect is zero
+            assertEquals(0, before.compareTo(player.getNetWorth(converter)));
+        }
+
+        @Test
+        @DisplayName("Repaying a loan does not change net worth")
+        void repayingLoanDoesNotChangeNetWorth() {
+            // Arrange
+            Loan loan = new Loan(offer, new BigDecimal("300.00"), 0);
+            player.takeLoan(loan, converter);
+            BigDecimal before = player.getNetWorth(converter);
+            // Act
+            player.repayLoan(loan);
+            // Assert — cash down by 300, debt down by 300: net effect is zero
+            assertEquals(0, before.compareTo(player.getNetWorth(converter)));
+        }
+
+        @Test
+        @DisplayName("getNetWorth() can be negative when debt exceeds assets")
+        void getNetWorthCanBeNegative() {
+            // Arrange — take a loan, then drain cash below the principal
+            Loan loan = new Loan(offer, new BigDecimal("400.00"), 0);
+            player.takeLoan(loan, converter);        // cash=1400, debt=400, net worth=1000
+            player.withdrawMoney(new BigDecimal("1390.00")); // cash=10, debt=400, net worth=-390
+            // Act & Assert
+            assertTrue(player.getNetWorth(converter).compareTo(BigDecimal.ZERO) < 0);
+        }
+
+        @Test
+        @DisplayName("getLoanCapacity() clamps to zero when net worth is negative")
+        void getLoanCapacityIsZeroOnNegativeNetWorth() {
+            // Arrange — same setup as above produces negative net worth
+            Loan loan = new Loan(offer, new BigDecimal("400.00"), 0);
+            player.takeLoan(loan, converter);
+            player.withdrawMoney(new BigDecimal("1390.00"));
+            // Act & Assert
+            assertEquals(0, BigDecimal.ZERO.compareTo(player.getLoanCapacity(converter)));
+        }
+
+        @Test
+        @DisplayName("Stacking loans to bypass the 50% cap is blocked")
+        void stackingLoansIsBlocked() {
+            // Arrange — player starts with 10 000 NOK, capacity = 5 000
+            Player rich = new Player("Rich", new BigDecimal("10000.00"));
+            LoanOffer bigOffer = new LoanOffer("big", new BigDecimal("0.01"), 10,
+                    new BigDecimal("50000.00"), LoanRiskLevel.LOW);
+            // First loan fills capacity exactly: debt=5000, net worth still 10000, available=0
+            rich.takeLoan(new Loan(bigOffer, new BigDecimal("5000.00"), 0), converter);
+            // Act & Assert — any further loan must be rejected
+            assertThrows(ExcessiveDebtException.class, () ->
+                    rich.takeLoan(new Loan(bigOffer, new BigDecimal("1.00"), 0), converter));
         }
     }
 }


### PR DESCRIPTION
Builds on the previous loan PR by adding the missing widget cards on the right side of the Loans tab and a large TotalDebtCard with a bar chart on the left. Also fixes an underlying bug in `Player.getNetWorth()` that was causing loan capacity to inflate incorrectly.
 
## What this adds
 
### Loan stats widget cards (right column)
 
Four `WidgetCard`-style cards stacked vertically:
 
- **Weekly interest cost** - sum of `remainingPrincipal × weeklyRate` across all active loans, the NOK amount deducted each `advanceWeek()`
- **Average interest rate** - weighted average annual rate across active loans, weighted by remaining principal. Shows "-" when no active loans.
- **Loan capacity** - `player.getLoanCapacity()`, with a muted subtitle "Maks 50% av nettoverdi" / "Max 50% of net worth"
- **Debt ratio** - `totalDebt / loanCapacity` as a percentage, with a colour-coded progress bar at 60% / 85% thresholds
Each card follows the existing widget card pattern: title with `InfoTooltip`, `StyledText.widgetValue()` for the number, lifecycle handled by `WidgetCard` base.
 
### TotalDebtCard (left column)
 
A large card mirroring `NetWorthCard`'s structure on the Portfolio tab:
 
- Title + tooltip
- Current total debt formatted via `CurrencyFormatter`
- Weekly change line showing arrow + signed percent + signed NOK amount, with **inverted colour semantics** relative to net worth: rising debt is red, falling debt is green
- `BarChart` of debt history with one bar per week, hover tooltips showing the exact NOK amount per week
- Subtitle below the chart showing the date range covered
Bars rather than an area chart because debt is naturally discrete - it only changes when loans are taken or repaid, not continuously like net worth. Hover tooltips on each bar give per-week detail without needing click interactions.
 
### Bug fix: `Player.getNetWorth()` now subtracts debt
 
Previously:
 
```java
return money.add(portfolio.getNetWorth());
```
 
Now:
 
```java
return money.add(portfolio.getNetWorth()).subtract(getTotalDebt());
```
 
This is the right definition economically - borrowed money isn't real wealth. Without this fix, taking a loan increased the player's net worth, which increased their loan capacity (50% of net worth), which would have let them take a larger loan, inflating net worth further. The 50% cap was bypassable in a self-reinforcing loop.
 
`getLoanCapacity()` is also clamped to non-negative values so the UI displays sensibly when a player's debt exceeds their assets (which can happen if the market drops sharply after a loan is taken).
 
### Domain support for debt history
 
`Player` gained a `totalDebtHistory` list, mirroring how `netWorthHistory` works. `GameService.advanceWeek()` now calls `player.recordTotalDebt()` alongside `player.recordNetWorth()` so the bar chart has data to render.
 
### Merge cleanup
 
One commit (`refactor: imports affected by merge`) cleans up import paths after `Card` was moved into `view/component/card/` on main. Several loan-tab classes were importing from the old location and would no longer compile.
 
## Design decisions worth highlighting
 
**Bars, not an area chart, for debt history.** Net worth flows continuously - share prices move every week, so an area chart's interpolation reflects reality. Debt jumps discretely - it only changes when a loan is taken or repaid, with weekly interest deductions as the only smooth component. Bars represent this honestly. A continuous chart would imply gradual change that doesn't exist between loan events.
 
**Inverted colour semantics on the debt change line.** On `NetWorthCard`, green = increase (you got richer); on `TotalDebtCard`, green = decrease (you owe less). The semantic inversion is documented in a code comment so a future reader doesn't "fix" it.
 
**Net worth must subtract debt.** This is the bigger structural fix. Loan capacity is defined as a percentage of net worth, so if net worth itself included borrowed money, the cap would inflate every time the player borrows - making the 50% rule meaningless as a forward-looking constraint. Now the rule works as intended: the player's loan ceiling is anchored to their actual equity, not to their cash flow.
 
**Debt ratio can exceed 100%.** This is a known and intentional state - it happens when the portfolio loses enough value that current debt exceeds current net worth. We don't try to prevent this retroactively because that would make the 50% cap meaningless as a forward check. The cap is enforced at the moment of taking the loan; market risk is a hazard the player accepts when they borrow to invest. The UI communicates the elevated risk through the progress bar's colour scale. A follow-up issue will add explicit "over 100%" styling and a clearer warning state.
 
## Out of scope (tracked separately)
 
- Explicit "over 100% debt ratio" visual treatment (current behaviour: the bar simply caps at the highest colour band)
- Forced share sale when the player can't cover weekly interest
- Persisting `totalDebtHistory` across save/load (if the existing save schema serialises `netWorthHistory`, this field should be added to match - check before merging if save/load is in scope for this milestone)
