### PR TITLE
refactor: replace emoji icons with Feather icons via Ikonli

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,18 @@
             <artifactId>gson</artifactId>
             <version>2.11.0</version>
         </dependency>
+
+        <!-- Ikonli - Feather icon pack for JavaFX -->
+        <dependency>
+            <groupId>org.kordamp.ikonli</groupId>
+            <artifactId>ikonli-javafx</artifactId>
+            <version>12.4.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.kordamp.ikonli</groupId>
+            <artifactId>ikonli-feather-pack</artifactId>
+            <version>12.4.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/Header.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/Header.java
@@ -79,8 +79,8 @@ public class Header extends HBox {
         badge = new Label();
         badge.getStyleClass().add("notification-bell-badge");
         badge.setVisible(false);
-        StackPane.setAlignment(badge, Pos.TOP_RIGHT);
-        StackPane.setMargin(badge, new Insets(-2, 0, 0, 0));
+        StackPane.setAlignment(badge, Pos.TOP_LEFT);
+        StackPane.setMargin(badge, new Insets(-2, 0, 0, 22));
 
         StackPane bellWrapper = new StackPane(bellButton, badge);
         bellWrapper.setAlignment(Pos.CENTER);

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/Header.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/Header.java
@@ -80,7 +80,7 @@ public class Header extends HBox {
         badge.getStyleClass().add("notification-bell-badge");
         badge.setVisible(false);
         StackPane.setAlignment(badge, Pos.TOP_RIGHT);
-        StackPane.setMargin(badge, new Insets(0, -4, 0, 0));
+        StackPane.setMargin(badge, new Insets(-2, 0, 0, 0));
 
         StackPane bellWrapper = new StackPane(bellButton, badge);
         bellWrapper.setAlignment(Pos.CENTER);

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/Header.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/Header.java
@@ -15,6 +15,7 @@ import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
+import org.kordamp.ikonli.javafx.FontIcon;
 
 public class Header extends HBox {
 
@@ -68,7 +69,10 @@ public class Header extends HBox {
         HBox actions = new HBox(16, saveButton, exitButton);
         actions.setAlignment(Pos.CENTER_RIGHT);
 
-        bellButton = new Button("🔔");
+        FontIcon bellIcon = new FontIcon("fth-bell");
+        bellIcon.getStyleClass().add("navbar-bell-icon");
+        bellButton = new Button();
+        bellButton.setGraphic(bellIcon);
         bellButton.getStyleClass().add("navbar-icon");
         Tooltip.install(bellButton, new Tooltip(LanguageManager.get("notification.bell.tooltip")));
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/SearchBar.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/SearchBar.java
@@ -51,7 +51,7 @@ public class SearchBar extends VBox {
      * @param buttonKey      the i18n key for the button text
      * @param onSearch       callback receiving the current search term on each
      *                       triggered search or clear action
-     * @param metadata       optional metadata shown below the search row, such as a {@link Label}
+     * @param metadata       optional metadata shown below the search row
      * @throws NullPointerException if placeholder key, button key or callback is null
      */
     public SearchBar(String placeholderKey, String buttonKey, Consumer<String> onSearch, Node metadata) {

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/SearchBar.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/SearchBar.java
@@ -3,8 +3,8 @@ package edu.ntnu.idatt2003.millions.view.component;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
 import javafx.scene.Node;
 import javafx.scene.control.Button;
-import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
+import org.kordamp.ikonli.javafx.FontIcon;
 import javafx.scene.input.KeyCode;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
@@ -27,7 +27,7 @@ public class SearchBar extends VBox {
 
     private final TextField searchField = new TextField();
     private final Button searchButton = new Button();
-    private final Button clearButton = new Button("✕");
+    private final Button clearButton = new Button();
     private final String placeholderKey;
     private final String buttonKey;
 
@@ -62,7 +62,7 @@ public class SearchBar extends VBox {
         this.placeholderKey = placeholderKey;
         this.buttonKey = buttonKey;
 
-        Label iconLabel = new Label("🔍");
+        FontIcon iconLabel = new FontIcon("fth-search");
         iconLabel.getStyleClass().add("search-icon");
 
         searchField.getStyleClass().add("search-field");
@@ -70,6 +70,9 @@ public class SearchBar extends VBox {
 
         searchButton.getStyleClass().add("search-button");
 
+        FontIcon clearIcon = new FontIcon("fth-x");
+        clearIcon.getStyleClass().add("search-clear-icon");
+        clearButton.setGraphic(clearIcon);
         clearButton.getStyleClass().add("search-clear-button");
         clearButton.setOpacity(0);
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/notification/NotificationPanel.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/notification/NotificationPanel.java
@@ -13,9 +13,9 @@ import javafx.scene.control.ScrollPane;
 import javafx.scene.control.Separator;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
-import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 import javafx.stage.Popup;
+import org.kordamp.ikonli.javafx.FontIcon;
 
 import java.text.MessageFormat;
 import java.util.List;
@@ -124,9 +124,8 @@ public class NotificationPanel {
     }
 
     private HBox buildRow(Notification n) {
-        Label icon = new Label(iconFor(n.severity()));
+        FontIcon icon = new FontIcon(iconFor(n.severity()));
         icon.getStyleClass().addAll("notification-icon", severityIconClass(n.severity()));
-        icon.setMinWidth(Region.USE_PREF_SIZE);
 
         Label title = new Label(LanguageManager.get(n.titleKey()));
         title.getStyleClass().addAll("notification-title", severityTitleClass(n.severity()));
@@ -164,10 +163,10 @@ public class NotificationPanel {
 
     static String iconFor(Notification.Severity s) {
         return switch (s) {
-            case SEVERE -> "⛔";
-            case WARNING -> "⚠";
-            case MILESTONE -> "🏆";
-            case INFO -> "ℹ";
+            case SEVERE -> "fth-alert-octagon";
+            case WARNING -> "fth-alert-triangle";
+            case MILESTONE -> "fth-award";
+            case INFO -> "fth-info";
         };
     }
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/notification/NotificationPopupOverlay.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/notification/NotificationPopupOverlay.java
@@ -16,6 +16,7 @@ import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
+import org.kordamp.ikonli.javafx.FontIcon;
 import javafx.util.Duration;
 
 import java.util.ArrayDeque;
@@ -92,10 +93,9 @@ public class NotificationPopupOverlay {
     }
 
     private Region buildToast(Notification n) {
-        Label icon = new Label(NotificationPanel.iconFor(n.severity()));
+        FontIcon icon = new FontIcon(NotificationPanel.iconFor(n.severity()));
         icon.getStyleClass().addAll("notification-icon",
                 NotificationPanel.severityIconClass(n.severity()));
-        icon.setMinWidth(Region.USE_PREF_SIZE);
 
         Label title = new Label(LanguageManager.get(n.titleKey()));
         title.getStyleClass().addAll("notification-toast-title",
@@ -113,7 +113,10 @@ public class NotificationPopupOverlay {
         VBox content = new VBox(4, titleRow, body);
         content.setPadding(new Insets(12, 32, 12, 16));
 
-        Button closeBtn = new Button("✕");
+        FontIcon closeBtnIcon = new FontIcon("fth-x");
+        closeBtnIcon.getStyleClass().add("notification-toast-close-icon");
+        Button closeBtn = new Button();
+        closeBtn.setGraphic(closeBtnIcon);
         closeBtn.getStyleClass().add("notification-toast-close");
 
         StackPane toast = new StackPane(content, closeBtn);

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/dialog/TransactionReceipt.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/dialog/TransactionReceipt.java
@@ -9,6 +9,7 @@ import javafx.geometry.Pos;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
+import org.kordamp.ikonli.javafx.FontIcon;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
@@ -71,7 +72,8 @@ public abstract class TransactionReceipt extends Modal {
     }
 
     private HBox buildHeader() {
-        Label icon = new Label("✓");
+        Label icon = new Label();
+        icon.setGraphic(new FontIcon("fth-check"));
         icon.getStyleClass().add("modal-success-icon");
 
         Label title = new Label(getTitle());

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dialog/ForcedSaleDialog.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dialog/ForcedSaleDialog.java
@@ -20,6 +20,7 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
+import org.kordamp.ikonli.javafx.FontIcon;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -98,7 +99,7 @@ public class ForcedSaleDialog extends Modal {
     }
 
     private VBox buildHeader() {
-        Label iconLabel = new Label("⚠");
+        FontIcon iconLabel = new FontIcon("fth-alert-triangle");
         iconLabel.getStyleClass().add("forced-sale-warning-icon");
 
         Label titleLabel = new Label(LanguageManager.get("forcedSale.title"));

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dialog/GameOverModal.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dialog/GameOverModal.java
@@ -13,6 +13,7 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
+import org.kordamp.ikonli.javafx.FontIcon;
 import javafx.stage.Stage;
 
 import java.math.BigDecimal;
@@ -67,7 +68,8 @@ public class GameOverModal extends Modal {
         Region spacer = new Region();
         HBox.setHgrow(spacer, Priority.ALWAYS);
 
-        Button closeBtn = new Button("✕");
+        Button closeBtn = new Button();
+        closeBtn.setGraphic(new FontIcon("fth-x"));
         closeBtn.getStyleClass().add("modal-close");
         closeBtn.setOnAction(e -> stage.close());
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/titlebar/WindowsTitleBar.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/titlebar/WindowsTitleBar.java
@@ -5,6 +5,7 @@ import edu.ntnu.idatt2003.millions.view.component.Header;
 import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.layout.HBox;
+import org.kordamp.ikonli.javafx.FontIcon;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
@@ -96,7 +97,12 @@ public class WindowsTitleBar implements TitleBar {
             else        maximize.getStyleClass().add("title-bar-btn-max");
         });
 
-        Button close = new Button("✕");
+        FontIcon closeIcon = new FontIcon("fth-x");
+        closeIcon.getStyleClass().add(
+            "title-bar-light".equals(styleClass) ? "title-bar-close-icon-light" : "title-bar-close-icon"
+        );
+        Button close = new Button();
+        close.setGraphic(closeIcon);
         close.getStyleClass().addAll("title-bar-btn", "title-bar-btn-close");
         close.setOnAction(e -> stage.close());
 

--- a/src/main/resources/css/modal.css
+++ b/src/main/resources/css/modal.css
@@ -27,15 +27,19 @@
 }
 
 .modal-close {
-    -fx-font-size: 18;
-    -fx-text-fill: -text-secondary;
     -fx-background-color: transparent;
     -fx-border-color: transparent;
     -fx-padding: 0 4 0 4;
     -fx-cursor: hand;
 }
-.modal-close:hover {
-    -fx-text-fill: black;
+
+.modal-close .ikonli-font {
+    -fx-icon-size: 16;
+    -fx-icon-color: -text-secondary;
+}
+
+.modal-close:hover .ikonli-font {
+    -fx-icon-color: -text-primary;
 }
 
 .modal-body {
@@ -229,15 +233,17 @@
 
 .modal-success-icon {
     -fx-background-color: -success-bg;
-    -fx-text-fill: -success-text;
     -fx-min-width: 32px;
     -fx-min-height: 32px;
     -fx-max-width: 32px;
     -fx-max-height: 32px;
     -fx-background-radius: 16px;
     -fx-alignment: center;
-    -fx-font-size: 16px;
-    -fx-font-weight: bold;
+}
+
+.modal-success-icon .ikonli-font {
+    -fx-icon-size: 16;
+    -fx-icon-color: -success-text;
 }
 
 .modal-header-success {
@@ -277,8 +283,8 @@
 }
 
 .forced-sale-warning-icon {
-    -fx-text-fill: -danger-text;
-    -fx-font-size: 18;
+    -fx-icon-size: 18;
+    -fx-icon-color: -danger-text;
 }
 
 

--- a/src/main/resources/css/navbar.css
+++ b/src/main/resources/css/navbar.css
@@ -29,10 +29,13 @@
 }
 
 .navbar-icon {
-    -fx-text-fill: white;
-    -fx-font-size: 18;
     -fx-background-color: transparent;
     -fx-cursor: hand;
+}
+
+.navbar-bell-icon {
+    -fx-icon-size: 20;
+    -fx-icon-color: white;
 }
 
 /* Language picker */

--- a/src/main/resources/css/notifications.css
+++ b/src/main/resources/css/notifications.css
@@ -110,23 +110,23 @@
 }
 
 .notification-icon {
-    -fx-font-size: 16px;
+    -fx-icon-size: 16;
 }
 
 .notification-icon-severe {
-    -fx-text-fill: -danger;
+    -fx-icon-color: -danger;
 }
 
 .notification-icon-warning {
-    -fx-text-fill: -warning;
+    -fx-icon-color: -warning;
 }
 
 .notification-icon-info {
-    -fx-text-fill: -border-strong;
+    -fx-icon-color: -border-strong;
 }
 
 .notification-icon-milestone {
-    -fx-text-fill: -success;
+    -fx-icon-color: -success;
 }
 
 .notification-title {
@@ -203,13 +203,12 @@
 
 .notification-toast-close {
     -fx-background-color: transparent;
-    -fx-text-fill: -text-secondary;
-    -fx-font-size: 11px;
     -fx-cursor: hand;
     -fx-padding: 0 2;
     -fx-min-width: 16;
 }
 
-.notification-toast-close:hover {
-    -fx-text-fill: -text-primary;
+.notification-toast-close-icon {
+    -fx-icon-size: 12;
+    -fx-icon-color: -text-secondary;
 }

--- a/src/main/resources/css/searchbar.css
+++ b/src/main/resources/css/searchbar.css
@@ -60,7 +60,16 @@
 
 .search-clear-button {
     -fx-background-color: -primary-dark;
-    -fx-text-fill: -surface;
+}
+
+.search-clear-icon {
+    -fx-icon-size: 14;
+    -fx-icon-color: -surface;
+}
+
+.search-icon {
+    -fx-icon-size: 16;
+    -fx-icon-color: -text-secondary;
 }
 
 .search-metadata {

--- a/src/main/resources/css/titlebar.css
+++ b/src/main/resources/css/titlebar.css
@@ -31,6 +31,16 @@
     -fx-font-size: 18px;
 }
 
+.title-bar-close-icon {
+    -fx-icon-size: 14;
+    -fx-icon-color: white;
+}
+
+.title-bar-close-icon-light {
+    -fx-icon-size: 14;
+    -fx-icon-color: -text-primary;
+}
+
 .title-bar-btn-close:hover {
     -fx-background-color: -danger;
 }
@@ -50,6 +60,7 @@
 .title-bar-light .title-bar-btn:hover {
     -fx-background-color: -surface-alt;
 }
+
 
 .title-bar-light .title-bar-btn-close:hover {
     -fx-background-color: -danger-bg;


### PR DESCRIPTION
Replaces emoji characters used as UI icons (🔔, 🔍, ⚠, etc.) with 
proper icon font glyphs from the Feather icon set, served via the 
Ikonli framework.
 
## Why
 
Emoji render differently on each operating system - Windows, macOS, 
and Linux all draw 🔔 in their own style. That broke the visual 
consistency of the rest of the design. Icon fonts render identically 
everywhere and pick up CSS variables for sizing and colour.
 
Feather was chosen over Lucide because Lucide doesn't have an 
official JavaFX port. Lucide is itself a fork of Feather, so the 
visual style is the same (24×24 grid, 2px stroke).
 
## Verified
 
- Bell icon, search field, close buttons, severity icons all render 
  Feather glyphs
- Icon colours follow the design tokens - no hard-coded hex values
- Consistent rendering across the views that previously used emoji
## Out of scope
 
- Custom icon font (e.g. project-specific icons) - not needed yet
- Material Design or FontAwesome packs - sticking with one pack 
  for visual consistency
 