### PR TITLE
refactor: single app-lifetime Scene with root swap navigation

### DIFF
--- a/leaderboard.json
+++ b/leaderboard.json
@@ -3,12 +3,12 @@
     "sessionId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
     "playerName": "Alva",
     "startingCapital": 10000.00,
-    "finalNetWorth": 12014.8813,
-    "returnPercent": 20.2,
-    "weeksPlayed": 24,
+    "finalNetWorth": 12529.1207,
+    "returnPercent": 25.3,
+    "weeksPlayed": 40,
     "status": "NOVICE",
-    "outcome": "RETIRED",
-    "lastUpdated": "2026-05-16T01:22:04.902031200Z"
+    "outcome": "ACTIVE",
+    "lastUpdated": "2026-05-16T01:54:52.266931Z"
   },
   {
     "sessionId": "80651cf1-aef5-4e63-b1b9-96c109f64730",

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
@@ -20,7 +20,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import javafx.application.Platform;
 import javafx.stage.FileChooser;
 import javafx.stage.Stage;
 
@@ -363,14 +362,12 @@ public class StartController {
     }
 
     /**
-     * Displays the start screen on the primary stage and binds UI events.
+     * Displays the start screen by swapping the root of the app-lifetime scene
+     * and binding UI events.
      */
     public void show() {
         bindEvents();
         stage.setTitle("Millions");
-        stage.setScene(view.getScene());
-        stage.show();
-        stage.setMaximized(true);
-        Platform.runLater(stage::centerOnScreen);
+        stage.getScene().setRoot(view.getRoot());
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/StartView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/StartView.java
@@ -1,7 +1,6 @@
 package edu.ntnu.idatt2003.millions.view;
 
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
-import edu.ntnu.idatt2003.millions.util.StylesheetLoader;
 import edu.ntnu.idatt2003.millions.view.component.AppTabPane;
 import edu.ntnu.idatt2003.millions.view.component.LanguagePicker;
 import edu.ntnu.idatt2003.millions.view.start.LoadGameTab;
@@ -12,7 +11,7 @@ import javafx.application.Platform;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
-import javafx.scene.Scene;
+import javafx.scene.Parent;
 import javafx.scene.control.Tab;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.HBox;
@@ -35,12 +34,10 @@ import java.util.function.Consumer;
  */
 public class StartView implements StartScreenInputs {
 
-    private static final double SCENE_WIDTH = 900;
-    private static final double SCENE_HEIGHT = 700;
     private static final double ROOT_SPACING = 24;
     private static final double START_CARD_WIDTH = 540;
 
-    private final Scene scene;
+    private final BorderPane root;
     private final StyledText title;
     private final AppTabPane tabPane;
     private final Tab newGameTab;
@@ -114,7 +111,7 @@ public class StartView implements StartScreenInputs {
                 START_CARD_WIDTH,
                 ROOT_SPACING);
 
-        BorderPane root = new BorderPane();
+        root = new BorderPane();
         root.getStyleClass().add("start-root");
 
         if (titleBarControls != null) {
@@ -123,13 +120,6 @@ public class StartView implements StartScreenInputs {
             root.setTop(topBar);
         }
         root.setCenter(center);
-
-        scene = new Scene(root, SCENE_WIDTH, SCENE_HEIGHT);
-        StylesheetLoader.load(scene,
-                StylesheetLoader.Stylesheet.TOKENS,
-                StylesheetLoader.Stylesheet.TITLE,
-                StylesheetLoader.Stylesheet.DROP_ZONE,
-                StylesheetLoader.Stylesheet.OTHER);
 
         updateTexts();
         LanguageManager.addObserver(this::updateTexts);
@@ -146,12 +136,12 @@ public class StartView implements StartScreenInputs {
     }
 
     /**
-     * Returns the JavaFX scene for this view.
+     * Returns the root node of this view for placement in the app-lifetime scene.
      *
-     * @return the scene
+     * @return the root node
      */
-    public Scene getScene() {
-        return scene;
+    public Parent getRoot() {
+        return root;
     }
 
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/titlebar/TitleBarFactory.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/titlebar/TitleBarFactory.java
@@ -19,6 +19,6 @@ public final class TitleBarFactory {
         if (OsDetector.isMac()) {
             return new NoOpTitleBar();
         }
-        return new WindowsTitleBar(stage, "title-bar-light", false);
+        return new WindowsTitleBar(stage, "title-bar", false);
     }
 }

--- a/src/main/resources/css/layout.css
+++ b/src/main/resources/css/layout.css
@@ -34,7 +34,7 @@
 
 /* === Start === */
 .start-root {
-    -fx-background-color: -footer-bg;
+    -fx-background-color: black;
 }
 
 


### PR DESCRIPTION
##  Summary

- Creates one Scene at app startup with transparent fill and all shared stylesheets; both StartController and MainController navigate by swapping the scene root, eliminating double-titlebar and scene-fill mismatch bugs
- Extracts applyWindowSize() from the old dev shortcut into a reusable helper on App (1920×1080 cap for large monitors, maximised otherwise)      
- StartView drops its own Scene and exposes getRoot() instead of getScene(), matching the pattern MainView already used
- Fixes start screen title bar icon visibility: TitleBarFactory.createForStartScreen now uses "title-bar" (black, white icons) instead of
"title-bar-light" (transparent, dark icons), consistent with the start screen's black background
- Aligns start-root background to black so the title bar and content area are seamless
