### PR TITLE
chore: force style on start css

### DIFF
--- a/src/main/resources/css/style.css
+++ b/src/main/resources/css/style.css
@@ -16,8 +16,5 @@
 @import "searchbar.css";
 @import "buttons.css";
 @import "notifications.css";
-<<<<<<< HEAD
 @import "start.css";
-=======
 @import "leaderboard.css";
->>>>>>> origin/main


### PR DESCRIPTION
Forgot to fix style merge conflict, start.css is implemented alongside leaderbord