### PR TITLE
fix: persist loan state, relink archive shares, and handle corrupt saves

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
@@ -1,5 +1,6 @@
 package edu.ntnu.idatt2003.millions.controller;
 
+import edu.ntnu.idatt2003.millions.file.game.GameSaveCorruptException;
 import edu.ntnu.idatt2003.millions.file.stock.InvalidStockDataException;
 import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.view.StartScreenInputs;
@@ -221,13 +222,13 @@ public class StartController {
      */
     @FunctionalInterface
     private interface GameAction {
-        void execute() throws InvalidStockDataException;
+        void execute() throws InvalidStockDataException, GameSaveCorruptException;
     }
 
     private void runOrShowError(GameAction action) {
         try {
             action.execute();
-        } catch (InvalidStockDataException | IllegalArgumentException
+        } catch (GameSaveCorruptException | InvalidStockDataException | IllegalArgumentException
                  | IllegalStateException | UncheckedIOException exception) {
             errorSink.accept(exception.getMessage());
         }

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/game/GameFileHandler.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/game/GameFileHandler.java
@@ -26,7 +26,9 @@ public interface GameFileHandler {
      *
      * @param file the file to load the game state from
      * @return a {@link GameState} containing the deserialized player and exchange
-     * @throws NullPointerException if the file is null
+     * @throws NullPointerException     if the file is null
+     * @throws GameSaveCorruptException if the file is not valid JSON or is missing
+     *                                  required fields
      */
-    GameState loadGame(File file);
+    GameState loadGame(File file) throws GameSaveCorruptException;
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/game/JsonGameFileHandler.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/game/JsonGameFileHandler.java
@@ -85,21 +85,44 @@ public class JsonGameFileHandler implements GameFileHandler {
      *
      * @param file the file to load the game state from
      * @return a {@link GameState} containing the deserialized player and exchange
-     * @throws NullPointerException if the file is null
-     * @throws UncheckedIOException if the file cannot be read
+     * @throws NullPointerException     if the file is null
+     * @throws UncheckedIOException     if the file cannot be read
+     * @throws GameSaveCorruptException if the file is not valid JSON or is missing
+     *                                  required top-level fields
      */
     @Override
-    public GameState loadGame(File file) {
+    public GameState loadGame(File file) throws GameSaveCorruptException {
         Objects.requireNonNull(file, "File cannot be null");
 
         try (FileReader reader = new FileReader(file)) {
-            JsonObject gameState = gson.fromJson(reader, JsonObject.class);
+            JsonObject gameState;
+            try {
+                gameState = gson.fromJson(reader, JsonObject.class);
+            } catch (JsonParseException e) {
+                throw new GameSaveCorruptException(
+                        "Save file contains invalid JSON: " + file.getName(), e);
+            }
 
-            Exchange exchange = gson.fromJson(gameState.get("exchange"), Exchange.class);
-            Player player = gson.fromJson(gameState.get("player"), Player.class);
+            if (gameState == null
+                    || !gameState.has("player")
+                    || !gameState.has("exchange")) {
+                throw new GameSaveCorruptException(
+                        "Save file is missing required fields 'player' or 'exchange': " + file.getName());
+            }
+
+            Exchange exchange;
+            Player player;
+            try {
+                exchange = gson.fromJson(gameState.get("exchange"), Exchange.class);
+                player = gson.fromJson(gameState.get("player"), Player.class);
+            } catch (JsonParseException e) {
+                throw new GameSaveCorruptException(
+                        "Save file has an unreadable structure: " + file.getName(), e);
+            }
 
             relinkShares(player, exchange);
             mergeSharesBySymbol(player);
+            relinkArchive(player, exchange);
 
             return new GameState(player, exchange);
 
@@ -156,6 +179,26 @@ public class JsonGameFileHandler implements GameFileHandler {
         }
     }
 
+
+    /**
+     * Relinks each share in every archived transaction to the canonical
+     * Stock object from the exchange after deserialization.
+     * Gson creates fresh Stock instances per JSON object; without relinking,
+     * archived transactions hold orphan Stock copies that diverge from the
+     * exchange's live instances.
+     *
+     * @param player   the player whose transaction archive should be relinked
+     * @param exchange the exchange containing the correct stock references
+     */
+    private void relinkArchive(Player player, Exchange exchange) {
+        for (Transaction transaction : player.getTransactionArchive().getAll()) {
+            Share oldShare = transaction.getShare();
+            var canonicalStock = exchange.getStock(oldShare.getStock().getSymbol());
+            if (canonicalStock != null) {
+                transaction.relinkShare(new Share(canonicalStock, oldShare.getQuantity(), oldShare.getPurchasePrice()));
+            }
+        }
+    }
 
     /**
      * Relinks each share in the player's portfolio to the correct

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/Transaction.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/Transaction.java
@@ -12,7 +12,7 @@ import java.util.Objects;
  * used to process it. Subclasses must implement {@link #commit(Player)}.
  */
 public abstract class Transaction {
-    private final Share share;
+    private Share share;
     private final int week;
     private boolean committed;
 
@@ -46,6 +46,19 @@ public abstract class Transaction {
      */
     public Share getShare() {
         return share;
+    }
+
+    /**
+     * Relinks this transaction's share to point to the canonical {@link edu.ntnu.idatt2003.millions.model.stock.Stock}
+     * from the exchange after deserialization. For deserialization use only — mirrors
+     * {@link edu.ntnu.idatt2003.millions.model.player.Portfolio#setShares(java.util.List)}.
+     *
+     * @param newShare the replacement share; must not be null
+     * @throws NullPointerException if newShare is null
+     */
+    public void relinkShare(Share newShare) {
+        Objects.requireNonNull(newShare, "Share cannot be null");
+        this.share = newShare;
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/TransactionArchive.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/TransactionArchive.java
@@ -44,6 +44,16 @@ public class TransactionArchive {
     }
 
     /**
+     * Returns all transactions in the archive regardless of week.
+     * Used by the file handler to iterate every archived transaction during relinking.
+     *
+     * @return a defensive copy of all transactions
+     */
+    public List<Transaction> getAll() {
+        return new ArrayList<>(transactions);
+    }
+
+    /**
      * Returns all transactions that took place in the specified week.
      *
      * @param week the week number to filter by

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/GameService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/GameService.java
@@ -1,6 +1,7 @@
 package edu.ntnu.idatt2003.millions.service;
 
 import edu.ntnu.idatt2003.millions.file.game.GameFileHandler;
+import edu.ntnu.idatt2003.millions.file.game.GameSaveCorruptException;
 import edu.ntnu.idatt2003.millions.file.game.GameState;
 import edu.ntnu.idatt2003.millions.file.game.JsonGameFileHandler;
 import edu.ntnu.idatt2003.millions.file.stock.CsvStockFileHandler;
@@ -195,9 +196,10 @@ public class GameService {
      * once the loaded state is in place.
      *
      * @param file the file to load the game state from
-     * @throws NullPointerException if the file is null
+     * @throws NullPointerException     if the file is null
+     * @throws GameSaveCorruptException if the save file is corrupt or has missing fields
      */
-    public void loadGame(File file) {
+    public void loadGame(File file) throws GameSaveCorruptException {
         Objects.requireNonNull(file, "File cannot be null");
         GameState state = gameFileHandler.loadGame(file);
         this.player = state.player();

--- a/src/test/java/edu/ntnu/idatt2003/millions/file/game/JsonGameFileHandlerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/file/game/JsonGameFileHandlerTest.java
@@ -2,9 +2,14 @@ package edu.ntnu.idatt2003.millions.file.game;
 
 import edu.ntnu.idatt2003.millions.model.currency.FixedRateCurrencyConverter;
 import edu.ntnu.idatt2003.millions.model.exchange.Exchange;
+import edu.ntnu.idatt2003.millions.model.loan.ExcessiveDebtException;
+import edu.ntnu.idatt2003.millions.model.loan.Loan;
+import edu.ntnu.idatt2003.millions.model.loan.LoanCatalog;
 import edu.ntnu.idatt2003.millions.model.player.Player;
 import edu.ntnu.idatt2003.millions.model.stock.Share;
 import edu.ntnu.idatt2003.millions.model.stock.Stock;
+import edu.ntnu.idatt2003.millions.model.transaction.Sale;
+import edu.ntnu.idatt2003.millions.model.transaction.Transaction;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -150,7 +155,7 @@ class JsonGameFileHandlerTest {
 
         @Test
         @DisplayName("Should return correct player name after load")
-        void returnsCorrectPlayerNameAfterLoad() {
+        void returnsCorrectPlayerNameAfterLoad() throws GameSaveCorruptException {
             // Arrange
             Path file = tempDir.resolve("save.json");
             handler.saveGame(player, exchange, file.toFile());
@@ -162,7 +167,7 @@ class JsonGameFileHandlerTest {
 
         @Test
         @DisplayName("Should return correct player money after load")
-        void returnsCorrectPlayerMoneyAfterLoad() {
+        void returnsCorrectPlayerMoneyAfterLoad() throws GameSaveCorruptException {
             // Arrange
             Path file = tempDir.resolve("save.json");
             handler.saveGame(player, exchange, file.toFile());
@@ -175,7 +180,7 @@ class JsonGameFileHandlerTest {
 
         @Test
         @DisplayName("Should return correct exchange name after load")
-        void returnsCorrectExchangeNameAfterLoad() {
+        void returnsCorrectExchangeNameAfterLoad() throws GameSaveCorruptException {
             // Arrange
             Path file = tempDir.resolve("save.json");
             handler.saveGame(player, exchange, file.toFile());
@@ -187,7 +192,7 @@ class JsonGameFileHandlerTest {
 
         @Test
         @DisplayName("Should return correct week after load")
-        void returnsCorrectWeekAfterLoad() {
+        void returnsCorrectWeekAfterLoad() throws GameSaveCorruptException {
             // Arrange
             Path file = tempDir.resolve("save.json");
             exchange.advance();
@@ -200,7 +205,7 @@ class JsonGameFileHandlerTest {
 
         @Test
         @DisplayName("Should return correct number of shares in portfolio after load")
-        void returnsCorrectNumberOfSharesAfterLoad() {
+        void returnsCorrectNumberOfSharesAfterLoad() throws GameSaveCorruptException {
             // Arrange
             Path file = tempDir.resolve("save.json");
             exchange.buy("EQNR", new BigDecimal("5"), player);
@@ -213,7 +218,7 @@ class JsonGameFileHandlerTest {
 
         @Test
         @DisplayName("Should relink share stock reference to exchange stock after load")
-        void relinksShareStockReferenceAfterLoad() {
+        void relinksShareStockReferenceAfterLoad() throws GameSaveCorruptException {
             // Arrange
             Path file = tempDir.resolve("save.json");
             exchange.buy("EQNR", new BigDecimal("5"), player);
@@ -228,7 +233,7 @@ class JsonGameFileHandlerTest {
 
         @Test
         @DisplayName("Should return correct number of transactions in archive after load")
-        void returnsCorrectNumberOfTransactionsAfterLoad() {
+        void returnsCorrectNumberOfTransactionsAfterLoad() throws GameSaveCorruptException {
             // Arrange
             Path file = tempDir.resolve("save.json");
             exchange.buy("EQNR", new BigDecimal("5"), player);
@@ -241,7 +246,7 @@ class JsonGameFileHandlerTest {
 
         @Test
         @DisplayName("Should return empty portfolio when no shares were owned")
-        void returnsEmptyPortfolioWhenNoSharesOwned() {
+        void returnsEmptyPortfolioWhenNoSharesOwned() throws GameSaveCorruptException {
             // Arrange
             Path file = tempDir.resolve("save.json");
             handler.saveGame(player, exchange, file.toFile());
@@ -253,7 +258,7 @@ class JsonGameFileHandlerTest {
 
         @Test
         @DisplayName("Should return empty transaction archive when no transactions were made")
-        void returnsEmptyTransactionArchiveWhenNoTransactionsMade() {
+        void returnsEmptyTransactionArchiveWhenNoTransactionsMade() throws GameSaveCorruptException {
             // Arrange
             Path file = tempDir.resolve("save.json");
             handler.saveGame(player, exchange, file.toFile());
@@ -265,7 +270,7 @@ class JsonGameFileHandlerTest {
 
         @Test
         @DisplayName("Should preserve price history after load")
-        void preservesPriceHistoryAfterLoad() {
+        void preservesPriceHistoryAfterLoad() throws GameSaveCorruptException {
             // Arrange
             Path file = tempDir.resolve("save.json");
             exchange.advance();
@@ -280,7 +285,7 @@ class JsonGameFileHandlerTest {
 
         @Test
         @DisplayName("Should merge shares with the same stock symbol from a legacy save on load")
-        void mergesSharesWithSameSymbolFromLegacySaveOnLoad() {
+        void mergesSharesWithSameSymbolFromLegacySaveOnLoad() throws GameSaveCorruptException {
             // Arrange: bypass addShare to simulate a legacy file with two entries for same stock
             Path file = tempDir.resolve("legacy_save.json");
             Share share1 = new Share(stock, new BigDecimal("5"), new BigDecimal("276.43"));
@@ -293,6 +298,28 @@ class JsonGameFileHandlerTest {
             assertEquals(1, state.player().getPortfolio().getShares().size());
             Share merged = state.player().getPortfolio().getShares().getFirst();
             assertEquals(0, new BigDecimal("8").compareTo(merged.getQuantity()));
+        }
+
+        @Test
+        @DisplayName("Should throw GameSaveCorruptException when file contains invalid JSON")
+        void throwsGameSaveCorruptExceptionForInvalidJson() throws Exception {
+            // Arrange
+            Path file = tempDir.resolve("corrupt.json");
+            Files.writeString(file, "{ this is not valid json }");
+            // Act & Assert
+            assertThrows(GameSaveCorruptException.class, () ->
+                    handler.loadGame(file.toFile()));
+        }
+
+        @Test
+        @DisplayName("Should throw GameSaveCorruptException when file is missing required fields")
+        void throwsGameSaveCorruptExceptionForMissingFields() throws Exception {
+            // Arrange
+            Path file = tempDir.resolve("incomplete.json");
+            Files.writeString(file, "{ \"player\": {} }");
+            // Act & Assert
+            assertThrows(GameSaveCorruptException.class, () ->
+                    handler.loadGame(file.toFile()));
         }
 
         @Test
@@ -314,8 +341,92 @@ class JsonGameFileHandlerTest {
         }
 
         @Test
+        @DisplayName("Should preserve active loans after round-trip save/load")
+        void preservesActiveLoansAfterRoundTrip() throws ExcessiveDebtException, GameSaveCorruptException {
+            // Arrange
+            Path file = tempDir.resolve("save.json");
+            Loan loan = new Loan(LoanCatalog.getOffers().get(0), new BigDecimal("4000.00"), 1);
+            player.takeLoan(loan, new FixedRateCurrencyConverter());
+            handler.saveGame(player, exchange, file.toFile());
+            // Act
+            GameState state = handler.loadGame(file.toFile());
+            // Assert
+            assertEquals(1, state.player().getActiveLoans().size());
+            Loan loadedLoan = state.player().getActiveLoans().get(0);
+            assertEquals(0, new BigDecimal("4000.00").compareTo(loadedLoan.principal()));
+            assertEquals(1, loadedLoan.takenAtWeek());
+        }
+
+        @Test
+        @DisplayName("Should preserve loan ledger entries after round-trip save/load")
+        void preservesLoanLedgerAfterRoundTrip() throws ExcessiveDebtException, GameSaveCorruptException {
+            // Arrange
+            Path file = tempDir.resolve("save.json");
+            Loan loan = new Loan(LoanCatalog.getOffers().get(0), new BigDecimal("4000.00"), 1);
+            player.takeLoan(loan, new FixedRateCurrencyConverter());
+            handler.saveGame(player, exchange, file.toFile());
+            // Act
+            GameState state = handler.loadGame(file.toFile());
+            // Assert
+            assertEquals(1, state.player().getLoanLedger().size());
+            assertEquals(0, new BigDecimal("4000.00")
+                    .compareTo(state.player().getLoanLedger().get(0).amount()));
+        }
+
+        @Test
+        @DisplayName("Should preserve total debt history after round-trip save/load")
+        void preservesTotalDebtHistoryAfterRoundTrip() throws ExcessiveDebtException, GameSaveCorruptException {
+            // Arrange
+            Path file = tempDir.resolve("save.json");
+            Loan loan = new Loan(LoanCatalog.getOffers().get(0), new BigDecimal("4000.00"), 1);
+            player.takeLoan(loan, new FixedRateCurrencyConverter());
+            player.recordTotalDebt();
+            handler.saveGame(player, exchange, file.toFile());
+            // Act
+            GameState state = handler.loadGame(file.toFile());
+            // Assert
+            assertEquals(1, state.player().getTotalDebtHistory().size());
+            assertEquals(0, new BigDecimal("4000.00")
+                    .compareTo(state.player().getTotalDebtHistory().get(0)));
+        }
+
+        @Test
+        @DisplayName("Should relink archived transaction shares to canonical exchange stocks after load")
+        void relinksArchivedTransactionShareAfterLoad() throws GameSaveCorruptException {
+            // Arrange
+            Path file = tempDir.resolve("save.json");
+            exchange.buy("EQNR", new BigDecimal("5"), player);
+            handler.saveGame(player, exchange, file.toFile());
+            // Act
+            GameState state = handler.loadGame(file.toFile());
+            // Assert
+            Stock canonicalStock = state.exchange().getStock("EQNR");
+            for (Transaction transaction : state.player().getTransactionArchive().getAll()) {
+                assertSame(canonicalStock, transaction.getShare().getStock());
+            }
+        }
+
+        @Test
+        @DisplayName("Should relink archived sale transaction share after load")
+        void relinksArchivedSaleShareAfterLoad() throws GameSaveCorruptException {
+            // Arrange
+            Path file = tempDir.resolve("save.json");
+            exchange.buy("EQNR", new BigDecimal("5"), player);
+            Share portfolioShare = player.getPortfolio().getShares().getFirst();
+            new Sale(portfolioShare, 1).commit(player);
+            handler.saveGame(player, exchange, file.toFile());
+            // Act
+            GameState state = handler.loadGame(file.toFile());
+            // Assert
+            Stock canonicalStock = state.exchange().getStock("EQNR");
+            for (Transaction transaction : state.player().getTransactionArchive().getAll()) {
+                assertSame(canonicalStock, transaction.getShare().getStock());
+            }
+        }
+
+        @Test
         @DisplayName("Should be able to advance week after loading game and reinitializing exchange")
-        void canAdvanceWeekAfterLoadingGameAndReinitialize() {
+        void canAdvanceWeekAfterLoadingGameAndReinitialize() throws GameSaveCorruptException {
             // Arrange
             Path file = tempDir.resolve("save.json");
             handler.saveGame(player, exchange, file.toFile());

--- a/src/test/java/edu/ntnu/idatt2003/millions/service/GameServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/service/GameServiceTest.java
@@ -1,5 +1,6 @@
 package edu.ntnu.idatt2003.millions.service;
 
+import edu.ntnu.idatt2003.millions.file.game.GameSaveCorruptException;
 import edu.ntnu.idatt2003.millions.file.game.JsonGameFileHandler;
 import edu.ntnu.idatt2003.millions.file.stock.InvalidStockDataException;
 import edu.ntnu.idatt2003.millions.model.calculator.SalesCalculator;
@@ -59,7 +60,7 @@ class GameServiceTest {
     Path tempDir;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws GameSaveCorruptException {
         Stock stock = new Stock("EQNR", "Equinor ASA",
                 new ArrayList<>(List.of(STOCK_PRICE)),
                 Currency.getInstance("NOK"));


### PR DESCRIPTION
 ## Summary
  
  - **Loan state persistence** - `activeLoans`, `loanLedger`, and `totalDebtHistory` now survive a save/load round-trip. Three new tests confirm    
  deserialization is correct with Gson 2.11.
  - **Archive share relinking** - `loadGame()` now runs a new `relinkArchive()` step so every archived `Transaction` points to the canonical `Stock`
   from `Exchange.stockMap`, not a Gson-created orphan copy. Two new tests assert `assertSame(canonicalStock, transaction.getShare().getStock())`   
  for both `Purchase` and `Sale` entries.
  - **Corrupt-save handling** - `GameSaveCorruptException` was defined but never thrown. `loadGame()` now catches `JsonParseException` and validates
   that `player` and `exchange` keys are present, throwing `GameSaveCorruptException` in either case. `StartController.runOrShowError` catches it so
   a corrupt file shows a friendly error dialog instead of crashing. Two new tests assert on `GameSaveCorruptException.class` specifically.

  ## Changes

  | File | Change |
  |---|---|
  | `JsonGameFileHandler` | `relinkArchive()` added; `loadGame()` validates JSON and wraps `JsonParseException` |
  | `Transaction` | `share` made non-final; `relinkShare(Share)` added (mirrors `Portfolio.setShares()`) |
  | `TransactionArchive` | `getAll()` added for file-handler iteration |
  | `GameFileHandler` (interface) | `loadGame()` declares `throws GameSaveCorruptException` |
  | `GameService` | `loadGame()` propagates `GameSaveCorruptException` |
  | `StartController` | `GameAction` and `runOrShowError` updated to handle `GameSaveCorruptException` |
  | `testgame.json` | Added `activeLoans`, `loanLedger`, `totalDebtHistory` fields |