### PR TITLE
refactor: remove unused legacy sessionId fallback

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/millions/model/player/Player.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/player/Player.java
@@ -107,7 +107,7 @@ public class Player {
      * @return the session UUID as a string
      */
     public String getSessionId() {
-        return sessionId == null ? "legacy-" + name : sessionId;
+        return sessionId;
     }
 
     /**


### PR DESCRIPTION
## What

Removes the legacy fallback in `Player.getSessionId()`. The method now
returns the field directly instead of returning `"legacy-" + name` when
the field is null.

## Why

The fallback was added defensively to handle savegames created before
the `sessionId` field existed. No such savegames exist in this project,
so the branch was unreachable.

Removing it:
- Eliminates dead code
- Makes the contract of `getSessionId()` unambiguous - it always returns
  a valid UUID string
- Prevents anyone from accidentally relying on a "legacy-..." prefix
  downstream