### PR TITLE
test: cover file upload validation in resume game flow

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
@@ -183,14 +183,12 @@ public class StartController {
      * fails, the file path is cleared and the error is shown to the user
      * via the {@link #errorSink} so they cannot proceed with an invalid file.
      *
-     * <p>The currency currently selected in the view is used for parsing.
-     * If no currency is selected yet, USD is used as a fallback so that
-     * structural errors (wrong field count, blank fields, invalid price) are
-     * still caught regardless of the currency choice.</p>
+     * <p>Package-private visibility allows controller tests in this package
+     * to invoke the handler directly without simulating a drag-and-drop event.</p>
      *
      * @param file the CSV file to validate and register
      */
-    private void validateAndSetStockFile(File file) {
+    void validateAndSetStockFile(File file) {
         inputs.setStockFilePath(file.getAbsolutePath());
         Currency currency = Optional.ofNullable(inputs.getSelectedCurrency())
                 .orElse(Currency.getInstance("USD"));
@@ -208,9 +206,12 @@ public class StartController {
      * fails, the file path is cleared and the error is shown to the user
      * via the {@link #errorSink} so they cannot proceed with a corrupt save file.
      *
+     * <p>Package-private visibility allows controller tests in this package
+     * to invoke the handler directly without simulating a drag-and-drop event.</p>
+     *
      * @param file the JSON save file to validate and register
      */
-    private void validateAndSetSaveFile(File file) {
+    void validateAndSetSaveFile(File file) {
         inputs.setSaveFilePath(file.getAbsolutePath());
         try {
             new JsonGameFileHandler().loadGame(file);

--- a/src/test/java/edu/ntnu/idatt2003/millions/controller/StartControllerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/controller/StartControllerTest.java
@@ -1,15 +1,23 @@
 package edu.ntnu.idatt2003.millions.controller;
 
+import edu.ntnu.idatt2003.millions.file.game.JsonGameFileHandler;
+import edu.ntnu.idatt2003.millions.model.currency.FixedRateCurrencyConverter;
+import edu.ntnu.idatt2003.millions.model.exchange.Exchange;
+import edu.ntnu.idatt2003.millions.model.player.Player;
+import edu.ntnu.idatt2003.millions.model.stock.Stock;
 import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.view.StartScreenInputs;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.math.BigDecimal;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Currency;
@@ -29,6 +37,9 @@ import static org.junit.jupiter.api.Assertions.*;
  * call made to the service layer and optionally throws a configured failure.</p>
  */
 class StartControllerTest {
+
+    @TempDir
+    Path tempDir;
 
     private StubInputs inputs;
     private RecordingGameService gameService;
@@ -282,6 +293,125 @@ class StartControllerTest {
             // Assert
             assertEquals(1, errors.size());
             assertFalse(showMainCalled);
+        }
+    }
+
+    @Nested
+    @DisplayName("validateAndSetSaveFile()")
+    class ValidateAndSetSaveFile {
+
+        @Test
+        @DisplayName("Should store file path when save file is valid")
+        void storesFilePathWhenSaveFileIsValid() throws IOException {
+            // Arrange
+            Path saveFile = tempDir.resolve("save.json");
+            Stock stock = new Stock("EQNR", "Equinor ASA",
+                    new ArrayList<>(List.of(new BigDecimal("276.43"))),
+                    Currency.getInstance("NOK"));
+            Exchange exchange = new Exchange("Oslo Børs",
+                    new ArrayList<>(List.of(stock)),
+                    new FixedRateCurrencyConverter());
+            Player player = new Player("Dara", new BigDecimal("10000.00"));
+            new JsonGameFileHandler().saveGame(player, exchange, saveFile.toFile());
+            // Act
+            controller.validateAndSetSaveFile(saveFile.toFile());
+            // Assert
+            assertEquals(saveFile.toAbsolutePath().toString(), inputs.saveFilePath);
+            assertTrue(errors.isEmpty());
+        }
+
+        @Test
+        @DisplayName("Should clear file path and report error when save file contains invalid JSON")
+        void clearsFilePathAndReportsErrorWhenSaveFileIsCorrupt() throws IOException {
+            // Arrange
+            Path saveFile = tempDir.resolve("corrupt.json");
+            Files.writeString(saveFile, "{ this is not valid json }");
+            // Act
+            controller.validateAndSetSaveFile(saveFile.toFile());
+            // Assert
+            assertTrue(inputs.saveFilePath.isBlank());
+            assertEquals(1, errors.size());
+        }
+
+        @Test
+        @DisplayName("Should clear file path and report error when save file is missing required fields")
+        void clearsFilePathAndReportsErrorWhenSaveFileMissingRequiredFields() throws IOException {
+            // Arrange
+            Path saveFile = tempDir.resolve("incomplete.json");
+            Files.writeString(saveFile, "{ \"player\": {} }");
+            // Act
+            controller.validateAndSetSaveFile(saveFile.toFile());
+            // Assert
+            assertTrue(inputs.saveFilePath.isBlank());
+            assertEquals(1, errors.size());
+        }
+
+        @Test
+        @DisplayName("Should clear file path and report error when save file does not exist")
+        void clearsFilePathAndReportsErrorWhenSaveFileDoesNotExist() {
+            // Arrange
+            File nonExistent = tempDir.resolve("ghost.json").toFile();
+            // Act
+            controller.validateAndSetSaveFile(nonExistent);
+            // Assert
+            assertTrue(inputs.saveFilePath.isBlank());
+            assertEquals(1, errors.size());
+        }
+    }
+
+    @Nested
+    @DisplayName("validateAndSetStockFile()")
+    class ValidateAndSetStockFile {
+
+        @Test
+        @DisplayName("Should store file path when stock file is valid")
+        void storesFilePathWhenStockFileIsValid() throws IOException {
+            // Arrange
+            Path stockFile = tempDir.resolve("stocks.csv");
+            Files.writeString(stockFile, "AAPL,Apple Inc.,276.43\n");
+            // Act
+            controller.validateAndSetStockFile(stockFile.toFile());
+            // Assert
+            assertEquals(stockFile.toAbsolutePath().toString(), inputs.stockFilePath);
+            assertTrue(errors.isEmpty());
+        }
+
+        @Test
+        @DisplayName("Should clear file path and report error when stock file has invalid format")
+        void clearsFilePathAndReportsErrorWhenStockFileHasInvalidFormat() throws IOException {
+            // Arrange
+            Path stockFile = tempDir.resolve("stocks.csv");
+            Files.writeString(stockFile, "INVALID_LINE\n");
+            // Act
+            controller.validateAndSetStockFile(stockFile.toFile());
+            // Assert
+            assertTrue(inputs.stockFilePath.isBlank());
+            assertEquals(1, errors.size());
+        }
+
+        @Test
+        @DisplayName("Should clear file path and report error when stock file is empty")
+        void clearsFilePathAndReportsErrorWhenStockFileIsEmpty() throws IOException {
+            // Arrange
+            Path stockFile = tempDir.resolve("stocks.csv");
+            Files.writeString(stockFile, "");
+            // Act
+            controller.validateAndSetStockFile(stockFile.toFile());
+            // Assert
+            assertTrue(inputs.stockFilePath.isBlank());
+            assertEquals(1, errors.size());
+        }
+
+        @Test
+        @DisplayName("Should clear file path and report error when stock file does not exist")
+        void clearsFilePathAndReportsErrorWhenStockFileDoesNotExist() {
+            // Arrange
+            File nonExistent = tempDir.resolve("ghost.csv").toFile();
+            // Act
+            controller.validateAndSetStockFile(nonExistent);
+            // Assert
+            assertTrue(inputs.stockFilePath.isBlank());
+            assertEquals(1, errors.size());
         }
     }
 

--- a/src/test/java/edu/ntnu/idatt2003/millions/file/game/JsonGameFileHandlerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/file/game/JsonGameFileHandlerTest.java
@@ -305,6 +305,28 @@ class JsonGameFileHandlerTest {
         }
 
         @Test
+        @DisplayName("Should throw GameSaveCorruptException when file is empty")
+        void throwsGameSaveCorruptExceptionWhenFileIsEmpty() throws Exception {
+            // Arrange
+            Path file = tempDir.resolve("empty.json");
+            Files.writeString(file, "");
+            // Act & Assert
+            assertThrows(GameSaveCorruptException.class, () ->
+                    handler.loadGame(file.toFile()));
+        }
+
+        @Test
+        @DisplayName("Should throw GameSaveCorruptException when file contains a JSON array instead of an object")
+        void throwsGameSaveCorruptExceptionWhenFileIsJsonArray() throws Exception {
+            // Arrange
+            Path file = tempDir.resolve("array.json");
+            Files.writeString(file, "[1, 2, 3]");
+            // Act & Assert
+            assertThrows(GameSaveCorruptException.class, () ->
+                    handler.loadGame(file.toFile()));
+        }
+
+        @Test
         @DisplayName("Should throw GameSaveCorruptException when file contains invalid JSON")
         void throwsGameSaveCorruptExceptionForInvalidJson() throws Exception {
             // Arrange


### PR DESCRIPTION
Closes the gap identified in the resume game issue: the drop-and-validate flow (validateAndSetSaveFile, validateAndSetStockFile) was untested despite the underlying logic already being in place.

### Changes

StartController: made validateAndSetSaveFile and validateAndSetStockFile package-private so they can be reached from controller tests without a JavaFX stage.

StartControllerTest: added ValidateAndSetSaveFile (4 tests) and ValidateAndSetStockFile (4 tests) covering valid input, corrupt/malformed files, missing required fields, and non-existent files.

JsonGameFileHandlerTest: added two edge cases for loadGame() , empty file and a JSON array - both of which should throw GameSaveCorruptException.