### PR TITLE
feat: introduce custom exception classes with structured payloads

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/LoanController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/LoanController.java
@@ -115,7 +115,7 @@ public class LoanController {
         try {
             gameService.repayLoan(loan);
             dialog.close();
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             dialog.showError(e.getMessage());
         }
     }

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/PortfolioController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/PortfolioController.java
@@ -165,7 +165,7 @@ public class PortfolioController {
             BigDecimal balanceAfter = gameService.getPlayer().getMoney();
             Platform.runLater(() ->
                     new BuyReceipt(transaction, balanceBefore, balanceAfter, preview).show());
-        } catch (Exception e) {
+        } catch (IllegalArgumentException | IllegalStateException e) {
             String message = e.getMessage();
             if (message == null || message.isBlank()) {
                 message = e.getClass().getSimpleName();
@@ -190,7 +190,7 @@ public class PortfolioController {
             BigDecimal balanceAfter = gameService.getPlayer().getMoney();
             Platform.runLater(() ->
                     new SellReceipt(transaction, balanceBefore, balanceAfter, preview).show());
-        } catch (Exception e) {
+        } catch (IllegalArgumentException | IllegalStateException e) {
             String message = e.getMessage();
             if (message == null || message.isBlank()) {
                 message = e.getClass().getSimpleName();

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
@@ -1,5 +1,6 @@
 package edu.ntnu.idatt2003.millions.controller;
 
+import edu.ntnu.idatt2003.millions.file.stock.InvalidStockDataException;
 import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.view.StartScreenInputs;
 import edu.ntnu.idatt2003.millions.view.StartView;
@@ -218,10 +219,16 @@ public class StartController {
      *
      * @param action the start-flow action to execute
      */
-    private void runOrShowError(Runnable action) {
+    @FunctionalInterface
+    private interface GameAction {
+        void execute() throws InvalidStockDataException;
+    }
+
+    private void runOrShowError(GameAction action) {
         try {
-            action.run();
-        } catch (IllegalArgumentException | IllegalStateException | UncheckedIOException exception) {
+            action.execute();
+        } catch (InvalidStockDataException | IllegalArgumentException
+                 | IllegalStateException | UncheckedIOException exception) {
             errorSink.accept(exception.getMessage());
         }
     }

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/game/GameSaveCorruptException.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/game/GameSaveCorruptException.java
@@ -1,0 +1,37 @@
+package edu.ntnu.idatt2003.millions.file.game;
+
+/**
+ * Thrown when a game save file cannot be deserialized because its content does not
+ * conform to the expected JSON schema — for example, a required field is missing,
+ * has the wrong type, or the file is truncated.
+ *
+ * <p>This is a recoverable failure. Callers should catch it, inform the player that
+ * the save file is corrupt, and offer to start a new game instead.
+ *
+ * <p>Note: this exception class is introduced here to give future save-file loading
+ * logic a specific type to throw. The wiring into {@link JsonGameFileHandler} is
+ * tracked separately.
+ */
+public class GameSaveCorruptException extends Exception {
+
+    /**
+     * Creates an exception with a descriptive message identifying what was corrupt.
+     *
+     * @param message a human-readable description of the schema violation
+     */
+    public GameSaveCorruptException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates an exception with a descriptive message and a chained cause.
+     * Use this constructor when wrapping a lower-level exception such as a
+     * {@link com.google.gson.JsonSyntaxException}.
+     *
+     * @param message a human-readable description of the schema violation
+     * @param cause   the lower-level exception that triggered this one
+     */
+    public GameSaveCorruptException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/stock/CsvStockFileHandler.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/stock/CsvStockFileHandler.java
@@ -27,6 +27,11 @@ import java.util.Objects;
  *
  * <p>Both file paths and arbitrary input streams are supported as input,
  * which lets callers parse classpath resources without writing them to disk.</p>
+ *
+ * <p>Any data line that has the wrong number of fields or a non-numeric
+ * price causes the entire parse to abort with an
+ * {@link InvalidStockDataException} identifying the offending line number
+ * and content.
  */
 public class CsvStockFileHandler implements StockFileHandler {
 
@@ -70,31 +75,34 @@ public class CsvStockFileHandler implements StockFileHandler {
     /**
      * Reads stock data from a CSV file at the given path.
      * Lines starting with {@code #} and blank lines are skipped.
-     * Lines with invalid format are also skipped.
      *
      * @param path the path to the CSV file to read from
      * @return a list of stocks parsed from the file
-     * @throws NullPointerException if path is null
-     * @throws UncheckedIOException if the file cannot be read
+     * @throws NullPointerException      if path is null
+     * @throws UncheckedIOException      if the file cannot be read
+     * @throws InvalidStockDataException if any data line has the wrong column count
+     *                                   or a non-numeric price field
      */
     @Override
-    public List<Stock> readStocks(Path path) {
+    public List<Stock> readStocks(Path path) throws InvalidStockDataException {
         return readStocks(path, DEFAULT_CURRENCY);
     }
 
     /**
      * Reads stock data from a CSV file at the given path and tags every
      * parsed stock with the supplied currency. Lines starting with {@code #}
-     * and blank lines are skipped. Lines with invalid format are also skipped.
+     * and blank lines are skipped.
      *
      * @param path     the path to the CSV file to read from
      * @param currency the currency to assign to every parsed stock
      * @return a list of stocks parsed from the file
-     * @throws NullPointerException if path or currency is null
-     * @throws UncheckedIOException if the file cannot be read
+     * @throws NullPointerException      if path or currency is null
+     * @throws UncheckedIOException      if the file cannot be read
+     * @throws InvalidStockDataException if any data line has the wrong column count
+     *                                   or a non-numeric price field
      */
     @Override
-    public List<Stock> readStocks(Path path, Currency currency) {
+    public List<Stock> readStocks(Path path, Currency currency) throws InvalidStockDataException {
         Objects.requireNonNull(path, "Path cannot be null");
         Objects.requireNonNull(currency, "Currency cannot be null");
 
@@ -107,61 +115,86 @@ public class CsvStockFileHandler implements StockFileHandler {
 
     /**
      * Reads stock data from a CSV input stream. Lines starting with {@code #}
-     * and blank lines are skipped. Lines with invalid format are also skipped.
-     * The caller retains ownership of the stream and is responsible for
-     * closing it.
+     * and blank lines are skipped. The caller retains ownership of the stream
+     * and is responsible for closing it.
      *
      * @param inputStream the input stream to read from
      * @return a list of stocks parsed from the stream
-     * @throws NullPointerException if inputStream is null
-     * @throws UncheckedIOException if the stream cannot be read
+     * @throws NullPointerException      if inputStream is null
+     * @throws UncheckedIOException      if the stream cannot be read
+     * @throws InvalidStockDataException if any data line has the wrong column count
+     *                                   or a non-numeric price field
      */
     @Override
-    public List<Stock> readStocks(InputStream inputStream) {
+    public List<Stock> readStocks(InputStream inputStream) throws InvalidStockDataException {
         return readStocks(inputStream, DEFAULT_CURRENCY);
     }
 
     /**
      * Reads stock data from a CSV input stream and tags every parsed stock
      * with the supplied currency. Lines starting with {@code #} and blank
-     * lines are skipped. Lines with invalid format are also skipped. The
-     * caller retains ownership of the stream and is responsible for closing it.
+     * lines are skipped. The caller retains ownership of the stream and is
+     * responsible for closing it.
      *
      * @param inputStream the input stream to read from
      * @param currency    the currency to assign to every parsed stock
      * @return a list of stocks parsed from the stream
-     * @throws NullPointerException if inputStream or currency is null
+     * @throws NullPointerException      if inputStream or currency is null
+     * @throws UncheckedIOException      if the stream cannot be read
+     * @throws InvalidStockDataException if any data line has the wrong column count
+     *                                   or a non-numeric price field
      */
     @Override
-    public List<Stock> readStocks(InputStream inputStream, Currency currency) {
+    public List<Stock> readStocks(InputStream inputStream, Currency currency) throws InvalidStockDataException {
         Objects.requireNonNull(inputStream, "Input stream cannot be null");
         Objects.requireNonNull(currency, "Currency cannot be null");
 
-        BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
+        BufferedReader reader = new BufferedReader(
+                new InputStreamReader(inputStream, StandardCharsets.UTF_8));
         return parse(reader, currency);
     }
 
     /**
      * Parses CSV stock data from the given reader and tags every produced
      * stock with the supplied currency. Lines starting with {@code #} and
-     * blank lines are skipped, as are lines that do not have the expected
-     * number of fields.
+     * blank lines are skipped. Any data line that has the wrong number of
+     * fields or a non-numeric price aborts the parse immediately.
      *
      * @param reader   the buffered reader to parse from
      * @param currency the currency to assign to every parsed stock
      * @return a list of stocks parsed from the reader
+     * @throws InvalidStockDataException if any data line is malformed
      */
-    private List<Stock> parse(BufferedReader reader, Currency currency) {
-        return reader.lines()
-                .filter(line -> !line.isBlank() && !line.startsWith(COMMENT_PREFIX))
-                .map(line -> line.split(DELIMITER))
-                .filter(fields -> fields.length == EXPECTED_FIELDS)
-                .map(fields -> new Stock(
+    private List<Stock> parse(BufferedReader reader, Currency currency) throws InvalidStockDataException {
+        List<Stock> result = new ArrayList<>();
+        int lineNumber = 0;
+        try {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                lineNumber++;
+                if (line.isBlank() || line.startsWith(COMMENT_PREFIX)) {
+                    continue;
+                }
+                String[] fields = line.split(DELIMITER);
+                if (fields.length != EXPECTED_FIELDS) {
+                    throw new InvalidStockDataException(lineNumber, line.trim());
+                }
+                BigDecimal price;
+                try {
+                    price = new BigDecimal(fields[PRICE_INDEX].trim());
+                } catch (NumberFormatException e) {
+                    throw new InvalidStockDataException(lineNumber, line.trim());
+                }
+                result.add(new Stock(
                         fields[SYMBOL_INDEX].trim(),
                         fields[NAME_INDEX].trim(),
-                        new ArrayList<>(List.of(new BigDecimal(fields[PRICE_INDEX].trim()))),
-                        currency))
-                .toList();
+                        new ArrayList<>(List.of(price)),
+                        currency));
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Could not read CSV data", e);
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/stock/InvalidStockDataException.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/stock/InvalidStockDataException.java
@@ -1,0 +1,60 @@
+package edu.ntnu.idatt2003.millions.file.stock;
+
+/**
+ * Thrown when a CSV stock file contains a line that cannot be parsed. The two
+ * triggering conditions are:
+ * <ul>
+ *   <li>A data line does not have exactly the expected number of fields
+ *       (wrong column count).</li>
+ *   <li>A numeric field (e.g. the price column) contains a non-numeric value.</li>
+ * </ul>
+ *
+ * <p>Blank lines and lines beginning with {@code #} are skipped silently and
+ * never trigger this exception.
+ *
+ * <p>Callers should report the {@link #getLineNumber() line number} and
+ * {@link #getLineContent() raw content} to the user so they can locate and
+ * correct the malformed entry in the file.
+ */
+public class InvalidStockDataException extends Exception {
+
+    private final int lineNumber;
+    private final String lineContent;
+
+    /**
+     * Creates an exception identifying the malformed line by its position in
+     * the file and its raw content.
+     *
+     * @param lineNumber  the 1-based line number of the malformed entry
+     * @param lineContent the raw text of the malformed line
+     */
+    public InvalidStockDataException(int lineNumber, String lineContent) {
+        super("Invalid stock data at line " + lineNumber + ": \"" + lineContent + "\"");
+        this.lineNumber = lineNumber;
+        this.lineContent = lineContent;
+    }
+
+    /**
+     * Creates an exception with a descriptive message and a chained cause.
+     * Use this constructor when wrapping a lower-level exception such as a
+     * {@link java.io.IOException}.
+     *
+     * @param message a human-readable description of the parse failure
+     * @param cause   the lower-level exception that triggered this one
+     */
+    public InvalidStockDataException(String message, Throwable cause) {
+        super(message, cause);
+        this.lineNumber = -1;
+        this.lineContent = null;
+    }
+
+    /** @return the 1-based line number of the malformed entry, or -1 if not set */
+    public int getLineNumber() {
+        return lineNumber;
+    }
+
+    /** @return the raw text of the malformed line, or null if not set */
+    public String getLineContent() {
+        return lineContent;
+    }
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/stock/StockFileHandler.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/stock/StockFileHandler.java
@@ -15,6 +15,11 @@ import java.util.List;
  * <p>Reading is exposed for both file paths and arbitrary input streams,
  * which lets callers parse classpath resources or in-memory data without
  * routing them through the filesystem.</p>
+ *
+ * <p>All read methods throw {@link InvalidStockDataException} when the file
+ * contains a line that cannot be parsed. The entire parse is aborted on the
+ * first bad line; the exception carries the line number and raw content so
+ * the caller can report a precise error to the user.
  */
 public interface StockFileHandler {
 
@@ -24,8 +29,9 @@ public interface StockFileHandler {
      *
      * @param path the path to the file to read from
      * @return a list of stocks parsed from the file
+     * @throws InvalidStockDataException if any data line cannot be parsed
      */
-    List<Stock> readStocks(Path path);
+    List<Stock> readStocks(Path path) throws InvalidStockDataException;
 
     /**
      * Reads stock data from the file at the given path and tags each stock
@@ -34,8 +40,9 @@ public interface StockFileHandler {
      * @param path     the path to the file to read from
      * @param currency the currency to assign to every parsed stock
      * @return a list of stocks parsed from the file
+     * @throws InvalidStockDataException if any data line cannot be parsed
      */
-    List<Stock> readStocks(Path path, Currency currency);
+    List<Stock> readStocks(Path path, Currency currency) throws InvalidStockDataException;
 
     /**
      * Reads stock data from the given input stream. Useful for parsing
@@ -46,8 +53,9 @@ public interface StockFileHandler {
      *
      * @param inputStream the input stream to read from
      * @return a list of stocks parsed from the stream
+     * @throws InvalidStockDataException if any data line cannot be parsed
      */
-    List<Stock> readStocks(InputStream inputStream);
+    List<Stock> readStocks(InputStream inputStream) throws InvalidStockDataException;
 
     /**
      * Reads stock data from the given input stream and tags each stock
@@ -57,8 +65,9 @@ public interface StockFileHandler {
      * @param inputStream the input stream to read from
      * @param currency    the currency to assign to every parsed stock
      * @return a list of stocks parsed from the stream
+     * @throws InvalidStockDataException if any data line cannot be parsed
      */
-    List<Stock> readStocks(InputStream inputStream, Currency currency);
+    List<Stock> readStocks(InputStream inputStream, Currency currency) throws InvalidStockDataException;
 
     /**
      * Writes stock data to the file at the given path.

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/loan/ExcessiveDebtException.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/loan/ExcessiveDebtException.java
@@ -1,13 +1,54 @@
 package edu.ntnu.idatt2003.millions.model.loan;
 
-/**
- * Thrown when a loan would cause the player's total outstanding debt to exceed
- * {@link edu.ntnu.idatt2003.millions.model.player.Player#MAX_DEBT_RATIO} of their
- * current net worth.
- */
-public class ExcessiveDebtException extends IllegalArgumentException {
+import java.math.BigDecimal;
 
-    public ExcessiveDebtException(String message) {
-        super(message);
+/**
+ * Thrown when a loan application would cause the player's total outstanding debt to exceed
+ * {@link edu.ntnu.idatt2003.millions.model.player.Player#MAX_DEBT_RATIO} of their current
+ * net worth.
+ *
+ * <p>This is a recoverable domain rule violation. No state is mutated when this exception
+ * is thrown. Callers should catch it and inform the player that their borrowing capacity
+ * has been reached.
+ */
+public class ExcessiveDebtException extends Exception {
+
+    private final BigDecimal debtAfter;
+    private final BigDecimal capacity;
+
+    /**
+     * Creates an exception carrying the computed debt and capacity figures.
+     *
+     * @param debtAfter the total debt the player would have after the rejected loan
+     * @param capacity  the maximum permitted debt at the time of the request
+     */
+    public ExcessiveDebtException(BigDecimal debtAfter, BigDecimal capacity) {
+        super("Loan would bring total debt to " + debtAfter
+                + " NOK, exceeding the capacity of " + capacity + " NOK.");
+        this.debtAfter = debtAfter;
+        this.capacity = capacity;
+    }
+
+    /**
+     * Creates an exception with a descriptive message and a chained cause.
+     * Use this constructor when wrapping a lower-level exception.
+     *
+     * @param message a human-readable description of the violation
+     * @param cause   the lower-level exception that triggered this one
+     */
+    public ExcessiveDebtException(String message, Throwable cause) {
+        super(message, cause);
+        this.debtAfter = null;
+        this.capacity = null;
+    }
+
+    /** @return the total debt the player would have held after the rejected loan, or null if not set */
+    public BigDecimal getDebtAfter() {
+        return debtAfter;
+    }
+
+    /** @return the maximum permitted debt at the time of the rejected request, or null if not set */
+    public BigDecimal getCapacity() {
+        return capacity;
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/loan/InsufficientSaleProceedsException.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/loan/InsufficientSaleProceedsException.java
@@ -1,12 +1,45 @@
 package edu.ntnu.idatt2003.millions.model.loan;
 
+import java.math.BigDecimal;
+
 /**
- * Thrown when the net proceeds from a forced share sale are insufficient
- * to cover the outstanding weekly interest obligation.
+ * Thrown when the net proceeds from a forced share sale are insufficient to cover the
+ * player's outstanding obligations for the current week (weekly interest plus any
+ * maturing loan principals).
+ *
+ * <p>This is a recoverable domain rule violation. No state is mutated when this
+ * exception is thrown. Callers should catch it and ask the player to select
+ * additional shares to sell.
  */
 public class InsufficientSaleProceedsException extends Exception {
 
-    public InsufficientSaleProceedsException(String message) {
-        super(message);
+    private final BigDecimal shortfall;
+
+    /**
+     * Creates an exception carrying the shortfall amount.
+     *
+     * @param shortfall the difference between required obligations and net sale proceeds;
+     *                  always positive when this exception is thrown
+     */
+    public InsufficientSaleProceedsException(BigDecimal shortfall) {
+        super("Net sale proceeds are " + shortfall + " NOK short of required obligations.");
+        this.shortfall = shortfall;
+    }
+
+    /**
+     * Creates an exception with a descriptive message and a chained cause.
+     * Use this constructor when wrapping a lower-level exception.
+     *
+     * @param message a human-readable description of the shortfall
+     * @param cause   the lower-level exception that triggered this one
+     */
+    public InsufficientSaleProceedsException(String message, Throwable cause) {
+        super(message, cause);
+        this.shortfall = null;
+    }
+
+    /** @return the amount by which the sale proceeds fall short, or null if not set */
+    public BigDecimal getShortfall() {
+        return shortfall;
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/player/Player.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/player/Player.java
@@ -298,17 +298,13 @@ public class Player {
      * @throws NullPointerException    if loan or converter is null
      * @throws ExcessiveDebtException  if taking the loan would breach the debt ratio
      */
-    public void takeLoan(Loan loan, CurrencyConverter converter) {
+    public void takeLoan(Loan loan, CurrencyConverter converter) throws ExcessiveDebtException {
         Objects.requireNonNull(loan, "Loan cannot be null");
         Objects.requireNonNull(converter, "Converter cannot be null");
         BigDecimal newTotalDebt = getTotalDebt().add(loan.principal());
         BigDecimal capacity = getLoanCapacity(converter);
         if (newTotalDebt.compareTo(capacity) > 0) {
-            throw new ExcessiveDebtException(
-                    "Loan of " + loan.principal() + " NOK would bring total debt to "
-                    + newTotalDebt + " NOK, exceeding the "
-                    + MAX_DEBT_RATIO.multiply(BigDecimal.valueOf(100)).stripTrailingZeros().toPlainString()
-                    + "% capacity of " + capacity + " NOK.");
+            throw new ExcessiveDebtException(newTotalDebt, capacity);
         }
         addMoney(loan.principal());
         activeLoansInternal().add(loan);

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/GameService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/GameService.java
@@ -4,11 +4,13 @@ import edu.ntnu.idatt2003.millions.file.game.GameFileHandler;
 import edu.ntnu.idatt2003.millions.file.game.GameState;
 import edu.ntnu.idatt2003.millions.file.game.JsonGameFileHandler;
 import edu.ntnu.idatt2003.millions.file.stock.CsvStockFileHandler;
+import edu.ntnu.idatt2003.millions.file.stock.InvalidStockDataException;
 import edu.ntnu.idatt2003.millions.file.stock.StockFileHandler;
 import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
 import edu.ntnu.idatt2003.millions.model.currency.FixedRateCurrencyConverter;
 import edu.ntnu.idatt2003.millions.model.exchange.Exchange;
 import edu.ntnu.idatt2003.millions.model.calculator.SalesCalculator;
+import edu.ntnu.idatt2003.millions.model.loan.ExcessiveDebtException;
 import edu.ntnu.idatt2003.millions.model.loan.InsufficientSaleProceedsException;
 import edu.ntnu.idatt2003.millions.model.loan.Loan;
 import edu.ntnu.idatt2003.millions.model.loan.LoanOffer;
@@ -119,7 +121,8 @@ public class GameService {
      * @throws IllegalArgumentException if name is blank, capital is negative,
      *                                  or the file contains no stocks
      */
-    public void createNewGame(String name, BigDecimal capital, File stockFile) {
+    public void createNewGame(String name, BigDecimal capital, File stockFile)
+            throws InvalidStockDataException {
         createNewGame(name, capital, stockFile, DEFAULT_STOCK_CURRENCY);
     }
 
@@ -137,7 +140,8 @@ public class GameService {
      * @throws IllegalArgumentException if name is blank, capital is negative,
      *                                  or the file contains no stocks
      */
-    public void createNewGame(String name, BigDecimal capital, File stockFile, Currency currency) {
+    public void createNewGame(String name, BigDecimal capital, File stockFile, Currency currency)
+            throws InvalidStockDataException {
         Objects.requireNonNull(stockFile, "Stock file cannot be null");
         Objects.requireNonNull(currency, "Currency cannot be null");
         Player newPlayer = new Player(name, capital);
@@ -178,6 +182,8 @@ public class GameService {
             return stockFileHandler.readStocks(inputStream, DEFAULT_STOCK_CURRENCY);
         } catch (IOException e) {
             throw new UncheckedIOException("Could not read default stock data", e);
+        } catch (InvalidStockDataException e) {
+            throw new IllegalStateException("Default stock data is malformed: " + e.getMessage(), e);
         }
     }
 
@@ -287,9 +293,7 @@ public class GameService {
                 .map(s -> SalesCalculator.calculateNetNok(s, converter))
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
         if (netTotal.compareTo(totalObligations) < 0) {
-            throw new InsufficientSaleProceedsException(
-                    "Net sale proceeds (" + netTotal + " NOK) are less than required obligations ("
-                    + totalObligations + " NOK).");
+            throw new InsufficientSaleProceedsException(totalObligations.subtract(netTotal));
         }
 
         player.setPreviousNetWorth(player.getNetWorth(converter));
@@ -366,7 +370,7 @@ public class GameService {
      * @throws edu.ntnu.idatt2003.millions.model.loan.ExcessiveDebtException
      *         if the loan would breach the player's debt-to-net-worth limit
      */
-    public Loan takeLoan(LoanOffer offer, BigDecimal amount) {
+    public Loan takeLoan(LoanOffer offer, BigDecimal amount) throws ExcessiveDebtException {
         Objects.requireNonNull(offer, "Offer cannot be null");
         Objects.requireNonNull(amount, "Amount cannot be null");
         Loan loan = new Loan(offer, amount, exchange.getWeek());

--- a/src/test/java/edu/ntnu/idatt2003/millions/file/game/GameSaveCorruptExceptionTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/file/game/GameSaveCorruptExceptionTest.java
@@ -1,0 +1,61 @@
+package edu.ntnu.idatt2003.millions.file.game;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link GameSaveCorruptException}.
+ */
+class GameSaveCorruptExceptionTest {
+
+    @Nested
+    @DisplayName("GameSaveCorruptException(String message)")
+    class MessageConstructor {
+
+        @Test
+        @DisplayName("getMessage() returns the supplied message")
+        void messageIsPreserved() {
+            GameSaveCorruptException ex =
+                    new GameSaveCorruptException("save file is missing 'player' field");
+            assertEquals("save file is missing 'player' field", ex.getMessage());
+        }
+
+        @Test
+        @DisplayName("getCause() is null when no cause is supplied")
+        void causeIsNullByDefault() {
+            GameSaveCorruptException ex = new GameSaveCorruptException("msg");
+            assertNull(ex.getCause());
+        }
+
+        @Test
+        @DisplayName("is a checked exception")
+        void isChecked() {
+            assertTrue(Exception.class.isAssignableFrom(GameSaveCorruptException.class));
+            assertFalse(RuntimeException.class.isAssignableFrom(GameSaveCorruptException.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("GameSaveCorruptException(String message, Throwable cause)")
+    class ChainingConstructor {
+
+        @Test
+        @DisplayName("getMessage() returns the supplied message")
+        void messageIsPreserved() {
+            GameSaveCorruptException ex =
+                    new GameSaveCorruptException("corrupt", new RuntimeException("root"));
+            assertEquals("corrupt", ex.getMessage());
+        }
+
+        @Test
+        @DisplayName("getCause() returns the supplied cause")
+        void causeIsPreserved() {
+            RuntimeException root = new RuntimeException("root");
+            GameSaveCorruptException ex = new GameSaveCorruptException("msg", root);
+            assertSame(root, ex.getCause());
+        }
+    }
+}

--- a/src/test/java/edu/ntnu/idatt2003/millions/file/stock/CsvStockFileHandlerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/file/stock/CsvStockFileHandlerTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import edu.ntnu.idatt2003.millions.file.stock.InvalidStockDataException;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -98,15 +99,36 @@ class CsvStockFileHandlerTest {
         }
 
         @Test
-        @DisplayName("Should skip lines with invalid format when file contains invalid lines")
-        void skipsInvalidLines() throws Exception {
+        @DisplayName("Should throw InvalidStockDataException for wrong column count")
+        void throwsForWrongColumnCount() throws Exception {
             // Arrange
             Path file = tempDir.resolve("stocks.csv");
             Files.writeString(file, "AAPL,Apple Inc.,276.43\nINVALID_LINE\n");
+            // Act & Assert
+            assertThrows(InvalidStockDataException.class, () -> handler.readStocks(file));
+        }
+
+        @Test
+        @DisplayName("Should throw InvalidStockDataException for non-numeric price")
+        void throwsForNonNumericPrice() throws Exception {
+            // Arrange
+            Path file = tempDir.resolve("stocks.csv");
+            Files.writeString(file, "AAPL,Apple Inc.,abc\n");
+            // Act & Assert
+            assertThrows(InvalidStockDataException.class, () -> handler.readStocks(file));
+        }
+
+        @Test
+        @DisplayName("Should report the correct line number when a data line is malformed")
+        void reportsCorrectLineNumberOnMalformedLine() throws Exception {
+            // Arrange — line 1 is a comment, line 2 is valid, line 3 is malformed
+            Path file = tempDir.resolve("stocks.csv");
+            Files.writeString(file, "# comment\nAAPL,Apple Inc.,276.43\nBAD\n");
             // Act
-            List<Stock> stocks = handler.readStocks(file);
-            // Assert
-            assertEquals(1, stocks.size());
+            InvalidStockDataException ex = assertThrows(InvalidStockDataException.class,
+                    () -> handler.readStocks(file));
+            // Assert — line 3 in the file is the bad one
+            assertEquals(3, ex.getLineNumber());
         }
 
         @Test
@@ -123,7 +145,7 @@ class CsvStockFileHandlerTest {
 
         @Test
         @DisplayName("Should throw exception when path is null")
-        void throwsExceptionWhenPathIsNull() {
+        void throwsExceptionWhenPathIsNull() throws InvalidStockDataException {
             // Arrange
             Path nullPath = null;
             // Act & Assert
@@ -133,7 +155,7 @@ class CsvStockFileHandlerTest {
 
         @Test
         @DisplayName("Should throw exception when file does not exist")
-        void throwsExceptionWhenFileDoesNotExist() {
+        void throwsExceptionWhenFileDoesNotExist() throws InvalidStockDataException {
             // Arrange
             Path file = tempDir.resolve("nonexistent.csv");
             // Act & Assert
@@ -186,7 +208,7 @@ class CsvStockFileHandlerTest {
 
         @Test
         @DisplayName("Should throw exception when path is null")
-        void throwsExceptionWhenPathIsNull() {
+        void throwsExceptionWhenPathIsNull() throws InvalidStockDataException {
             // Arrange
             Currency usd = Currency.getInstance("USD");
             // Act & Assert
@@ -212,7 +234,7 @@ class CsvStockFileHandlerTest {
 
         @Test
         @DisplayName("Should parse stocks from input stream")
-        void parsesStocksFromStream() {
+        void parsesStocksFromStream() throws InvalidStockDataException {
             // Arrange
             InputStream stream = new ByteArrayInputStream(
                     "AAPL,Apple Inc.,276.43\nMSFT,Microsoft,404.68\n".getBytes(StandardCharsets.UTF_8));
@@ -225,7 +247,7 @@ class CsvStockFileHandlerTest {
 
         @Test
         @DisplayName("Should default stock currency to USD when no currency is supplied")
-        void defaultsCurrencyToUsd() {
+        void defaultsCurrencyToUsd() throws InvalidStockDataException {
             // Arrange
             InputStream stream = new ByteArrayInputStream(
                     "AAPL,Apple Inc.,276.43\n".getBytes(StandardCharsets.UTF_8));
@@ -237,7 +259,7 @@ class CsvStockFileHandlerTest {
 
         @Test
         @DisplayName("Should return empty list when stream is empty")
-        void returnsEmptyListWhenStreamIsEmpty() {
+        void returnsEmptyListWhenStreamIsEmpty() throws InvalidStockDataException {
             // Arrange
             InputStream stream = new ByteArrayInputStream(new byte[0]);
             // Act
@@ -248,7 +270,7 @@ class CsvStockFileHandlerTest {
 
         @Test
         @DisplayName("Should throw exception when stream is null")
-        void throwsExceptionWhenStreamIsNull() {
+        void throwsExceptionWhenStreamIsNull() throws InvalidStockDataException {
             // Arrange
             InputStream nullStream = null;
             // Act & Assert
@@ -263,7 +285,7 @@ class CsvStockFileHandlerTest {
 
         @Test
         @DisplayName("Should tag every parsed stock with the supplied currency")
-        void tagsStocksWithSuppliedCurrency() {
+        void tagsStocksWithSuppliedCurrency() throws InvalidStockDataException {
             // Arrange
             InputStream stream = new ByteArrayInputStream(
                     "AAPL,Apple Inc.,276.43\nMSFT,Microsoft,404.68\n".getBytes(StandardCharsets.UTF_8));
@@ -277,7 +299,7 @@ class CsvStockFileHandlerTest {
 
         @Test
         @DisplayName("Should throw exception when stream is null")
-        void throwsExceptionWhenStreamIsNull() {
+        void throwsExceptionWhenStreamIsNull() throws InvalidStockDataException {
             // Arrange
             Currency usd = Currency.getInstance("USD");
             // Act & Assert
@@ -287,7 +309,7 @@ class CsvStockFileHandlerTest {
 
         @Test
         @DisplayName("Should throw exception when currency is null")
-        void throwsExceptionWhenCurrencyIsNull() {
+        void throwsExceptionWhenCurrencyIsNull() throws InvalidStockDataException {
             // Arrange
             InputStream stream = new ByteArrayInputStream(
                     "AAPL,Apple Inc.,276.43\n".getBytes(StandardCharsets.UTF_8));
@@ -368,7 +390,7 @@ class CsvStockFileHandlerTest {
 
         @Test
         @DisplayName("Should return same number of stocks after write and read")
-        void returnsSameNumberOfStocks() {
+        void returnsSameNumberOfStocks() throws InvalidStockDataException {
             // Arrange
             Path file = tempDir.resolve("stocks.csv");
             List<Stock> original = List.of(
@@ -384,7 +406,7 @@ class CsvStockFileHandlerTest {
 
         @Test
         @DisplayName("Should return same symbol after write and read")
-        void returnsSameSymbol() {
+        void returnsSameSymbol() throws InvalidStockDataException {
             // Arrange
             Path file = tempDir.resolve("stocks.csv");
             List<Stock> original = List.of(
@@ -399,7 +421,7 @@ class CsvStockFileHandlerTest {
 
         @Test
         @DisplayName("Should return same price after write and read")
-        void returnsSamePrice() {
+        void returnsSamePrice() throws InvalidStockDataException {
             // Arrange
             Path file = tempDir.resolve("stocks.csv");
             List<Stock> original = List.of(

--- a/src/test/java/edu/ntnu/idatt2003/millions/file/stock/InvalidStockDataExceptionTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/file/stock/InvalidStockDataExceptionTest.java
@@ -1,0 +1,84 @@
+package edu.ntnu.idatt2003.millions.file.stock;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link InvalidStockDataException}.
+ */
+class InvalidStockDataExceptionTest {
+
+    @Nested
+    @DisplayName("InvalidStockDataException(int lineNumber, String lineContent)")
+    class PayloadConstructor {
+
+        @Test
+        @DisplayName("getLineNumber() returns the supplied line number")
+        void lineNumberIsPreserved() {
+            InvalidStockDataException ex = new InvalidStockDataException(5, "AAPL,Apple,abc");
+            assertEquals(5, ex.getLineNumber());
+        }
+
+        @Test
+        @DisplayName("getLineContent() returns the supplied line content")
+        void lineContentIsPreserved() {
+            InvalidStockDataException ex = new InvalidStockDataException(5, "AAPL,Apple,abc");
+            assertEquals("AAPL,Apple,abc", ex.getLineContent());
+        }
+
+        @Test
+        @DisplayName("message contains the line number")
+        void messageContainsLineNumber() {
+            InvalidStockDataException ex = new InvalidStockDataException(5, "AAPL,Apple,abc");
+            assertTrue(ex.getMessage().contains("5"),
+                    "message should contain the line number");
+        }
+
+        @Test
+        @DisplayName("message contains the line content")
+        void messageContainsLineContent() {
+            InvalidStockDataException ex = new InvalidStockDataException(5, "AAPL,Apple,abc");
+            assertTrue(ex.getMessage().contains("AAPL,Apple,abc"),
+                    "message should contain the raw line content");
+        }
+
+        @Test
+        @DisplayName("is a checked exception")
+        void isChecked() {
+            assertTrue(Exception.class.isAssignableFrom(InvalidStockDataException.class));
+            assertFalse(RuntimeException.class.isAssignableFrom(InvalidStockDataException.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("InvalidStockDataException(String message, Throwable cause)")
+    class ChainingConstructor {
+
+        @Test
+        @DisplayName("getMessage() returns the supplied message")
+        void messageIsPreserved() {
+            InvalidStockDataException ex =
+                    new InvalidStockDataException("custom message", null);
+            assertEquals("custom message", ex.getMessage());
+        }
+
+        @Test
+        @DisplayName("getCause() returns the supplied cause")
+        void causeIsPreserved() {
+            RuntimeException root = new RuntimeException("root");
+            InvalidStockDataException ex = new InvalidStockDataException("msg", root);
+            assertSame(root, ex.getCause());
+        }
+
+        @Test
+        @DisplayName("getLineNumber() is -1 and getLineContent() is null for chaining constructor")
+        void payloadIsDefaultForChainingConstructor() {
+            InvalidStockDataException ex = new InvalidStockDataException("msg", null);
+            assertEquals(-1, ex.getLineNumber());
+            assertNull(ex.getLineContent());
+        }
+    }
+}

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/PlayerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/PlayerTest.java
@@ -430,7 +430,7 @@ class PlayerTest {
 
         @Test
         @DisplayName("Should support multiple recordings in order")
-        void supportsMultipleRecordings() {
+        void supportsMultipleRecordings() throws ExcessiveDebtException {
             // Arrange
             LoanOffer offer = new LoanOffer("test", new BigDecimal("0.01"), 10,
                     new BigDecimal("50000.00"), LoanRiskLevel.LOW);
@@ -444,6 +444,7 @@ class PlayerTest {
             assertTrue(history.getLast().compareTo(history.getFirst()) > 0);
         }
     }
+
 
     @Nested
     @DisplayName("getTotalDebtHistory()")
@@ -469,7 +470,7 @@ class PlayerTest {
 
         @Test
         @DisplayName("Should reflect every recordTotalDebt call in order")
-        void reflectsRecordingsInOrder() {
+        void reflectsRecordingsInOrder() throws ExcessiveDebtException {
             // Arrange
             LoanOffer offer = new LoanOffer("test", new BigDecimal("0.01"), 10,
                     new BigDecimal("50000.00"), LoanRiskLevel.LOW);
@@ -702,7 +703,7 @@ class PlayerTest {
 
         @Test
         @DisplayName("getTotalDebt() sums principals of multiple loans")
-        void getTotalDebtSumsMultipleLoans() {
+        void getTotalDebtSumsMultipleLoans() throws ExcessiveDebtException {
             // Arrange — player starts with 1000, net worth=1000, capacity=500
             player.takeLoan(new Loan(offer, new BigDecimal("200.00"), 0), converter);
             // After first loan: money=1200, debt=200, net worth=1000, capacity=500, available=300
@@ -732,7 +733,7 @@ class PlayerTest {
 
         @Test
         @DisplayName("getAvailableLoanCapacity() decreases after taking a loan")
-        void getAvailableLoanCapacityDecreasesAfterLoan() {
+        void getAvailableLoanCapacityDecreasesAfterLoan() throws ExcessiveDebtException {
             // Arrange
             BigDecimal before = player.getAvailableLoanCapacity(converter);
             // Act
@@ -744,7 +745,7 @@ class PlayerTest {
 
         @Test
         @DisplayName("takeLoan() increases player money by the principal")
-        void takeLoanIncreasesMoney() {
+        void takeLoanIncreasesMoney() throws ExcessiveDebtException {
             // Arrange
             BigDecimal before = player.getMoney();
             BigDecimal principal = new BigDecimal("300.00");
@@ -756,7 +757,7 @@ class PlayerTest {
 
         @Test
         @DisplayName("takeLoan() adds the loan to active loans")
-        void takeLoanAddsToActiveLoans() {
+        void takeLoanAddsToActiveLoans() throws ExcessiveDebtException {
             // Arrange
             Loan loan = new Loan(offer, new BigDecimal("300.00"), 0);
             // Act
@@ -797,7 +798,7 @@ class PlayerTest {
 
         @Test
         @DisplayName("repayLoan() removes the loan from active loans")
-        void repayLoanRemovesFromActiveLoans() {
+        void repayLoanRemovesFromActiveLoans() throws ExcessiveDebtException {
             // Arrange
             Loan loan = new Loan(offer, new BigDecimal("200.00"), 0);
             player.takeLoan(loan, converter);
@@ -809,7 +810,7 @@ class PlayerTest {
 
         @Test
         @DisplayName("repayLoan() deducts the principal from player money")
-        void repayLoanDeductsMoney() {
+        void repayLoanDeductsMoney() throws ExcessiveDebtException {
             // Arrange
             Loan loan = new Loan(offer, new BigDecimal("200.00"), 0);
             player.takeLoan(loan, converter); // money: 1000 + 200 = 1200
@@ -822,7 +823,7 @@ class PlayerTest {
 
         @Test
         @DisplayName("repayLoan() throws when player cannot afford the principal")
-        void repayLoanThrowsWhenInsufficientFunds() {
+        void repayLoanThrowsWhenInsufficientFunds() throws ExcessiveDebtException {
             // Arrange — give player a tiny balance by draining most of their cash
             Player broke = new Player("Broke", new BigDecimal("100.00"));
             // Manually add a loan with a principal larger than cash using internal via takeLoan
@@ -847,7 +848,7 @@ class PlayerTest {
 
         @Test
         @DisplayName("getNetWorth() subtracts outstanding debt")
-        void getNetWorthSubtractsDebt() {
+        void getNetWorthSubtractsDebt() throws ExcessiveDebtException {
             // Arrange — player starts with 1000 cash
             BigDecimal principal = new BigDecimal("300.00");
             player.takeLoan(new Loan(offer, principal, 0), converter);
@@ -857,7 +858,7 @@ class PlayerTest {
 
         @Test
         @DisplayName("Taking a loan does not change net worth")
-        void takingLoanDoesNotChangeNetWorth() {
+        void takingLoanDoesNotChangeNetWorth() throws ExcessiveDebtException {
             // Arrange
             BigDecimal before = player.getNetWorth(converter);
             // Act
@@ -868,7 +869,7 @@ class PlayerTest {
 
         @Test
         @DisplayName("Repaying a loan does not change net worth")
-        void repayingLoanDoesNotChangeNetWorth() {
+        void repayingLoanDoesNotChangeNetWorth() throws ExcessiveDebtException {
             // Arrange
             Loan loan = new Loan(offer, new BigDecimal("300.00"), 0);
             player.takeLoan(loan, converter);
@@ -881,7 +882,7 @@ class PlayerTest {
 
         @Test
         @DisplayName("getNetWorth() can be negative when debt exceeds assets")
-        void getNetWorthCanBeNegative() {
+        void getNetWorthCanBeNegative() throws ExcessiveDebtException {
             // Arrange — take a loan, then drain cash below the principal
             Loan loan = new Loan(offer, new BigDecimal("400.00"), 0);
             player.takeLoan(loan, converter);        // cash=1400, debt=400, net worth=1000
@@ -892,7 +893,7 @@ class PlayerTest {
 
         @Test
         @DisplayName("getLoanCapacity() clamps to zero when net worth is negative")
-        void getLoanCapacityIsZeroOnNegativeNetWorth() {
+        void getLoanCapacityIsZeroOnNegativeNetWorth() throws ExcessiveDebtException {
             // Arrange — same setup as above produces negative net worth
             Loan loan = new Loan(offer, new BigDecimal("400.00"), 0);
             player.takeLoan(loan, converter);
@@ -903,7 +904,7 @@ class PlayerTest {
 
         @Test
         @DisplayName("takeLoan() appends a DISBURSEMENT ledger entry")
-        void takeLoanAppendsDisbursementEntry() {
+        void takeLoanAppendsDisbursementEntry() throws ExcessiveDebtException {
             Loan loan = new Loan(offer, new BigDecimal("200.00"), 1);
             player.takeLoan(loan, converter);
             List<LoanLedgerEntry> ledger = player.getLoanLedger();
@@ -916,7 +917,7 @@ class PlayerTest {
 
         @Test
         @DisplayName("repayLoan() appends a REPAYMENT ledger entry with negative amount")
-        void repayLoanAppendsRepaymentEntry() {
+        void repayLoanAppendsRepaymentEntry() throws ExcessiveDebtException {
             Loan loan = new Loan(offer, new BigDecimal("200.00"), 1);
             player.takeLoan(loan, converter);
             player.repayLoan(loan, 2);
@@ -930,7 +931,7 @@ class PlayerTest {
 
         @Test
         @DisplayName("getLoanLedger() returns a defensive copy")
-        void getLoanLedgerReturnsDefensiveCopy() {
+        void getLoanLedgerReturnsDefensiveCopy() throws ExcessiveDebtException {
             Loan loan = new Loan(offer, new BigDecimal("100.00"), 1);
             player.takeLoan(loan, converter);
             List<LoanLedgerEntry> ledger = player.getLoanLedger();
@@ -946,7 +947,7 @@ class PlayerTest {
 
         @Test
         @DisplayName("Stacking loans to bypass the 50% cap is blocked")
-        void stackingLoansIsBlocked() {
+        void stackingLoansIsBlocked() throws ExcessiveDebtException {
             // Arrange — player starts with 10 000 NOK, capacity = 5 000
             Player rich = new Player("Rich", new BigDecimal("10000.00"));
             LoanOffer bigOffer = new LoanOffer("big", new BigDecimal("0.01"), 10,
@@ -966,7 +967,7 @@ class PlayerTest {
 
         @Test
         @DisplayName("getWeeklyInterestDue() sums interest across all active loans")
-        void getWeeklyInterestDueSumsAllActiveLoans() {
+        void getWeeklyInterestDueSumsAllActiveLoans() throws ExcessiveDebtException {
             // Arrange — player starts with 1000 NOK, capacity = 500.
             // Two loans within capacity: 200 NOK at 1% = 2.00, 100 NOK at 1% = 1.00 → total 3.00
             player.takeLoan(new Loan(offer, new BigDecimal("200.00"), 1), converter);
@@ -976,7 +977,7 @@ class PlayerTest {
 
         @Test
         @DisplayName("canCoverInterestThisWeek() returns true when cash >= interest due")
-        void canCoverInterestThisWeekReturnsTrueWhenMoneyExceedsDue() {
+        void canCoverInterestThisWeekReturnsTrueWhenMoneyExceedsDue() throws ExcessiveDebtException {
             // Arrange — take 400 NOK loan (within 500 capacity): money = 1400, interest = 4.00
             player.takeLoan(new Loan(offer, new BigDecimal("400.00"), 1), converter);
             assertTrue(player.canCoverInterestThisWeek());
@@ -984,7 +985,7 @@ class PlayerTest {
 
         @Test
         @DisplayName("canCoverInterestThisWeek() returns false when cash < interest due")
-        void canCoverInterestThisWeekReturnsFalseWhenMoneyIsLess() {
+        void canCoverInterestThisWeekReturnsFalseWhenMoneyIsLess() throws ExcessiveDebtException {
             // Arrange — take 400 NOK loan: money = 1400, interest = 4.00. Then drain to 3.00.
             player.takeLoan(new Loan(offer, new BigDecimal("400.00"), 1), converter);
             player.withdrawMoney(new BigDecimal("1397.00")); // money = 3.00 < 4.00 interest
@@ -993,7 +994,7 @@ class PlayerTest {
 
         @Test
         @DisplayName("getMaturityDueThisWeek() returns zero when no loans are maturing")
-        void getMaturityDueThisWeek_zeroWhenNoneAreMaturing() {
+        void getMaturityDueThisWeek_zeroWhenNoneAreMaturing() throws ExcessiveDebtException {
             // Arrange — loan taken at week 1, term 10: due at week 11, not week 2
             player.takeLoan(new Loan(offer, new BigDecimal("200.00"), 1), converter);
             assertEquals(0, BigDecimal.ZERO.compareTo(player.getMaturityDueThisWeek(2)));
@@ -1001,7 +1002,7 @@ class PlayerTest {
 
         @Test
         @DisplayName("getMaturityDueThisWeek() returns principal of maturing loan")
-        void getMaturityDueThisWeek_returnsPrincipalOfMaturingLoan() {
+        void getMaturityDueThisWeek_returnsPrincipalOfMaturingLoan() throws ExcessiveDebtException {
             // Arrange — offer has term 10: taken at week 1, due at week 11
             player.takeLoan(new Loan(offer, new BigDecimal("200.00"), 1), converter);
             assertEquals(0, new BigDecimal("200.00").compareTo(player.getMaturityDueThisWeek(11)));
@@ -1009,7 +1010,7 @@ class PlayerTest {
 
         @Test
         @DisplayName("getMaturityDueThisWeek() sums principals of multiple maturing loans")
-        void getMaturityDueThisWeek_sumsBothMaturingLoans() {
+        void getMaturityDueThisWeek_sumsBothMaturingLoans() throws ExcessiveDebtException {
             // Both loans taken at week 1 with term 10 → both mature at week 11
             // player starts with 1000, capacity 500; two loans sum to 350 which is within limit
             player.takeLoan(new Loan(offer, new BigDecimal("200.00"), 1), converter);
@@ -1019,7 +1020,7 @@ class PlayerTest {
 
         @Test
         @DisplayName("getTotalObligationsThisWeek() equals interest-only when no loans mature")
-        void getTotalObligationsThisWeek_equalsInterestWhenNoMaturity() {
+        void getTotalObligationsThisWeek_equalsInterestWhenNoMaturity() throws ExcessiveDebtException {
             // Arrange — 400 NOK at 1% = 4.00 weekly; loan matures at week 11, not week 2
             player.takeLoan(new Loan(offer, new BigDecimal("400.00"), 1), converter);
             assertEquals(0, new BigDecimal("4.00").compareTo(player.getTotalObligationsThisWeek(2)));
@@ -1027,7 +1028,7 @@ class PlayerTest {
 
         @Test
         @DisplayName("getTotalObligationsThisWeek() includes maturity principal when loan matures")
-        void getTotalObligationsThisWeek_includesMaturityPrincipal() {
+        void getTotalObligationsThisWeek_includesMaturityPrincipal() throws ExcessiveDebtException {
             // 400 NOK at 1%/week: interest = 4.00, maturity = 400.00 → obligations = 404.00
             player.takeLoan(new Loan(offer, new BigDecimal("400.00"), 1), converter);
             assertEquals(0, new BigDecimal("404.00").compareTo(player.getTotalObligationsThisWeek(11)));
@@ -1035,7 +1036,7 @@ class PlayerTest {
 
         @Test
         @DisplayName("canCoverObligationsThisWeek() returns true when cash covers interest only")
-        void canCoverObligationsThisWeek_trueForInterestOnly() {
+        void canCoverObligationsThisWeek_trueForInterestOnly() throws ExcessiveDebtException {
             // 400 NOK loan at 1%: money=1400, interest=4.00, no maturity at week 2 → true
             player.takeLoan(new Loan(offer, new BigDecimal("400.00"), 1), converter);
             assertTrue(player.canCoverObligationsThisWeek(2));
@@ -1043,7 +1044,7 @@ class PlayerTest {
 
         @Test
         @DisplayName("canCoverObligationsThisWeek() returns false when cash cannot cover interest + maturity")
-        void canCoverObligationsThisWeek_falseWhenObligationsExceedCash() {
+        void canCoverObligationsThisWeek_falseWhenObligationsExceedCash() throws ExcessiveDebtException {
             // 400 NOK loan at 1%: money=1400 initially.
             // At week 11, obligations = 4.00 + 400.00 = 404.00. Drain to 403.00.
             player.takeLoan(new Loan(offer, new BigDecimal("400.00"), 1), converter);

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/loan/ExcessiveDebtExceptionTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/loan/ExcessiveDebtExceptionTest.java
@@ -1,0 +1,85 @@
+package edu.ntnu.idatt2003.millions.model.loan;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link ExcessiveDebtException}.
+ */
+class ExcessiveDebtExceptionTest {
+
+    @Nested
+    @DisplayName("ExcessiveDebtException(BigDecimal debtAfter, BigDecimal capacity)")
+    class PayloadConstructor {
+
+        @Test
+        @DisplayName("message contains both debtAfter and capacity")
+        void messageContainsBothValues() {
+            ExcessiveDebtException ex = new ExcessiveDebtException(
+                    new BigDecimal("600.00"), new BigDecimal("500.00"));
+            assertTrue(ex.getMessage().contains("600.00"),
+                    "message should contain debtAfter");
+            assertTrue(ex.getMessage().contains("500.00"),
+                    "message should contain capacity");
+        }
+
+        @Test
+        @DisplayName("getDebtAfter() returns the supplied debtAfter")
+        void getDebtAfterReturnValue() {
+            BigDecimal debtAfter = new BigDecimal("600.00");
+            ExcessiveDebtException ex = new ExcessiveDebtException(
+                    debtAfter, new BigDecimal("500.00"));
+            assertEquals(0, debtAfter.compareTo(ex.getDebtAfter()));
+        }
+
+        @Test
+        @DisplayName("getCapacity() returns the supplied capacity")
+        void getCapacityReturnValue() {
+            BigDecimal capacity = new BigDecimal("500.00");
+            ExcessiveDebtException ex = new ExcessiveDebtException(
+                    new BigDecimal("600.00"), capacity);
+            assertEquals(0, capacity.compareTo(ex.getCapacity()));
+        }
+
+        @Test
+        @DisplayName("is a checked exception")
+        void isChecked() {
+            assertTrue(Exception.class.isAssignableFrom(ExcessiveDebtException.class));
+            assertFalse(RuntimeException.class.isAssignableFrom(ExcessiveDebtException.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("ExcessiveDebtException(String message, Throwable cause)")
+    class ChainingConstructor {
+
+        @Test
+        @DisplayName("getMessage() returns the supplied message")
+        void messageIsPreserved() {
+            ExcessiveDebtException ex = new ExcessiveDebtException(
+                    "custom message", new RuntimeException("root"));
+            assertEquals("custom message", ex.getMessage());
+        }
+
+        @Test
+        @DisplayName("getCause() returns the supplied cause")
+        void causeIsPreserved() {
+            RuntimeException root = new RuntimeException("root");
+            ExcessiveDebtException ex = new ExcessiveDebtException("msg", root);
+            assertSame(root, ex.getCause());
+        }
+
+        @Test
+        @DisplayName("payload fields are null when using chaining constructor")
+        void payloadIsNullForChainingConstructor() {
+            ExcessiveDebtException ex = new ExcessiveDebtException("msg", null);
+            assertNull(ex.getDebtAfter());
+            assertNull(ex.getCapacity());
+        }
+    }
+}

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/loan/InsufficientSaleProceedsExceptionTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/loan/InsufficientSaleProceedsExceptionTest.java
@@ -1,0 +1,77 @@
+package edu.ntnu.idatt2003.millions.model.loan;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link InsufficientSaleProceedsException}.
+ */
+class InsufficientSaleProceedsExceptionTest {
+
+    @Nested
+    @DisplayName("InsufficientSaleProceedsException(BigDecimal shortfall)")
+    class PayloadConstructor {
+
+        @Test
+        @DisplayName("message contains the shortfall amount")
+        void messageContainsShortfall() {
+            InsufficientSaleProceedsException ex =
+                    new InsufficientSaleProceedsException(new BigDecimal("250.00"));
+            assertTrue(ex.getMessage().contains("250.00"),
+                    "message should contain the shortfall amount");
+        }
+
+        @Test
+        @DisplayName("getShortfall() returns the supplied shortfall")
+        void getShortfallReturnValue() {
+            BigDecimal shortfall = new BigDecimal("250.00");
+            InsufficientSaleProceedsException ex =
+                    new InsufficientSaleProceedsException(shortfall);
+            assertEquals(0, shortfall.compareTo(ex.getShortfall()));
+        }
+
+        @Test
+        @DisplayName("is a checked exception")
+        void isChecked() {
+            assertTrue(Exception.class.isAssignableFrom(
+                    InsufficientSaleProceedsException.class));
+            assertFalse(RuntimeException.class.isAssignableFrom(
+                    InsufficientSaleProceedsException.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("InsufficientSaleProceedsException(String message, Throwable cause)")
+    class ChainingConstructor {
+
+        @Test
+        @DisplayName("getMessage() returns the supplied message")
+        void messageIsPreserved() {
+            InsufficientSaleProceedsException ex =
+                    new InsufficientSaleProceedsException("custom message", null);
+            assertEquals("custom message", ex.getMessage());
+        }
+
+        @Test
+        @DisplayName("getCause() returns the supplied cause")
+        void causeIsPreserved() {
+            RuntimeException root = new RuntimeException("root");
+            InsufficientSaleProceedsException ex =
+                    new InsufficientSaleProceedsException("msg", root);
+            assertSame(root, ex.getCause());
+        }
+
+        @Test
+        @DisplayName("getShortfall() is null when using chaining constructor")
+        void shortfallIsNullForChainingConstructor() {
+            InsufficientSaleProceedsException ex =
+                    new InsufficientSaleProceedsException("msg", null);
+            assertNull(ex.getShortfall());
+        }
+    }
+}

--- a/src/test/java/edu/ntnu/idatt2003/millions/service/GameServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/service/GameServiceTest.java
@@ -1,9 +1,11 @@
 package edu.ntnu.idatt2003.millions.service;
 
 import edu.ntnu.idatt2003.millions.file.game.JsonGameFileHandler;
+import edu.ntnu.idatt2003.millions.file.stock.InvalidStockDataException;
 import edu.ntnu.idatt2003.millions.model.calculator.SalesCalculator;
 import edu.ntnu.idatt2003.millions.model.currency.FixedRateCurrencyConverter;
 import edu.ntnu.idatt2003.millions.model.exchange.Exchange;
+import edu.ntnu.idatt2003.millions.model.loan.ExcessiveDebtException;
 import edu.ntnu.idatt2003.millions.model.loan.InsufficientSaleProceedsException;
 import edu.ntnu.idatt2003.millions.model.loan.Loan;
 import edu.ntnu.idatt2003.millions.model.loan.LoanLedgerEntryType;
@@ -151,7 +153,7 @@ class GameServiceTest {
 
         @Test
         @DisplayName("Should create player and exchange from stock file")
-        void createsPlayerAndExchangeFromStockFile() throws IOException {
+        void createsPlayerAndExchangeFromStockFile() throws IOException, InvalidStockDataException {
             // Arrange
             File stockFile = createStockFile("AAPL,Apple Inc.,276.43\nMSFT,Microsoft,404.68\n");
             CountingObserver observer = new CountingObserver();
@@ -244,7 +246,7 @@ class GameServiceTest {
 
         @Test
         @DisplayName("Should tag uploaded stocks with the selected currency")
-        void tagsUploadedStocksWithSelectedCurrency() throws IOException {
+        void tagsUploadedStocksWithSelectedCurrency() throws IOException, InvalidStockDataException {
             // Arrange
             File stockFile = createStockFile("AAPL,Apple Inc.,100.00\n");
             Currency selectedCurrency = Currency.getInstance("EUR");
@@ -258,7 +260,7 @@ class GameServiceTest {
 
         @Test
         @DisplayName("Should convert purchase cost from selected currency to NOK")
-        void convertsPurchaseCostFromSelectedCurrencyToNok() throws IOException {
+        void convertsPurchaseCostFromSelectedCurrencyToNok() throws IOException, InvalidStockDataException {
             // Arrange
             File stockFile = createStockFile("AAPL,Apple Inc.,100.00\n");
             Currency usd = Currency.getInstance("USD");
@@ -287,7 +289,7 @@ class GameServiceTest {
 
         @Test
         @DisplayName("Should default stock currency to USD when no currency is supplied")
-        void defaultsStockCurrencyToUsdForCustomFile() throws IOException {
+        void defaultsStockCurrencyToUsdForCustomFile() throws IOException, InvalidStockDataException {
             // Arrange
             File stockFile = createStockFile("AAPL,Apple Inc.,100.00\n");
             GameService newGameService = new GameService();
@@ -431,7 +433,7 @@ class GameServiceTest {
 
         @Test
         @DisplayName("sells shares and deducts obligations from cash")
-        void executeForcedSale_sellsSharesAndPaysObligations() throws InsufficientSaleProceedsException {
+        void executeForcedSale_sellsSharesAndPaysObligations() throws InsufficientSaleProceedsException, ExcessiveDebtException {
             // Arrange — buy shares then take a loan so there is interest due
             gameService.takeLoan(offer, new BigDecimal("500.00"));
             Share share = buyAndGetShare();
@@ -448,7 +450,7 @@ class GameServiceTest {
 
         @Test
         @DisplayName("writes INTEREST ledger entries for each active loan")
-        void executeForcedSale_writesInterestLedgerEntries() throws InsufficientSaleProceedsException {
+        void executeForcedSale_writesInterestLedgerEntries() throws InsufficientSaleProceedsException, ExcessiveDebtException {
             // Arrange
             gameService.takeLoan(offer, new BigDecimal("500.00"));
             Share share = buyAndGetShare();
@@ -463,7 +465,7 @@ class GameServiceTest {
 
         @Test
         @DisplayName("throws InsufficientSaleProceedsException when proceeds < obligations")
-        void executeForcedSale_throwsWhenSharesDontCover() {
+        void executeForcedSale_throwsWhenSharesDontCover() throws ExcessiveDebtException {
             // Arrange — player: 10000 NOK, capacity = 5000.
             // Loan: 4000 NOK at 50%/week → interest = 2000 NOK.
             // Selling 5 shares at 100 NOK (NOK stock): net ≈ 495 NOK < 2000 → throws.
@@ -478,7 +480,7 @@ class GameServiceTest {
 
         @Test
         @DisplayName("is all-or-nothing: no mutations happen when proceeds are insufficient")
-        void executeForcedSale_isAllOrNothingOnInsufficientSale() {
+        void executeForcedSale_isAllOrNothingOnInsufficientSale() throws ExcessiveDebtException {
             // Arrange — same as above: obligations >> share net sale value
             LoanOffer bigRate = new LoanOffer("big", new BigDecimal("0.50"), 10,
                     new BigDecimal("50000.00"), LoanRiskLevel.HIGH);
@@ -499,7 +501,7 @@ class GameServiceTest {
 
         @Test
         @DisplayName("advances the week and records total debt after forced sale")
-        void executeForcedSale_advancesWeekAndRecordsTotalDebt() throws InsufficientSaleProceedsException {
+        void executeForcedSale_advancesWeekAndRecordsTotalDebt() throws InsufficientSaleProceedsException, ExcessiveDebtException {
             // Arrange
             gameService.takeLoan(offer, new BigDecimal("200.00"));
             Share share = buyAndGetShare();
@@ -513,7 +515,7 @@ class GameServiceTest {
 
         @Test
         @DisplayName("repays maturing loan and removes it from active loans")
-        void executeForcedSale_repaysMaturingLoanOnDueWeek() throws InsufficientSaleProceedsException {
+        void executeForcedSale_repaysMaturingLoanOnDueWeek() throws InsufficientSaleProceedsException, ExcessiveDebtException {
             // Arrange — offer has term 10; loan taken at week 1, due at week 11 (nextWeek = 2 here)
             // Use a short-term offer instead: term = 1 so due at week 2 (nextWeek after setUp)
             LoanOffer shortOffer = new LoanOffer("short", new BigDecimal("0.01"), 1,
@@ -528,7 +530,7 @@ class GameServiceTest {
 
         @Test
         @DisplayName("writes REPAYMENT ledger entry for maturing loan")
-        void executeForcedSale_writesRepaymentEntryForMaturingLoan() throws InsufficientSaleProceedsException {
+        void executeForcedSale_writesRepaymentEntryForMaturingLoan() throws InsufficientSaleProceedsException, ExcessiveDebtException {
             LoanOffer shortOffer = new LoanOffer("short", new BigDecimal("0.01"), 1,
                     new BigDecimal("50000.00"), LoanRiskLevel.LOW);
             gameService.takeLoan(shortOffer, new BigDecimal("200.00"));
@@ -547,7 +549,7 @@ class GameServiceTest {
 
         @Test
         @DisplayName("repays maturing loan and removes it from active loans")
-        void advanceWeek_repaysMaturingLoan() {
+        void advanceWeek_repaysMaturingLoan() throws ExcessiveDebtException {
             // Arrange — term 1 loan taken at week 1, due at week 2
             LoanOffer shortOffer = new LoanOffer("short", new BigDecimal("0.01"), 1,
                     new BigDecimal("50000.00"), LoanRiskLevel.LOW);
@@ -561,7 +563,7 @@ class GameServiceTest {
 
         @Test
         @DisplayName("writes INTEREST and REPAYMENT entries for maturing loan")
-        void advanceWeek_writesInterestAndRepaymentForMaturingLoan() {
+        void advanceWeek_writesInterestAndRepaymentForMaturingLoan() throws ExcessiveDebtException {
             LoanOffer shortOffer = new LoanOffer("short", new BigDecimal("0.01"), 1,
                     new BigDecimal("50000.00"), LoanRiskLevel.LOW);
             gameService.takeLoan(shortOffer, new BigDecimal("200.00"));
@@ -576,7 +578,7 @@ class GameServiceTest {
 
         @Test
         @DisplayName("deducts interest plus principal from cash on maturity week")
-        void advanceWeek_deductsInterestAndPrincipalOnMaturityWeek() {
+        void advanceWeek_deductsInterestAndPrincipalOnMaturityWeek() throws ExcessiveDebtException {
             LoanOffer shortOffer = new LoanOffer("short", new BigDecimal("0.01"), 1,
                     new BigDecimal("50000.00"), LoanRiskLevel.LOW);
             BigDecimal principal = new BigDecimal("200.00");


### PR DESCRIPTION
## Summary

- Promotes `ExcessiveDebtException` to a checked exception (extends 
  `Exception`) with `debtAfter` and `capacity` payload fields and 
  getters, so callers can display the exact figures to the player.
- Enhances `InsufficientSaleProceedsException` with a `shortfall` 
  payload field and getter.
- Introduces `InvalidStockDataException` (checked, in `file/stock/`) 
  thrown by `CsvStockFileHandler` on the first malformed CSV line; 
  carries `lineNumber` and `lineContent` so the UI can show a precise 
  error.
- Introduces `GameSaveCorruptException` (checked, in `file/game/`) 
  for future wiring into `JsonGameFileHandler` (the save-load 
  persistence fix is a separate issue).
- Rewrites `CsvStockFileHandler.parse()` from a stream pipeline to 
  a traditional loop, because Java streams cannot propagate checked 
  exceptions cleanly.
- Replaces `Runnable` in `StartController.runOrShowError` with a 
  private `GameAction` functional interface that declares 
  `throws InvalidStockDataException`, so checked exceptions propagate 
  through the callback.
- Narrows `catch (Exception e)` blocks in `LoanController` and 
  `PortfolioController` to the specific types that can actually be 
  thrown there.

## Behavioural changes worth highlighting

- `CsvStockFileHandler.parse()` now aborts on the first bad line 
  instead of silently skipping. A line like `AAPL,Apple,abc` (right 
  column count but non-numeric price) used to throw 
  `NumberFormatException` and propagate unwrapped; lines with the 
  wrong column count used to be silently dropped. Both cases now 
  throw `InvalidStockDataException` with line number and content. 
  This is a clearer contract: either the whole file parses 
  successfully, or you get a precise error identifying the first 
  problem.

- `Player.takeLoan` and `GameService.takeLoan` now declare `throws 
  ExcessiveDebtException`. Callers that don't catch it must propagate 
  it. All existing call sites were updated.

## Package placement

Custom exceptions live in the package whose domain they belong to, 
following the JDK convention (`java.io.FileNotFoundException` lives 
in `java.io`, not in a central exception package):

- `ExcessiveDebtException` and `InsufficientSaleProceedsException` 
  stay in `model/loan/`
- `InvalidStockDataException` in `file/stock/`
- `GameSaveCorruptException` in `file/game/`

No central `exception/` package was introduced.