### PR TITLE
refactor: extract price simulation logic

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/millions/model/exchange/Exchange.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/exchange/Exchange.java
@@ -1,6 +1,7 @@
 package edu.ntnu.idatt2003.millions.model.exchange;
 
 import edu.ntnu.idatt2003.millions.factory.TransactionFactory;
+import edu.ntnu.idatt2003.millions.file.game.JsonGameFileHandler;
 import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
 import edu.ntnu.idatt2003.millions.model.transaction.Sale;
 import edu.ntnu.idatt2003.millions.model.transaction.Transaction;
@@ -9,14 +10,12 @@ import edu.ntnu.idatt2003.millions.model.stock.Share;
 import edu.ntnu.idatt2003.millions.model.stock.Stock;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.Comparator;
 import java.util.Currency;
 import java.util.List;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Random;
 import java.util.stream.Stream;
 
 /**
@@ -38,14 +37,8 @@ public class Exchange {
     private int week;
     private final Map<String, Stock> stockMap;
 
-    @SuppressWarnings("java:S2065") // transient is needed to prevent Gson from serializing Random
-    private transient Random random = new Random();
-
-    /** The lowest price a stock can have after a weekly update. */
-    private static final BigDecimal MIN_PRICE = new BigDecimal("0.01");
-
-    /** The maximum amount a stock price can change per week (10%). */
-    private static final BigDecimal MAX_WEEKLY_CHANGE = new BigDecimal("0.10");
+    @SuppressWarnings("java:S2065") // transient is needed to prevent Gson from serializing the simulator
+    private transient PriceSimulator simulator;
 
     private static final Currency NOK = Currency.getInstance("NOK");
 
@@ -53,22 +46,40 @@ public class Exchange {
     private transient CurrencyConverter currencyConverter;
 
     /**
-     * Creates a new exchange with the given name, list of stocks, and currency converter.
-     * The stocks are stored in a map using their symbol as the key. Week starts at 1.
-     * The converter is used by {@link #buy} and {@link #sell} to translate transaction
-     * amounts from each stock's native currency to NOK before adjusting the player's balance.
+     * Creates a new exchange with a {@link RandomPriceSimulator} as the default pricing model.
+     * Delegates to {@link #Exchange(String, List, CurrencyConverter, PriceSimulator)}.
      *
      * @param name              the name of the exchange
      * @param stocks            the stocks that can be traded on this exchange
      * @param currencyConverter the converter used to translate stock-currency amounts to NOK
      * @throws NullPointerException     if name, stocks, currencyConverter, or any stock in the list is null
+     * @throws IllegalArgumentException if name is blank, stocks is empty, contains null,
+     *                                  or contains duplicate symbols
+     */
+    public Exchange(String name, List<Stock> stocks, CurrencyConverter currencyConverter) {
+        this(name, stocks, currencyConverter, new RandomPriceSimulator());
+    }
+
+    /**
+     * Creates a new exchange with the given name, list of stocks, currency converter,
+     * and price simulator. The stocks are stored in a map using their symbol as the key.
+     * Week starts at 1.
+     *
+     * @param name              the name of the exchange
+     * @param stocks            the stocks that can be traded on this exchange
+     * @param currencyConverter the converter used to translate stock-currency amounts to NOK
+     * @param simulator         the strategy used to compute new stock prices each week
+     * @throws NullPointerException     if name, stocks, currencyConverter, simulator,
+     *                                  or any stock in the list is null
      * @throws IllegalArgumentException if name is blank, stocks is empty,
      *                                  contains null, or contains duplicate symbols
      */
-    public Exchange(String name, List<Stock> stocks, CurrencyConverter currencyConverter) {
+    public Exchange(String name, List<Stock> stocks, CurrencyConverter currencyConverter,
+                    PriceSimulator simulator) {
         Objects.requireNonNull(name, "Exchange name cannot be null");
         Objects.requireNonNull(stocks, "Exchange stocks cannot be null");
         Objects.requireNonNull(currencyConverter, "CurrencyConverter cannot be null");
+        Objects.requireNonNull(simulator, "PriceSimulator cannot be null");
 
         if (name.isBlank()) throw new IllegalArgumentException("Exchange name cannot be blank");
         if (stocks.isEmpty()) throw new IllegalArgumentException("Exchange stocks cannot be empty");
@@ -77,6 +88,7 @@ public class Exchange {
         this.week = 1;
         this.stockMap = new HashMap<>();
         this.currencyConverter = currencyConverter;
+        this.simulator = simulator;
 
         for (Stock stock : stocks) {
             Objects.requireNonNull(stock, "Stock list cannot contain null");
@@ -291,25 +303,12 @@ public class Exchange {
     /**
      * Moves the exchange forward by one week.
      * The week counter is incremented, and each stock gets a new price
-     * based on a random change of up to ±10%. No stock can go below MIN_PRICE.
+     * computed by the injected {@link PriceSimulator}.
      */
     public void advance() {
         week++;
         for (Stock stock : stockMap.values()) {
-            BigDecimal currentPrice = stock.getSalesPrice();
-
-            double randomFraction = (random.nextDouble() * 2.0) - 1.0;
-            BigDecimal percentChange = MAX_WEEKLY_CHANGE.multiply(BigDecimal.valueOf(randomFraction));
-
-            BigDecimal newPrice = currentPrice
-                    .multiply(BigDecimal.ONE.add(percentChange))
-                    .setScale(2, RoundingMode.HALF_UP);
-
-            if (newPrice.compareTo(MIN_PRICE) < 0) {
-                newPrice = MIN_PRICE;
-            }
-
-            stock.addNewSalesPrice(newPrice);
+            stock.addNewSalesPrice(simulator.nextPrice(stock.getSalesPrice()));
         }
     }
 
@@ -411,17 +410,15 @@ public class Exchange {
 
     /**
      * Reinitializes transient fields after deserialization.
-     * Must be called by {@link edu.ntnu.idatt2003.millions.file.game.JsonGameFileHandler}
-     * after loading a game from file, since Gson does not invoke constructors and
-     * the converter is marked transient.
+     * Must be called by {@link JsonGameFileHandler} after loading a game from file,
+     * since Gson does not invoke constructors and transient fields are not restored.
      *
      * @param currencyConverter the converter to use for the loaded game session
      * @throws NullPointerException if currencyConverter is null
      */
     public void reinitialize(CurrencyConverter currencyConverter) {
         Objects.requireNonNull(currencyConverter, "CurrencyConverter cannot be null");
-        this.random = new Random();
         this.currencyConverter = currencyConverter;
+        this.simulator = new RandomPriceSimulator();
     }
-
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/exchange/PriceSimulator.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/exchange/PriceSimulator.java
@@ -1,0 +1,24 @@
+package edu.ntnu.idatt2003.millions.model.exchange;
+
+import java.math.BigDecimal;
+
+/**
+ * Strategy interface for computing the next sales price of a stock.
+ *
+ * <p>Implementations define a pricing model (for example a random walk or a
+ * trend-based model, without coupling the model to {@link Exchange}).
+ * The interface is FunctionalInterface-annotated, so implementations
+ * may be supplied as lambdas where deterministic behaviour is needed (e.g. in tests)</p>
+ *
+ */
+@FunctionalInterface
+public interface PriceSimulator {
+
+    /**
+     * Computes the next sales price for a stock given its current price.
+     *
+     * @param currentPrice the stock's current sales price; never {@code null}
+     * @return the new sales price to apply; must not be {@code null}
+     */
+    BigDecimal nextPrice(BigDecimal currentPrice);
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/exchange/RandomPriceSimulator.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/exchange/RandomPriceSimulator.java
@@ -1,0 +1,52 @@
+package edu.ntnu.idatt2003.millions.model.exchange;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Random;
+
+/**
+ * A {@link PriceSimulator} that updates stock prices using a random walk model.
+ * Owns the random instance.
+ *
+ * <p>Each call applies a uniformly distributed random percentage change in the range
+ * {@code [-MAX_WEEKLY_CHANGE, +MAX_WEEKLY_CHANGE]} to the current price.
+ * The result is rounded to two decimal places and floored
+ * at {@code MIN_PRICE} so that no stock price reaches zero.</p>
+ */
+public class RandomPriceSimulator implements PriceSimulator {
+
+    /** The lowest price a stock can have after a weekly update. */
+    private static final BigDecimal MIN_PRICE = new BigDecimal("0.01");
+
+    /** The maximum percentage a stock price can change per week (10%). */
+    private static final BigDecimal MAX_WEEKLY_CHANGE = new BigDecimal("0.10");
+
+    private final Random random;
+
+    /**
+     * Creates a new {@code RandomPriceSimulator} with an unseeded {@link Random}.
+     */
+    public RandomPriceSimulator() {
+        this.random = new Random();
+    }
+
+    /**
+     * Computes the next price by applying a random percentage change to the current price.
+     * The change is uniformly distributed in {@code [-10%, +10%]}.
+     * The result is rounded to two decimal places and is never below {@link #MIN_PRICE}.
+     *
+     * @param currentPrice the stock's current sales price
+     * @return the new sales price after the random walk step
+     */
+    @Override
+    public BigDecimal nextPrice(BigDecimal currentPrice) {
+        double randomFraction = (random.nextDouble() * 2.0) - 1.0;
+        BigDecimal percentChange = MAX_WEEKLY_CHANGE.multiply(BigDecimal.valueOf(randomFraction));
+
+        BigDecimal newPrice = currentPrice
+                .multiply(BigDecimal.ONE.add(percentChange))
+                .setScale(2, RoundingMode.HALF_UP);
+
+        return newPrice.compareTo(MIN_PRICE) < 0 ? MIN_PRICE : newPrice;
+    }
+}

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/ExchangeTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/ExchangeTest.java
@@ -3,6 +3,7 @@ package edu.ntnu.idatt2003.millions.model;
 import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
 import edu.ntnu.idatt2003.millions.model.currency.FixedRateCurrencyConverter;
 import edu.ntnu.idatt2003.millions.model.exchange.Exchange;
+import edu.ntnu.idatt2003.millions.model.exchange.PriceSimulator;
 import edu.ntnu.idatt2003.millions.model.player.Player;
 import edu.ntnu.idatt2003.millions.model.stock.Share;
 import edu.ntnu.idatt2003.millions.model.stock.Stock;
@@ -482,14 +483,17 @@ class ExchangeTest {
         }
 
         @Test
-        @DisplayName("Should update stock price when advance is called")
-        void updatesStockPrice() {
+        @DisplayName("Should apply the exact price returned by the simulator when advance is called")
+        void appliesExactSimulatorResult() {
             // Arrange
-            BigDecimal priceBefore = stock.getSalesPrice();
+            BigDecimal fixedPrice = new BigDecimal("200.00");
+            PriceSimulator fixed = currentPrice -> fixedPrice;
+            Exchange deterministicExchange = new Exchange(
+                    "NYSE", new ArrayList<>(List.of(stock)), converter, fixed);
             // Act
-            exchange.advance();
+            deterministicExchange.advance();
             // Assert
-            assertNotEquals(priceBefore, stock.getSalesPrice());
+            assertEquals(0, fixedPrice.compareTo(stock.getSalesPrice()));
         }
 
         @Test

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/exchange/ExchangeTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/exchange/ExchangeTest.java
@@ -1,4 +1,4 @@
-package edu.ntnu.idatt2003.millions.model;
+package edu.ntnu.idatt2003.millions.model.exchange;
 
 import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
 import edu.ntnu.idatt2003.millions.model.currency.FixedRateCurrencyConverter;

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/exchange/RandomPriceSimulatorTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/exchange/RandomPriceSimulatorTest.java
@@ -1,0 +1,90 @@
+package edu.ntnu.idatt2003.millions.model.exchange;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link RandomPriceSimulator}.
+ */
+@DisplayName("RandomPriceSimulator")
+class RandomPriceSimulatorTest {
+
+    private RandomPriceSimulator simulator;
+
+    @BeforeEach
+    void setUp() {
+        simulator = new RandomPriceSimulator();
+    }
+
+    @Nested
+    @DisplayName("nextPrice()")
+    class NextPrice {
+
+        @Test
+        @DisplayName("Should return a price within ±10% of the current price")
+        void returnsNewPriceWithinBounds() {
+            // Arrange
+            BigDecimal current = new BigDecimal("100.00");
+            BigDecimal lower = new BigDecimal("90.00");
+            BigDecimal upper = new BigDecimal("110.00");
+
+            // Act & Assert
+            for (int i = 0; i < 1000; i++) {
+                BigDecimal next = simulator.nextPrice(current);
+                assertTrue(
+                        next.compareTo(lower) >= 0 && next.compareTo(upper) <= 0,
+                        "Price out of ±10% bounds: " + next);
+            }
+        }
+
+        @Test
+        @DisplayName("Should return a price with exactly two decimal places")
+        void returnsPriceWithTwoDecimalPlaces() {
+            // Arrange
+            BigDecimal current = new BigDecimal("100.00");
+
+            // Act & Assert
+            for (int i = 0; i < 100; i++) {
+                BigDecimal next = simulator.nextPrice(current);
+                assertEquals(2, next.scale(), "Expected scale 2, got: " + next);
+            }
+        }
+
+        @Test
+        @DisplayName("Should never return a price below the minimum floor of 0.01")
+        void neverReturnsPriceBelowMinimum() {
+            // Arrange
+            BigDecimal current = new BigDecimal("100.00");
+            BigDecimal minPrice = new BigDecimal("0.01");
+
+            // Act & Assert
+            for (int i = 0; i < 1000; i++) {
+                BigDecimal next = simulator.nextPrice(current);
+                assertTrue(
+                        next.compareTo(minPrice) >= 0,
+                        "Price fell below minimum: " + next);
+            }
+        }
+
+        @Test
+        @DisplayName("Should return the minimum floor price when input is at the minimum")
+        void floorsPriceAtMinimumForTinyInput() {
+            // Arrange
+            BigDecimal tinyPrice = new BigDecimal("0.01");
+            BigDecimal expected = new BigDecimal("0.01");
+
+            // Act & Assert — at 0.01, both ±10% round back to 0.01
+            for (int i = 0; i < 100; i++) {
+                BigDecimal next = simulator.nextPrice(tinyPrice);
+                assertEquals(0, expected.compareTo(next),
+                        "Expected 0.01 for tiny input, got: " + next);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Exchange.advance() previously handled two distinct responsibilities: incrementing the week counter and computing new stock prices inline. I separated the pricing concern by introducing a PriceSimulator strategy interface and a RandomPriceSimulator implementation.

### Changes

- Add PriceSimulator: a @FunctionalInterface in exchange/ defining the pricing contract
- Add RandomPricesimulator: owns Random, MIN_PRICE, and MAX_WEEKLY_CHANGE; implements the existing ±10% random walk algorithm
- Refactor Exchange: injects PriceSimulator via a new 4-arg constructor; the existing 3-arg constructor delegates to it with RandomPriceSimulator as default; advance() is reduced to a single delegation call; reinitialize() restores the transient simulator after Gson deserialization
- Add RandomPriceSimulatorTest:  unit tests verifying that the simulator keeps prices within ±10% bounds, always produces two decimal places, never returns a price below the 0.01 floor, and returns 0.01 deterministically when the input is at the minimum
- Fix ExchangeTest: replace the non-deterministic updatesStockPrice assertion with appliesExactSimulatorResult, which injects a fixed lambda via the 4-arg constructor and asserts the exact resulting price

No behaviour change. The pricing algorithm is identical, only its location has changed.