### PR TITLE
 fix: notification replay on load, repair save flow

### DIFF
--- a/leaderboard.json
+++ b/leaderboard.json
@@ -3,12 +3,12 @@
     "sessionId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
     "playerName": "Alva",
     "startingCapital": 10000.00,
-    "finalNetWorth": 12529.1207,
-    "returnPercent": 25.3,
-    "weeksPlayed": 40,
+    "finalNetWorth": 12508.9508,
+    "returnPercent": 25.1,
+    "weeksPlayed": 39,
     "status": "NOVICE",
     "outcome": "ACTIVE",
-    "lastUpdated": "2026-05-16T01:54:52.266931Z"
+    "lastUpdated": "2026-05-16T02:18:34.673578700Z"
   },
   {
     "sessionId": "80651cf1-aef5-4e63-b1b9-96c109f64730",

--- a/src/main/java/edu/ntnu/idatt2003/millions/App.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/App.java
@@ -1,20 +1,67 @@
 package edu.ntnu.idatt2003.millions;
 
-import javafx.application.Application;
-import javafx.stage.Stage;
 import edu.ntnu.idatt2003.millions.controller.StartController;
+import edu.ntnu.idatt2003.millions.util.OsDetector;
+import edu.ntnu.idatt2003.millions.util.StylesheetLoader;
+import javafx.application.Application;
+import javafx.geometry.Rectangle2D;
+import javafx.scene.Scene;
+import javafx.scene.layout.StackPane;
+import javafx.scene.paint.Color;
+import javafx.stage.Screen;
+import javafx.stage.Stage;
+import javafx.stage.StageStyle;
 
 /**
  * Entry point for the Millions application.
  *
- * <p>Extends {@link Application} and delegates startup to
- * {@link StartController}, which builds and displays the start screen.</p>
+ * <p>Creates a single app-lifetime {@link Scene} with transparent fill and all
+ * shared stylesheets, then hands off to {@link StartController}. Both
+ * {@code StartController} and {@code MainController} navigate by swapping the
+ * scene root, so there is never more than one scene or one title bar on
+ * screen at a time.</p>
  */
 public class App extends Application {
 
     @Override
     public void start(Stage stage) {
+        if (OsDetector.isMac()) {
+            stage.initStyle(StageStyle.UNIFIED);
+        } else {
+            stage.initStyle(StageStyle.TRANSPARENT);
+        }
+
+        Scene scene = new Scene(new StackPane(), 1920, 1080);
+        if (!OsDetector.isMac()) {
+            scene.setFill(Color.TRANSPARENT);
+        }
+        StylesheetLoader.load(scene,
+                StylesheetLoader.Stylesheet.TOKENS,
+                StylesheetLoader.Stylesheet.TITLE,
+                StylesheetLoader.Stylesheet.DROP_ZONE,
+                StylesheetLoader.Stylesheet.OTHER);
+        stage.setScene(scene);
+        applyWindowSize(stage);
+
         new StartController(stage).show();
+        stage.show();
+    }
+
+    /**
+     * Applies the standard window size to {@code stage}. On screens at or below
+     * 1920×1080 the stage is maximised; on larger screens it is centred at a fixed
+     * 1920×1080 cap so it does not expand absurdly on ultra-wide or 4K displays.
+     */
+    private static void applyWindowSize(Stage stage) {
+        Rectangle2D screen = Screen.getPrimary().getVisualBounds();
+        if (screen.getWidth() <= 1920 && screen.getHeight() <= 1080) {
+            stage.setMaximized(true);
+        } else {
+            stage.setWidth(1920);
+            stage.setHeight(1080);
+            stage.setX(screen.getMinX() + (screen.getWidth() - 1920) / 2);
+            stage.setY(screen.getMinY() + (screen.getHeight() - 1080) / 2);
+        }
     }
 
     /**
@@ -23,6 +70,9 @@ public class App extends Application {
      * @param args command-line arguments passed to the application
      */
     public static void main(String[] args) {
+        if (OsDetector.isMac()) {
+            System.setProperty("apple.awt.application.appearance", "NSAppearanceNameDarkAqua");
+        }
         launch(args);
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/Header.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/Header.java
@@ -114,6 +114,7 @@ public class Header extends HBox {
         setAlignment(Pos.TOP_LEFT);
 
         LanguageManager.addObserver(this::updateTexts);
+        onGameUpdated();
     }
 
     public void setOnLeaderboard(Runnable callback) {

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/notification/NotificationPopupOverlay.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/notification/NotificationPopupOverlay.java
@@ -44,6 +44,10 @@ public class NotificationPopupOverlay {
         stack.setMaxWidth(TOAST_WIDTH);
         stack.setPickOnBounds(false);
         stack.setVisible(false);
+        this.lastShownId = gameService.getPlayer().getNotifications().stream()
+                .mapToInt(Notification::id)
+                .max()
+                .orElse(0);
     }
 
     public Node getNode() {

--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -501,3 +501,6 @@ newGame.confirmContent=The current game will end.
 newGame.saveAndStartNew=Save and start new
 newGame.sellAllAndStartNew=Sell all and start new
 newGame.startNewWithoutSaving=Start new without saving
+# Toast messages
+toast.gameSaved=Game saved
+toast.gameSaveFailed=Could not save game - try again or choose a different location

--- a/src/main/resources/i18n/messages_no.properties
+++ b/src/main/resources/i18n/messages_no.properties
@@ -483,7 +483,7 @@ tooltip.stocks.watchlist=Legg til eller fjern aksjen fra overvåkningslisten.
 
 #loans
 tooltip.loans.weeksLeft=Antall uker igjen av lånets løpetid. Når dette når null, må hovedstolen tilbakebetales.
-tooltip.loans.remaining=Gjenstående hovedstol på lånet ? beløpet du skylder ekskludert fremtidig rente.
+tooltip.loans.remaining=Gjenstående hovedstol på lånet - beløpet du skylder ekskludert fremtidig rente.
 tooltip.loans.ledger.amount=Beløpet for denne transaksjonen i NOK. Utbetaling er positiv, rente og nedbetaling er negative.
 # New game modal
 nav.newGame=Nytt spill
@@ -492,3 +492,6 @@ newGame.confirmContent=Det nåværende spillet vil avsluttes.
 newGame.saveAndStartNew=Lagre og start nytt
 newGame.sellAllAndStartNew=Selg alt og start nytt
 newGame.startNewWithoutSaving=Start nytt uten å lagre
+# Toast-meldinger
+toast.gameSaved=Spillet er lagret
+toast.gameSaveFailed=Kunne ikke lagre spillet - prøv igjen eller velg en annen plassering


### PR DESCRIPTION
 Two related bug fixes discovered while testing the load-and-play 
flow on a long-running game.
 
## Old notifications popping up on load
 
When loading a saved game with existing notifications in history, 
every observer firing (advancing a week, marking notifications as 
read, clearing them) caused all the historical notifications to 
appear as popups again. The player saw a flood of repeated 
notifications they had already seen.
 
Root cause: `NotificationPopupOverlay.lastShownId` was initialised 
to 0 at construction. When a game with existing notifications 
loaded, the first observer firing saw every notification as 
"id > 0" and pushed them all to the popup stack.
 
Fix: at the moment the overlay is constructed, set `lastShownId` 
to the player's current maximum notification id. The popup overlay 
treats everything in history as "already seen" - only notifications 
pushed AFTER load trigger popups. The notification panel still 
shows the full history as before.
 
The bell badge had a related issue: it didn't show the unread 
count immediately on load because `onGameUpdated` hadn't fired yet 
in the observer registration cycle. Fix: header calls 
`onGameUpdated()` once at the end of its constructor to sync the 
badge with existing state. Same initialisation-gap pattern as the 
popup overlay.
 
## Save flow silently swallowing errors
 
When trying to save a loaded game via "Lagre og avslutt", the 
first click appeared to do nothing, the second click opened an 
unexpected file picker, and the app never exited after saving.
 
Root cause: missing i18n keys (`toast.gameSaved`, 
`toast.gameSaveFailed`) caused `LanguageManager.get()` to throw 
`MissingResourceException` after the save itself had already 
succeeded on disk. The catch-block in `saveToFile()` interpreted 
this as a save failure: it cleared the current save path 
(fail-soft logic), returned false, and the dialog kept itself open 
without calling `onContinue.run()` (which would have closed the 
app).
 
The file was actually being written to disk correctly - the player 
just had no way to know, and the app refused to exit.
 
Fix: added the missing toast keys to both Norwegian and English 
bundles.
 
Two lessons worth noting for the report:
 
- **Catch-blocks that cover too much scope hide the root cause.** 
  We caught `RuntimeException` around both the save and the toast 
  feedback, so a missing-i18n-key crash looked like a save 
  failure.
- **Error reporting itself must be robust.** If the feedback for 
  a failure can itself fail, the user gets nothing.
