### PR TITLE
feat: add GameOverModal

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/GameOverController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/GameOverController.java
@@ -1,0 +1,43 @@
+package edu.ntnu.idatt2003.millions.controller;
+
+import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
+import edu.ntnu.idatt2003.millions.model.player.Player;
+import edu.ntnu.idatt2003.millions.service.GameService;
+import edu.ntnu.idatt2003.millions.view.dialog.GameOverModal;
+import javafx.stage.Stage;
+
+import java.math.BigDecimal;
+
+/**
+ * Controller for the game-over flow. Collects the end-of-game context
+ * (week, obligations, liquidation value) and delegates rendering to
+ * {@link GameOverModal}.
+ */
+public class GameOverController {
+
+    private final GameService gameService;
+    private final Stage ownerStage;
+    private final Runnable onNewGame;
+
+    public GameOverController(GameService gameService, Stage ownerStage, Runnable onNewGame) {
+        this.gameService = gameService;
+        this.ownerStage = ownerStage;
+        this.onNewGame = onNewGame;
+    }
+
+    /**
+     * Opens the game-over modal. The week passed is the upcoming week the player
+     * failed to advance to (obligations were computed for that week).
+     *
+     * @param failedWeek the week number whose obligations the player could not cover
+     */
+    public void open(int failedWeek) {
+        Player player = gameService.getPlayer();
+        CurrencyConverter converter = gameService.getCurrencyConverter();
+
+        BigDecimal totalObligations = player.getTotalObligationsThisWeek(failedWeek);
+        BigDecimal totalLiquidationValue = player.getTotalLiquidationValue(converter);
+
+        new GameOverModal(failedWeek, totalObligations, totalLiquidationValue, ownerStage, onNewGame).show();
+    }
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/LoanController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/LoanController.java
@@ -68,6 +68,10 @@ public class LoanController {
         return gameService.getExchange().getWeek();
     }
 
+    public boolean isGameOver() {
+        return gameService.isGameOver();
+    }
+
     /**
      * Opens the read-only loan details modal for the given loan.
      *

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/MainController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/MainController.java
@@ -22,6 +22,7 @@ public class MainController {
     private final MainView view;
     private final GameService gameService;
     private final ForcedSaleController forcedSaleController;
+    private final GameOverController gameOverController;
 
     /**
      * Constructs a new MainController and creates the main view.
@@ -33,6 +34,8 @@ public class MainController {
         this.stage = stage;
         this.gameService = gameService;
         this.forcedSaleController = new ForcedSaleController(gameService);
+        this.gameOverController = new GameOverController(gameService, stage,
+                () -> new StartController(stage, gameService).show());
         PortfolioController portfolioController = new PortfolioController(gameService);
         LoanController loanController = new LoanController(gameService);
         this.view = new MainView(
@@ -55,8 +58,12 @@ public class MainController {
         int nextWeek = gameService.getExchange().getWeek() + 1;
         if (gameService.getPlayer().canCoverObligationsThisWeek(nextWeek)) {
             gameService.advanceWeek();
-        } else {
+        } else if (gameService.getPlayer().canCoverWithFullLiquidation(
+                nextWeek, gameService.getCurrencyConverter())) {
             forcedSaleController.open(nextWeek);
+        } else {
+            gameService.declareGameOver();
+            gameOverController.open(nextWeek);
         }
     }
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/PortfolioController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/PortfolioController.java
@@ -62,6 +62,10 @@ public class PortfolioController {
         return gameService.getCurrencyConverter();
     }
 
+    public boolean isGameOver() {
+        return gameService.isGameOver();
+    }
+
     /**
      * Returns a preview of buying the given quantity of a stock.
      *

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/player/Player.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/player/Player.java
@@ -1,5 +1,6 @@
 package edu.ntnu.idatt2003.millions.model.player;
 
+import edu.ntnu.idatt2003.millions.model.calculator.SalesCalculator;
 import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
 import edu.ntnu.idatt2003.millions.model.loan.ExcessiveDebtException;
 import edu.ntnu.idatt2003.millions.model.loan.Loan;
@@ -480,6 +481,43 @@ public class Player {
                         LoanLedgerEntryType.INTEREST, interest.negate()));
             }
         }
+    }
+
+    /**
+     * Returns the total liquidation value of all portfolio positions plus cash, in NOK.
+     * Liquidation value per share is the net payout after commission and tax,
+     * converted to NOK via the given converter.
+     *
+     * @param converter the currency converter used to translate share values to NOK
+     * @return cash plus net liquidation value of all holdings, in NOK
+     * @throws NullPointerException if converter is null
+     */
+    public BigDecimal getTotalLiquidationValue(CurrencyConverter converter) {
+        Objects.requireNonNull(converter, "Converter cannot be null");
+        BigDecimal portfolioLiquidation = portfolio.getShares().stream()
+                .map(s -> SalesCalculator.calculateNetNok(s, converter))
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        return money.add(portfolioLiquidation);
+    }
+
+    /**
+     * Returns {@code true} iff the player's total liquidation value
+     * (cash plus net sale proceeds from all holdings) is enough to cover
+     * {@link #getTotalObligationsThisWeek(int)}.
+     *
+     * <p>When this returns {@code false} and
+     * {@link #canCoverObligationsThisWeek(int)} is also {@code false}, a
+     * forced sale cannot save the player — the game is over.</p>
+     *
+     * @param currentWeek the game week to evaluate
+     * @param converter   the currency converter used to compute liquidation value
+     * @return true if forced-sale is viable; false if game over
+     * @throws NullPointerException if converter is null
+     */
+    public boolean canCoverWithFullLiquidation(int currentWeek, CurrencyConverter converter) {
+        Objects.requireNonNull(converter, "Converter cannot be null");
+        return getTotalLiquidationValue(converter)
+                .compareTo(getTotalObligationsThisWeek(currentWeek)) >= 0;
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/GameService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/GameService.java
@@ -50,6 +50,7 @@ public class GameService {
 
     private Player player;
     private Exchange exchange;
+    private boolean gameOver = false;
     private final GameFileHandler gameFileHandler;
     private final List<GameObserver> observers = new ArrayList<>();
 
@@ -70,6 +71,26 @@ public class GameService {
     public void addObserver(GameObserver observer) {
         Objects.requireNonNull(observer, "Observer cannot be null");
         observers.add(observer);
+    }
+
+    /**
+     * Returns whether the game has ended.
+     *
+     * @return true if the game is over; false otherwise
+     */
+    public boolean isGameOver() {
+        return gameOver;
+    }
+
+    /**
+     * Marks the game as over and notifies observers.
+     * Call this when the player cannot cover obligations even through full liquidation.
+     * After this call, all trading and week-advance operations will throw
+     * {@link IllegalStateException}.
+     */
+    public void declareGameOver() {
+        this.gameOver = true;
+        notifyObservers();
     }
 
     /**
@@ -162,6 +183,7 @@ public class GameService {
     private void activate(Player newPlayer, List<Stock> stocks) {
         this.player = newPlayer;
         this.exchange = new Exchange(DEFAULT_EXCHANGE_NAME, stocks, new FixedRateCurrencyConverter());
+        this.gameOver = false;
         notifyObservers();
     }
 
@@ -205,6 +227,7 @@ public class GameService {
         this.player = state.player();
         this.exchange = state.exchange();
         this.exchange.reinitialize(new FixedRateCurrencyConverter());
+        this.gameOver = false;
         notifyObservers();
     }
 
@@ -218,6 +241,7 @@ public class GameService {
      * @return the completed purchase transaction
      */
     public Transaction buy(String symbol, BigDecimal quantity) {
+        if (gameOver) throw new IllegalStateException("Game is over");
         Transaction transaction = exchange.buy(symbol, quantity, player);
         notifyObservers();
         return transaction;
@@ -248,6 +272,7 @@ public class GameService {
      * @return the completed sale transaction
      */
     public Transaction sell(Share share, BigDecimal quantity) {
+        if (gameOver) throw new IllegalStateException("Game is over");
         Transaction transaction = exchange.sell(share, quantity, player);
         notifyObservers();
         return transaction;
@@ -260,6 +285,7 @@ public class GameService {
      * when they cannot.
      */
     public void advanceWeek() {
+        if (gameOver) throw new IllegalStateException("Game is over");
         CurrencyConverter converter = exchange.getCurrencyConverter();
         player.setPreviousNetWorth(player.getNetWorth(converter));
         exchange.advance();
@@ -286,6 +312,7 @@ public class GameService {
      */
     public void executeForcedSale(List<Share> shares, int currentWeek)
             throws InsufficientSaleProceedsException {
+        if (gameOver) throw new IllegalStateException("Game is over");
         CurrencyConverter converter = exchange.getCurrencyConverter();
 
         List<Loan> maturingLoans = player.getLoansDueThisWeek(currentWeek);
@@ -373,6 +400,7 @@ public class GameService {
      *         if the loan would breach the player's debt-to-net-worth limit
      */
     public Loan takeLoan(LoanOffer offer, BigDecimal amount) throws ExcessiveDebtException {
+        if (gameOver) throw new IllegalStateException("Game is over");
         Objects.requireNonNull(offer, "Offer cannot be null");
         Objects.requireNonNull(amount, "Amount cannot be null");
         Loan loan = new Loan(offer, amount, exchange.getWeek());
@@ -390,6 +418,7 @@ public class GameService {
      * @throws IllegalArgumentException if the player cannot afford the repayment
      */
     public void repayLoan(Loan loan) {
+        if (gameOver) throw new IllegalStateException("Game is over");
         Objects.requireNonNull(loan, "Loan cannot be null");
         player.repayLoan(loan, exchange.getWeek());
         notifyObservers();

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/WeekBar.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/WeekBar.java
@@ -54,11 +54,12 @@ public class WeekBar extends HBox implements GameObserver {
     }
 
     /**
-     * Updates the week label when the game state changes.
+     * Updates the week label and disables the advance button when the game is over.
      */
     @Override
     public void onGameUpdated() {
         weekLabel.setText(LanguageManager.get("app.week") + " "
                 + gameService.getExchange().getWeek());
+        advanceButton.setDisable(gameService.isGameOver());
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/card/ActiveLoansCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/card/ActiveLoansCard.java
@@ -143,6 +143,7 @@ public class ActiveLoansCard extends Card {
     private HBox buildActionCell(Loan loan, int loanIndex) {
         Button repay = new Button(LanguageManager.get("loans.active.button.repay"));
         repay.getStyleClass().addAll("holdings-action-link", "holdings-action-buy");
+        repay.setDisable(gameService.isGameOver());
         repay.setOnAction(e -> controller.openRepayDialog(loan, loanIndex));
 
         Button details = new Button("❯");

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/card/AvailableLoansCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/card/AvailableLoansCard.java
@@ -42,6 +42,7 @@ public class AvailableLoansCard extends Card {
 
     private static final int OFFER_COUNT = 3;
 
+    private final GameService gameService;
     private final StyledText title = StyledText.sectionTitle();
     private final GridPane offersGrid = new GridPane();
 
@@ -55,6 +56,7 @@ public class AvailableLoansCard extends Card {
 
     public AvailableLoansCard(GameService gameService) {
         super(gameService);
+        this.gameService = gameService;
         setSpacing(16);
 
         offersGrid.setHgap(16);
@@ -85,7 +87,8 @@ public class AvailableLoansCard extends Card {
 
     @Override
     public void onGameUpdated() {
-        // Loan catalog is static — no response to game-state changes needed
+        boolean gameOver = gameService.isGameOver();
+        applyButtons.forEach(btn -> btn.setDisable(gameOver));
     }
 
     @Override

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/dialog/LoanDetailsModal.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/dialog/LoanDetailsModal.java
@@ -133,6 +133,7 @@ public class LoanDetailsModal extends Modal {
 
         Button repayBtn = new Button(LanguageManager.get("loans.details.button.repay"));
         repayBtn.getStyleClass().addAll("modal-button", "modal-button-primary");
+        repayBtn.setDisable(controller.isGameOver());
         repayBtn.setOnAction(e -> {
             close();
             Platform.runLater(() -> controller.openRepayDialog(loan, loanIndex));

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/HoldingsCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/HoldingsCard.java
@@ -169,9 +169,15 @@ public class HoldingsCard extends Card {
     }
 
     private HBox buildActionButtons(Share share) {
+        boolean gameOver = gameService.isGameOver();
+
         Button buy = actionButton(LanguageManager.get("dashboard.portfolio.buy"), "holdings-action-buy");
         Button sell = actionButton(LanguageManager.get("dashboard.portfolio.sell"), "holdings-action-sell");
         Button sellAll = actionButton(LanguageManager.get("dashboard.portfolio.sellAll"), "holdings-action-sell");
+
+        buy.setDisable(gameOver);
+        sell.setDisable(gameOver);
+        sellAll.setDisable(gameOver);
 
         buy.setOnAction(e -> controller.openBuyDialog(share.getStock()));
         sell.setOnAction(e -> controller.openSellDialog(share));

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/dialog/ShareDetailsModal.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/dialog/ShareDetailsModal.java
@@ -65,8 +65,11 @@ public class ShareDetailsModal extends Modal {
                 currencyCode,
                 NUMBER_FORMAT.format(stock.getSalesPrice()));
 
+        boolean gameOver = controller.isGameOver();
+
         Button buyMore = new Button(LanguageManager.get("details.button.buyMore"));
         buyMore.getStyleClass().addAll("modal-button", "modal-button-primary");
+        buyMore.setDisable(gameOver);
         buyMore.setOnAction(e -> {
             close();
             Platform.runLater(() -> controller.openBuyDialog(stock));
@@ -74,6 +77,7 @@ public class ShareDetailsModal extends Modal {
 
         Button sell = new Button(LanguageManager.get("details.button.sell"));
         sell.getStyleClass().addAll("modal-button", "modal-button-danger");
+        sell.setDisable(gameOver);
         sell.setOnAction(e -> {
             close();
             Platform.runLater(() -> controller.openSellDialog(share));
@@ -81,6 +85,7 @@ public class ShareDetailsModal extends Modal {
 
         Button sellAll = new Button(LanguageManager.get("details.button.sellAll"));
         sellAll.getStyleClass().addAll("modal-button", "modal-button-danger");
+        sellAll.setDisable(gameOver);
         sellAll.setOnAction(e -> {
             close();
             Platform.runLater(() -> controller.openSellAllDialog(share));

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dialog/GameOverModal.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dialog/GameOverModal.java
@@ -1,0 +1,124 @@
+package edu.ntnu.idatt2003.millions.view.dialog;
+
+import edu.ntnu.idatt2003.millions.util.CurrencyFormatter;
+import edu.ntnu.idatt2003.millions.util.LanguageManager;
+import edu.ntnu.idatt2003.millions.view.component.Modal;
+import edu.ntnu.idatt2003.millions.view.component.ModalActions;
+import edu.ntnu.idatt2003.millions.view.component.StyledText;
+import javafx.application.Platform;
+import javafx.geometry.Pos;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+
+import java.math.BigDecimal;
+import java.text.MessageFormat;
+
+/**
+ * Modal shown when the player cannot cover their obligations even through
+ * full portfolio liquidation. ESC is blocked; the player must choose to
+ * review the final game state or start a new game.
+ */
+public class GameOverModal extends Modal {
+
+    private final int currentWeek;
+    private final BigDecimal totalObligations;
+    private final BigDecimal totalLiquidationValue;
+    private final Stage ownerStage;
+    private final Runnable onNewGame;
+
+    public GameOverModal(int currentWeek,
+                         BigDecimal totalObligations,
+                         BigDecimal totalLiquidationValue,
+                         Stage ownerStage,
+                         Runnable onNewGame) {
+        this.currentWeek = currentWeek;
+        this.totalObligations = totalObligations;
+        this.totalLiquidationValue = totalLiquidationValue;
+        this.ownerStage = ownerStage;
+        this.onNewGame = onNewGame;
+    }
+
+    /** ESC is blocked — the player must use one of the two buttons. */
+    @Override
+    public void close() {}
+
+    @Override
+    protected void showStage() {
+        stage.show();
+        Platform.runLater(() -> {
+            stage.setX(ownerStage.getX() + (ownerStage.getWidth()  - stage.getWidth())  / 2);
+            stage.setY(ownerStage.getY() + (ownerStage.getHeight() - stage.getHeight()) / 2);
+        });
+    }
+
+    @Override
+    protected Region buildContent() {
+        VBox content = new VBox(0);
+        content.getChildren().addAll(buildCloseRow(), buildBody());
+        return content;
+    }
+
+    private HBox buildCloseRow() {
+        Region spacer = new Region();
+        HBox.setHgrow(spacer, Priority.ALWAYS);
+
+        Button closeBtn = new Button("✕");
+        closeBtn.getStyleClass().add("modal-close");
+        closeBtn.setOnAction(e -> stage.close());
+
+        HBox row = new HBox(spacer, closeBtn);
+        row.getStyleClass().add("modal-header");
+        row.setStyle("-fx-border-width: 0; -fx-padding: 12 24 0 24;");
+        return row;
+    }
+
+    private VBox buildBody() {
+        Label titleLabel = new Label(LanguageManager.get("gameOver.title"));
+        titleLabel.getStyleClass().add("game-over-title");
+
+        Region above = new Region();
+        above.setPrefHeight(20);
+        Region below = new Region();
+        below.setPrefHeight(20);
+
+        Label reasonLabel = StyledText.detailValue(LanguageManager.get("gameOver.reason"));
+        reasonLabel.setWrapText(true);
+        reasonLabel.setMaxWidth(380);
+
+        String contextText = MessageFormat.format(
+                LanguageManager.get("gameOver.context"),
+                currentWeek,
+                CurrencyFormatter.format(totalObligations),
+                CurrencyFormatter.format(totalLiquidationValue));
+        Label contextLabel = StyledText.detailLabel(contextText);
+        contextLabel.setWrapText(true);
+        contextLabel.setMaxWidth(380);
+
+        VBox paragraphs = new VBox(12, reasonLabel, contextLabel);
+        paragraphs.setAlignment(Pos.CENTER);
+
+        Button reviewBtn = new Button(LanguageManager.get("gameOver.review"));
+        reviewBtn.getStyleClass().addAll("modal-button", "modal-button-outlined");
+        reviewBtn.setOnAction(e -> stage.close());
+
+        Button newGameBtn = new Button(LanguageManager.get("gameOver.newGame"));
+        newGameBtn.getStyleClass().addAll("modal-button", "modal-button-primary");
+        newGameBtn.setOnAction(e -> {
+            stage.close();
+            onNewGame.run();
+        });
+
+        HBox buttons = ModalActions.row(reviewBtn, newGameBtn);
+
+        VBox body = new VBox(16, above, titleLabel, below, paragraphs, buttons);
+        body.getStyleClass().add("modal-body");
+        body.setStyle("-fx-padding: 0 24 20 24;");
+        body.setAlignment(Pos.CENTER);
+        return body;
+    }
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/exchange/stocks/card/StocksRowRenderer.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/exchange/stocks/card/StocksRowRenderer.java
@@ -161,8 +161,11 @@ class StocksRowRenderer {
      * @return an {@link HBox} containing the action buttons
      */
     private HBox buildTradeButtons(Stock stock) {
+        boolean gameOver = gameService.isGameOver();
+
         Button buyButton = new Button(LanguageManager.get("exchange.stocks.buy"));
         buyButton.getStyleClass().addAll("holdings-action-link", "holdings-action-buy");
+        buyButton.setDisable(gameOver);
         buyButton.setOnAction(e -> controller.openBuyDialog(stock));
 
         HBox buttons = new HBox(4, buyButton);
@@ -172,6 +175,7 @@ class StocksRowRenderer {
             Share share = shares.getFirst();
             Button sellButton = new Button(LanguageManager.get("exchange.stocks.sell"));
             sellButton.getStyleClass().addAll("holdings-action-link", "holdings-action-sell");
+            sellButton.setDisable(gameOver);
             sellButton.setOnAction(e -> controller.openSellDialog(share));
             buttons.getChildren().add(sellButton);
         }

--- a/src/main/resources/css/holdings.css
+++ b/src/main/resources/css/holdings.css
@@ -36,6 +36,12 @@ Button.holdings-header:hover {
     -fx-cursor: hand;
 }
 
+.holdings-action-link:disabled {
+    -fx-text-fill: -text-muted;
+    -fx-cursor: default;
+    -fx-underline: false;
+}
+
 .holdings-action-buy {
     -fx-text-fill: -primary;
 }

--- a/src/main/resources/css/modal.css
+++ b/src/main/resources/css/modal.css
@@ -252,6 +252,15 @@
     -fx-text-fill: -success-text;
 }
 
+/* ─── Game over modal ───────────────────────────────────────────────── */
+
+.game-over-title {
+    -fx-font-size: 52;
+    -fx-font-weight: 700;
+    -fx-text-fill: -text-primary;
+    -fx-padding: 0;
+}
+
 /* ─── Forced sale header ─────────────────────────────────────────────── */
 
 .forced-sale-header {

--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -359,3 +359,9 @@ forcedSale.status.short=Short by {0} NOK
 forcedSale.status.exact=Covers obligations exactly
 forcedSale.status.over=Covers obligations with {0} NOK to spare
 forcedSale.confirm=Confirm sale and continue
+# Game over modal
+gameOver.title=GAME OVER
+gameOver.reason=You're bankrupt. Your debts have outgrown everything you own.
+gameOver.context=Week {0} - you owe {1}, but only have {2} in cash and shares combined.
+gameOver.review=Review game
+gameOver.newGame=Start new game

--- a/src/main/resources/i18n/messages_no.properties
+++ b/src/main/resources/i18n/messages_no.properties
@@ -359,3 +359,9 @@ forcedSale.status.short=Mangler {0} NOK
 forcedSale.status.exact=Dekker rente nøyaktig
 forcedSale.status.over=Dekker rente med {0} NOK overskudd
 forcedSale.confirm=Bekreft salg og fortsett
+# Game over modal
+gameOver.title=GAME OVER
+gameOver.reason=Du er konkurs. Gjelden er større enn alt du eier.
+gameOver.context=Uke {0} - du skylder {1}, men har bare {2} i kontanter og aksjer til sammen.
+gameOver.review=Se over spillet
+gameOver.newGame=Start nytt spill

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/PlayerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/PlayerTest.java
@@ -1,5 +1,6 @@
 package edu.ntnu.idatt2003.millions.model;
 
+import edu.ntnu.idatt2003.millions.model.calculator.SalesCalculator;
 import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
 import edu.ntnu.idatt2003.millions.model.currency.FixedRateCurrencyConverter;
 import edu.ntnu.idatt2003.millions.model.loan.ExcessiveDebtException;
@@ -1050,6 +1051,50 @@ class PlayerTest {
             player.takeLoan(new Loan(offer, new BigDecimal("400.00"), 1), converter);
             player.withdrawMoney(new BigDecimal("997.00")); // money = 403.00 < 404.00
             assertFalse(player.canCoverObligationsThisWeek(11));
+        }
+    }
+
+    @Nested
+    @DisplayName("getTotalLiquidationValue() and canCoverWithFullLiquidation()")
+    class LiquidationMethods {
+
+        @Test
+        @DisplayName("getTotalLiquidationValue() equals cash when portfolio is empty")
+        void liquidationValueEqualsCashWhenPortfolioEmpty() {
+            // Arrange — fresh player with no shares
+            // Act
+            BigDecimal result = player.getTotalLiquidationValue(converter);
+            // Assert
+            assertEquals(0, player.getMoney().compareTo(result));
+        }
+
+        @Test
+        @DisplayName("getTotalLiquidationValue() includes net share proceeds plus cash")
+        void liquidationValueIncludesShareProceeds() {
+            // Arrange — add a NOK share; compute expected net via SalesCalculator
+            Stock stock = nokStock("AAPL", "Apple", new BigDecimal("200.00"));
+            Share share = new Share(stock, new BigDecimal("2"), new BigDecimal("100.00"));
+            player.getPortfolio().addShare(share);
+            BigDecimal expectedNet = SalesCalculator.calculateNetNok(share, converter);
+            BigDecimal expected = player.getMoney().add(expectedNet);
+            // Act
+            BigDecimal result = player.getTotalLiquidationValue(converter);
+            // Assert
+            assertEquals(0, expected.compareTo(result));
+        }
+
+        @Test
+        @DisplayName("canCoverWithFullLiquidation() returns false when liquidation value is less than obligations")
+        void canCoverWithFullLiquidation_falseWhenTotalBelowObligations() throws ExcessiveDebtException {
+            // Arrange — drain cash and create a large loan obligation
+            LoanOffer highRisk = new LoanOffer("hr", new BigDecimal("0.05"), 2,
+                    new BigDecimal("500.00"), LoanRiskLevel.HIGH);
+            player.takeLoan(new Loan(highRisk, new BigDecimal("500.00"), 1), converter);
+            // obligations at week 2 = interest 25 + principal 500 = 525
+            // player has 1500 cash → can cover from cash; drain to 0 to force game-over scenario
+            player.withdrawMoney(player.getMoney()); // money = 0
+            // Liquidation value = 0 (no shares) < 525 obligations → false
+            assertFalse(player.canCoverWithFullLiquidation(2, converter));
         }
     }
 }

--- a/src/test/java/edu/ntnu/idatt2003/millions/service/GameServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/service/GameServiceTest.java
@@ -592,6 +592,107 @@ class GameServiceTest {
         }
     }
 
+    @Nested
+    @DisplayName("isGameOver() and declareGameOver()")
+    class GameOverState {
+
+        @Test
+        @DisplayName("isGameOver() returns false when game is freshly loaded")
+        void isGameOver_falseInitially() {
+            assertFalse(gameService.isGameOver());
+        }
+
+        @Test
+        @DisplayName("isGameOver() returns true after declareGameOver()")
+        void isGameOver_trueAfterDeclare() {
+            gameService.declareGameOver();
+            assertTrue(gameService.isGameOver());
+        }
+
+        @Test
+        @DisplayName("declareGameOver() notifies observers")
+        void declareGameOver_notifiesObservers() {
+            CountingObserver observer = new CountingObserver();
+            gameService.addObserver(observer);
+            int before = observer.updateCount;
+            gameService.declareGameOver();
+            assertEquals(before + 1, observer.updateCount);
+        }
+
+        @Test
+        @DisplayName("buy() throws IllegalStateException when game is over")
+        void buy_throwsWhenGameOver() {
+            gameService.declareGameOver();
+            assertThrows(IllegalStateException.class, () ->
+                    gameService.buy("EQNR", BigDecimal.ONE));
+        }
+
+        @Test
+        @DisplayName("sell() throws IllegalStateException when game is over")
+        void sell_throwsWhenGameOver() {
+            gameService.declareGameOver();
+            Share share = new Share(gameService.getExchange().getStock("EQNR"),
+                    BigDecimal.ONE, STOCK_PRICE);
+            assertThrows(IllegalStateException.class, () ->
+                    gameService.sell(share, BigDecimal.ONE));
+        }
+
+        @Test
+        @DisplayName("advanceWeek() throws IllegalStateException when game is over")
+        void advanceWeek_throwsWhenGameOver() {
+            gameService.declareGameOver();
+            assertThrows(IllegalStateException.class, () ->
+                    gameService.advanceWeek());
+        }
+
+        @Test
+        @DisplayName("takeLoan() throws IllegalStateException when game is over")
+        void takeLoan_throwsWhenGameOver() {
+            gameService.declareGameOver();
+            LoanOffer offer = new LoanOffer("t", new BigDecimal("0.01"), 10,
+                    new BigDecimal("9000.00"), LoanRiskLevel.LOW);
+            assertThrows(IllegalStateException.class, () ->
+                    gameService.takeLoan(offer, new BigDecimal("100.00")));
+        }
+
+        @Test
+        @DisplayName("repayLoan() throws IllegalStateException when game is over")
+        void repayLoan_throwsWhenGameOver() throws ExcessiveDebtException {
+            LoanOffer offer = new LoanOffer("t", new BigDecimal("0.01"), 10,
+                    new BigDecimal("9000.00"), LoanRiskLevel.LOW);
+            Loan loan = gameService.takeLoan(offer, new BigDecimal("100.00"));
+            gameService.declareGameOver();
+            assertThrows(IllegalStateException.class, () ->
+                    gameService.repayLoan(loan));
+        }
+
+        @Test
+        @DisplayName("isGameOver() resets to false when createNewGame() is called")
+        void createNewGame_resetsGameOver() {
+            gameService.declareGameOver();
+            gameService.createNewGame("Fresh", new BigDecimal("5000.00"));
+            assertFalse(gameService.isGameOver());
+        }
+
+        @Test
+        @DisplayName("isGameOver() resets to false when loadGame() is called")
+        void loadGame_resetsGameOver() throws GameSaveCorruptException {
+            gameService.declareGameOver();
+            Path file = tempDir.resolve("reset-save.json");
+            Stock stock = new Stock("EQNR", "Equinor ASA",
+                    new ArrayList<>(List.of(STOCK_PRICE)),
+                    Currency.getInstance("NOK"));
+            edu.ntnu.idatt2003.millions.model.exchange.Exchange exchange =
+                    new edu.ntnu.idatt2003.millions.model.exchange.Exchange(
+                            "NYSE", new ArrayList<>(List.of(stock)),
+                            new FixedRateCurrencyConverter());
+            Player player = new Player("Dara", STARTING_MONEY);
+            new JsonGameFileHandler().saveGame(player, exchange, file.toFile());
+            gameService.loadGame(file.toFile());
+            assertFalse(gameService.isGameOver());
+        }
+    }
+
     private static class CountingObserver implements GameObserver {
         private int updateCount;
 


### PR DESCRIPTION
### Game over flow

Adds a game-over state that triggers when the player cannot cover their weekly obligations even after liquidating their entire portfolio.

### What changed

**Domain / service**
- Player.getTotalLiquidationValue(CurrencyConverter) - sums cash + net sale proceeds for all held shares
- Player.canCoverWithFullLiquidation(int week, CurrencyConverter) - checks whether full liquidation covers this week's obligations
- GameService.gameOver boolean with isGameOver() / declareGameOver(); all mutating operations (buy, sell, advanceWeek, takeLoan, repayLoan,       
executeForcedSale) throw IllegalStateException when set
- State is reset on createNewGame / loadGame

**Controller**
- MainController.handleAdvanceWeek() now has three branches: advance normally → forced sale → game over
- New GameOverController collects end-of-game context (week, obligations, liquidation value) and opens the modal

**Game over modal**
- Large centered "GAME OVER" heading with equal spacing above and below
- Two body paragraphs: reason sentence + contextual line with week number, total obligations and total liquidation value
- Two side-by-side buttons: "Se over spillet" (dismisses modal) and "Start nytt spill" (navigates to start screen)
- ESC is blocked - player must make an explicit choice
- Modal is centered over the main application window

**Button disabling**
- All trade and loan action buttons are disabled when the game is over, across every surface where they appear:
  - Holdings card (buy / sell / sell all)
  - Stocks table (buy / sell)
  - Available loans card (apply buttons) - won't be available anyway because the player does not meet the requirements for a loan when bankrupt
  - Active loans card (repay)
  - Share details modal opened via chevron (buy more / sell / sell all)
  - Loan details modal opened via chevron (repay)
  - Advance-week button in the week bar
