### PR TITLE
feat: add receipt for downpayment of loan

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/LoanController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/LoanController.java
@@ -8,7 +8,9 @@ import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.service.LoanPreviewService;
 import edu.ntnu.idatt2003.millions.view.dashboard.loans.dialog.LoanApplicationDialog;
 import edu.ntnu.idatt2003.millions.view.dashboard.loans.dialog.LoanDetailsModal;
+import edu.ntnu.idatt2003.millions.view.dashboard.loans.dialog.LoanRepaymentReceipt;
 import edu.ntnu.idatt2003.millions.view.dashboard.loans.dialog.RepayLoanDialog;
+import javafx.application.Platform;
 
 import java.math.BigDecimal;
 import java.util.Optional;
@@ -55,7 +57,7 @@ public class LoanController {
         RepayLoanDialog[] ref = new RepayLoanDialog[1];
         ref[0] = new RepayLoanDialog(loan, loanIndex, player.getMoney(), currentWeek,
                 validateRepay(loan));
-        ref[0].setOnConfirm(l -> handleRepayConfirm(ref[0], l));
+        ref[0].setOnConfirm(l -> handleRepayConfirm(ref[0], l, loanIndex));
         ref[0].show();
     }
 
@@ -115,10 +117,15 @@ public class LoanController {
         }
     }
 
-    private void handleRepayConfirm(RepayLoanDialog dialog, Loan loan) {
+    private void handleRepayConfirm(RepayLoanDialog dialog, Loan loan, int loanIndex) {
         try {
+            BigDecimal balanceBefore = gameService.getPlayer().getMoney();
+            int week = gameService.getExchange().getWeek();
             gameService.repayLoan(loan);
             dialog.close();
+            BigDecimal balanceAfter = gameService.getPlayer().getMoney();
+            Platform.runLater(() ->
+                    new LoanRepaymentReceipt(loan, loanIndex, balanceBefore, balanceAfter, week).show());
         } catch (IllegalArgumentException e) {
             dialog.showError(e.getMessage());
         }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/dialog/LoanRepaymentReceipt.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/dialog/LoanRepaymentReceipt.java
@@ -1,0 +1,146 @@
+package edu.ntnu.idatt2003.millions.view.dashboard.loans.dialog;
+
+import edu.ntnu.idatt2003.millions.model.loan.Loan;
+import edu.ntnu.idatt2003.millions.util.LanguageManager;
+import edu.ntnu.idatt2003.millions.view.component.Modal;
+import edu.ntnu.idatt2003.millions.view.component.StyledText;
+import edu.ntnu.idatt2003.millions.view.component.SummaryBox;
+import javafx.geometry.Pos;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
+import org.kordamp.ikonli.javafx.FontIcon;
+
+import java.math.BigDecimal;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
+
+/**
+ * Receipt shown after a successful loan repayment.
+ */
+public class LoanRepaymentReceipt extends Modal {
+
+    private static final DecimalFormat NUMBER_FORMAT;
+
+    static {
+        DecimalFormatSymbols symbols = new DecimalFormatSymbols(Locale.forLanguageTag("nb-NO"));
+        NUMBER_FORMAT = new DecimalFormat("#,##0.00", symbols);
+    }
+
+    private final Loan loan;
+    private final int loanIndex;
+    private final BigDecimal balanceBefore;
+    private final BigDecimal balanceAfter;
+    private final int currentWeek;
+
+    public LoanRepaymentReceipt(
+            Loan loan,
+            int loanIndex,
+            BigDecimal balanceBefore,
+            BigDecimal balanceAfter,
+            int currentWeek) {
+        this.loan = loan;
+        this.loanIndex = loanIndex;
+        this.balanceBefore = balanceBefore;
+        this.balanceAfter = balanceAfter;
+        this.currentWeek = currentWeek;
+    }
+
+    @Override
+    protected Region buildContent() {
+        VBox content = new VBox();
+        content.getChildren().addAll(buildHeader(), buildBody());
+        return content;
+    }
+
+    private HBox buildHeader() {
+        Label icon = new Label();
+        icon.setGraphic(new FontIcon("fth-check"));
+        icon.getStyleClass().add("modal-success-icon");
+
+        Label title = new Label(LanguageManager.get("receipt.loan.repay.title"));
+        title.getStyleClass().add("modal-title");
+
+        HBox titleGroup = new HBox(12, icon, title);
+        titleGroup.setAlignment(Pos.CENTER_LEFT);
+
+        Region spacer = new Region();
+        HBox.setHgrow(spacer, Priority.ALWAYS);
+
+        Button close = new Button("✕");
+        close.getStyleClass().add("modal-close");
+        close.setOnAction(e -> close());
+
+        HBox header = new HBox(titleGroup, spacer, close);
+        header.getStyleClass().addAll("modal-header", "modal-header-success");
+        return header;
+    }
+
+    private VBox buildBody() {
+        VBox body = new VBox();
+        body.getStyleClass().add("modal-body");
+        body.getChildren().addAll(
+                buildLoanSection(),
+                buildSummary(),
+                buildBalanceSection(),
+                buildActions()
+        );
+        return body;
+    }
+
+    private VBox buildLoanSection() {
+        StyledText label = StyledText.detailLabel(LanguageManager.get("receipt.loan.label"));
+
+        String offerName = LanguageManager.get("loans.offer." + loan.offer().id() + ".name");
+        Label value = new Label(offerName + " #" + loanIndex);
+        value.getStyleClass().add("modal-section-value");
+
+        return new VBox(4, label, value);
+    }
+
+    private SummaryBox buildSummary() {
+        SummaryBox summary = new SummaryBox();
+        summary.addRow(
+                LanguageManager.get("receipt.loan.repay.summary.amountPaid"),
+                NUMBER_FORMAT.format(loan.principal()) + " NOK");
+        summary.addRow(
+                LanguageManager.get("receipt.loan.repay.summary.interestSaved"),
+                NUMBER_FORMAT.format(loan.interestSaved(currentWeek)) + " NOK",
+                "positive");
+        return summary;
+    }
+
+    private VBox buildBalanceSection() {
+        StyledText beforeLabel = StyledText.detailLabel(LanguageManager.get("receipt.balance.before"));
+        StyledText beforeValue = StyledText.detailValue(NUMBER_FORMAT.format(balanceBefore) + " NOK");
+        Region spacer1 = new Region();
+        HBox.setHgrow(spacer1, Priority.ALWAYS);
+        HBox beforeRow = new HBox(beforeLabel, spacer1, beforeValue);
+        beforeRow.getStyleClass().add("modal-balance-row");
+
+        StyledText afterLabel = StyledText.detailLabel(LanguageManager.get("receipt.balance.after"));
+        StyledText afterValue = StyledText.detailValue(NUMBER_FORMAT.format(balanceAfter) + " NOK");
+        Region spacer2 = new Region();
+        HBox.setHgrow(spacer2, Priority.ALWAYS);
+        HBox afterRow = new HBox(afterLabel, spacer2, afterValue);
+        afterRow.getStyleClass().add("modal-balance-row");
+
+        return new VBox(4, beforeRow, afterRow);
+    }
+
+    private HBox buildActions() {
+        Button closeButton = new Button(LanguageManager.get("receipt.button.close"));
+        closeButton.getStyleClass().add("modal-button");
+        closeButton.setOnAction(e -> close());
+        closeButton.setMaxWidth(Double.MAX_VALUE);
+        HBox.setHgrow(closeButton, Priority.ALWAYS);
+
+        HBox actions = new HBox(closeButton);
+        actions.getStyleClass().add("modal-actions");
+        return actions;
+    }
+}

--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -174,6 +174,11 @@ receipt.profit.gain=Gain on sale
 receipt.profit.loss=Loss on sale
 receipt.balance.before=Balance before
 receipt.balance.after=Balance after
+# Dashboard - Loan repayment receipt
+receipt.loan.repay.title=Loan repaid
+receipt.loan.label=Loan
+receipt.loan.repay.summary.interestSaved=Interest saved
+receipt.loan.repay.summary.amountPaid=Amount repaid
 # Dashboard - Share details modal
 details.title=Details on your share
 details.stock.label=Stock

--- a/src/main/resources/i18n/messages_no.properties
+++ b/src/main/resources/i18n/messages_no.properties
@@ -174,6 +174,11 @@ receipt.profit.loss=Tap på salget
 receipt.balance.before=Saldo før
 receipt.balance.after=Saldo etter
 receipt.button.close=Lukk
+# Dashboard - Loan repayment receipt
+receipt.loan.repay.title=Lån tilbakebetalt
+receipt.loan.label=Lån
+receipt.loan.repay.summary.interestSaved=Renter spart
+receipt.loan.repay.summary.amountPaid=Innbetalt
 # Dashboard - Share details modal
 details.title=Detaljer om din andel
 details.stock.label=Aksje


### PR DESCRIPTION
## What

Adds a receipt that appears after a loan is paid back, matching the
confirmation flow that already exists for stock purchases and sales.

## Why

The buy and sell flows close with a receipt that confirms what just
happened - ticker, quantity, total, new balance. Loan repayments
silently committed without any confirmation, which broke the pattern
and left the user without a clear "the payment went through" signal.