### PR TITLE
Fix/game over to start

### DIFF
--- a/leaderboard.json
+++ b/leaderboard.json
@@ -3,12 +3,12 @@
     "sessionId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
     "playerName": "Alva",
     "startingCapital": 10000.00,
-    "finalNetWorth": 12508.9508,
-    "returnPercent": 25.1,
-    "weeksPlayed": 39,
+    "finalNetWorth": 12584.3503,
+    "returnPercent": 25.8,
+    "weeksPlayed": 48,
     "status": "NOVICE",
     "outcome": "ACTIVE",
-    "lastUpdated": "2026-05-16T02:18:34.673578700Z"
+    "lastUpdated": "2026-05-16T04:26:16.681206900Z"
   },
   {
     "sessionId": "80651cf1-aef5-4e63-b1b9-96c109f64730",
@@ -42,5 +42,16 @@
     "status": "NOVICE",
     "outcome": "ACTIVE",
     "lastUpdated": "2026-05-15T22:46:59.604251Z"
+  },
+  {
+    "sessionId": "deadbeef-0000-4000-a000-000000000001",
+    "playerName": "TestNearGameOver",
+    "startingCapital": 10000.00,
+    "finalNetWorth": -79971.7110,
+    "returnPercent": -899.7,
+    "weeksPlayed": 28,
+    "status": "NOVICE",
+    "outcome": "BANKRUPTCY",
+    "lastUpdated": "2026-05-16T04:33:47.739156800Z"
   }
 ]

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/GameOverController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/GameOverController.java
@@ -7,6 +7,7 @@ import edu.ntnu.idatt2003.millions.view.dialog.GameOverModal;
 import javafx.stage.Stage;
 
 import java.math.BigDecimal;
+import java.util.function.BooleanSupplier;
 
 /**
  * Controller for the game-over flow. Collects the end-of-game context
@@ -18,11 +19,18 @@ public class GameOverController {
     private final GameService gameService;
     private final Stage ownerStage;
     private final Runnable onNewGame;
+    private final BooleanSupplier saveAction;
+    private final Runnable sellAllAction;
+    private final Runnable noSaveAction;
 
-    public GameOverController(GameService gameService, Stage ownerStage, Runnable onNewGame) {
+    public GameOverController(GameService gameService, Stage ownerStage, Runnable onNewGame,
+                              BooleanSupplier saveAction, Runnable sellAllAction, Runnable noSaveAction) {
         this.gameService = gameService;
         this.ownerStage = ownerStage;
         this.onNewGame = onNewGame;
+        this.saveAction = saveAction;
+        this.sellAllAction = sellAllAction;
+        this.noSaveAction = noSaveAction;
     }
 
     /**
@@ -38,6 +46,7 @@ public class GameOverController {
         BigDecimal totalObligations = player.getTotalObligationsThisWeek(failedWeek);
         BigDecimal totalLiquidationValue = player.getTotalLiquidationValue(converter);
 
-        new GameOverModal(failedWeek, totalObligations, totalLiquidationValue, ownerStage, onNewGame).show();
+        new GameOverModal(failedWeek, totalObligations, totalLiquidationValue, ownerStage,
+                onNewGame, saveAction, sellAllAction, noSaveAction).show();
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/MainController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/MainController.java
@@ -41,7 +41,10 @@ public class MainController {
         this.toastService = toastService;
         this.forcedSaleController = new ForcedSaleController(gameService);
         this.gameOverController = new GameOverController(gameService, stage,
-                () -> new StartController(stage, gameService).show());
+                () -> new StartController(stage, gameService).show(),
+                this::handleSaveGame,
+                gameService::sellAllAndExit,
+                gameService::recordLeaderboardEntry);
         TradeController tradeController = new TradeController(gameService);
         LoanController loanController = new LoanController(gameService);
         TitleBar titleBar = TitleBarFactory.create(stage, gameService);

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/game/GameFileHandler.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/game/GameFileHandler.java
@@ -16,10 +16,11 @@ public interface GameFileHandler {
      *
      * @param player   the player whose state should be saved
      * @param exchange the exchange whose state should be saved
+     * @param gameOver whether the game has ended (bankruptcy)
      * @param file     the file to save the game state to
      * @throws NullPointerException if player, exchange or file is null
      */
-    void saveGame(Player player, Exchange exchange, File file);
+    void saveGame(Player player, Exchange exchange, boolean gameOver, File file);
 
     /**
      * Loads a saved game state from a file.

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/game/GameState.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/game/GameState.java
@@ -11,6 +11,7 @@ import edu.ntnu.idatt2003.millions.model.player.Player;
  *
  * @param player   the player state loaded from file
  * @param exchange the exchange state loaded from file
+ * @param gameOver whether the game had ended (bankruptcy) when it was saved
  */
-public record GameState(Player player, Exchange exchange) {
+public record GameState(Player player, Exchange exchange, boolean gameOver) {
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/game/JsonGameFileHandler.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/game/JsonGameFileHandler.java
@@ -57,7 +57,7 @@ public class JsonGameFileHandler implements GameFileHandler {
      * @throws UncheckedIOException if the file cannot be written to
      */
     @Override
-    public void saveGame(Player player, Exchange exchange, File file) {
+    public void saveGame(Player player, Exchange exchange, boolean gameOver, File file) {
         Objects.requireNonNull(player, "Player cannot be null");
         Objects.requireNonNull(exchange, "Exchange cannot be null");
         Objects.requireNonNull(file, "File cannot be null");
@@ -65,6 +65,7 @@ public class JsonGameFileHandler implements GameFileHandler {
         JsonObject gameState = new JsonObject();
         gameState.add("player", gson.toJsonTree(player));
         gameState.add("exchange", gson.toJsonTree(exchange));
+        gameState.addProperty("gameOver", gameOver);
 
         try (FileWriter writer = new FileWriter(file)) {
             gson.toJson(gameState, writer);
@@ -124,7 +125,8 @@ public class JsonGameFileHandler implements GameFileHandler {
             mergeSharesBySymbol(player);
             relinkArchive(player, exchange);
 
-            return new GameState(player, exchange);
+            boolean gameOver = gameState.has("gameOver") && gameState.get("gameOver").getAsBoolean();
+            return new GameState(player, exchange, gameOver);
 
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to load game from file: " + file.getName(), e);

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/GameService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/GameService.java
@@ -116,7 +116,7 @@ public class GameService {
                     player, exchange, exchange.getCurrencyConverter(), Outcome.BANKRUPTCY);
             if (currentSaveFile != null) {
                 try {
-                    gameFileHandler.saveGame(player, exchange, currentSaveFile);
+                    gameFileHandler.saveGame(player, exchange, gameOver, currentSaveFile);
                 } catch (Exception e) {
                     System.err.println("Could not write save file on bankruptcy: " + e.getMessage());
                 }
@@ -138,7 +138,7 @@ public class GameService {
         if (player == null || exchange == null) {
             throw new IllegalStateException("No active game to save");
         }
-        gameFileHandler.saveGame(player, exchange, file);
+        gameFileHandler.saveGame(player, exchange, gameOver, file);
         this.currentSaveFile = file;
         try {
             leaderboardService.recordOrUpdate(player, exchange, exchange.getCurrencyConverter(), Outcome.ACTIVE);
@@ -284,7 +284,7 @@ public class GameService {
         this.player = state.player();
         this.exchange = state.exchange();
         this.exchange.reinitialize(new FixedRateCurrencyConverter());
-        this.gameOver = false;
+        this.gameOver = state.gameOver();
         this.currentSaveFile = file;
         notifyObservers();
     }
@@ -498,7 +498,7 @@ public class GameService {
                 player, exchange, exchange.getCurrencyConverter(), Outcome.RETIRED);
         if (currentSaveFile != null) {
             try {
-                gameFileHandler.saveGame(player, exchange, currentSaveFile);
+                gameFileHandler.saveGame(player, exchange, gameOver, currentSaveFile);
             } catch (Exception e) {
                 System.err.println("Could not write save file on retire: " + e.getMessage());
             }

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/GameService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/GameService.java
@@ -141,7 +141,8 @@ public class GameService {
         gameFileHandler.saveGame(player, exchange, gameOver, file);
         this.currentSaveFile = file;
         try {
-            leaderboardService.recordOrUpdate(player, exchange, exchange.getCurrencyConverter(), Outcome.ACTIVE);
+            leaderboardService.recordOrUpdate(player, exchange, exchange.getCurrencyConverter(),
+                    gameOver ? Outcome.BANKRUPTCY : Outcome.ACTIVE);
         } catch (RuntimeException e) {
             System.err.println("Could not update leaderboard after save: " + e.getMessage());
         }
@@ -512,7 +513,8 @@ public class GameService {
      */
     public void recordLeaderboardEntry() {
         if (player != null && exchange != null) {
-            leaderboardService.recordOrUpdate(player, exchange, exchange.getCurrencyConverter(), Outcome.ACTIVE);
+            leaderboardService.recordOrUpdate(player, exchange, exchange.getCurrencyConverter(),
+                    gameOver ? Outcome.BANKRUPTCY : Outcome.ACTIVE);
         }
     }
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/GameService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/GameService.java
@@ -493,10 +493,11 @@ public class GameService {
      */
     public void sellAllAndExit() {
         for (Share share : new ArrayList<>(player.getPortfolio().getShares())) {
-            sell(share);
+            exchange.sell(share, player);
         }
         leaderboardService.recordOrUpdate(
-                player, exchange, exchange.getCurrencyConverter(), Outcome.RETIRED);
+                player, exchange, exchange.getCurrencyConverter(),
+                gameOver ? Outcome.BANKRUPTCY : Outcome.RETIRED);
         if (currentSaveFile != null) {
             try {
                 gameFileHandler.saveGame(player, exchange, gameOver, currentSaveFile);

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dialog/GameOverModal.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dialog/GameOverModal.java
@@ -18,6 +18,7 @@ import javafx.stage.Stage;
 
 import java.math.BigDecimal;
 import java.text.MessageFormat;
+import java.util.function.BooleanSupplier;
 
 /**
  * Modal shown when the player cannot cover their obligations even through
@@ -31,17 +32,26 @@ public class GameOverModal extends Modal {
     private final BigDecimal totalLiquidationValue;
     private final Stage ownerStage;
     private final Runnable onNewGame;
+    private final BooleanSupplier saveAction;
+    private final Runnable sellAllAction;
+    private final Runnable noSaveAction;
 
     public GameOverModal(int currentWeek,
                          BigDecimal totalObligations,
                          BigDecimal totalLiquidationValue,
                          Stage ownerStage,
-                         Runnable onNewGame) {
+                         Runnable onNewGame,
+                         BooleanSupplier saveAction,
+                         Runnable sellAllAction,
+                         Runnable noSaveAction) {
         this.currentWeek = currentWeek;
         this.totalObligations = totalObligations;
         this.totalLiquidationValue = totalLiquidationValue;
         this.ownerStage = ownerStage;
         this.onNewGame = onNewGame;
+        this.saveAction = saveAction;
+        this.sellAllAction = sellAllAction;
+        this.noSaveAction = noSaveAction;
     }
 
     /** ESC is blocked — the player must use one of the two buttons. */
@@ -112,7 +122,18 @@ public class GameOverModal extends Modal {
         newGameBtn.getStyleClass().addAll("modal-button", "modal-button-primary");
         newGameBtn.setOnAction(e -> {
             stage.close();
-            onNewGame.run();
+            new EndGameDialog(
+                    "nav.newGame",
+                    "gameOver.dialogHeader",
+                    "gameOver.dialogContent",
+                    "newGame.saveAndStartNew",
+                    "newGame.sellAllAndStartNew",
+                    "newGame.startNewWithoutSaving",
+                    saveAction,
+                    sellAllAction,
+                    noSaveAction,
+                    onNewGame
+            ).show();
         });
 
         HBox buttons = ModalActions.row(reviewBtn, newGameBtn);

--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -506,3 +506,5 @@ newGame.startNewWithoutSaving=Start new without saving
 # Toast messages
 toast.gameSaved=Game saved
 toast.gameSaveFailed=Could not save game - try again or choose a different location
+toast.scoreUpdated=Score updated
+toast.scoreUpdateFailed=Could not update score — try again

--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -414,6 +414,8 @@ gameOver.reason=You're bankrupt. Your debts have outgrown everything you own.
 gameOver.context=Week {0} - you owe {1}, but only have {2} in cash and shares combined.
 gameOver.review=Review game
 gameOver.newGame=Start new game
+gameOver.dialogHeader=Game over - start a new game?
+gameOver.dialogContent=You can save your progress or sell remaining shares before starting over.
 # Dashboard - Watchlist
 watchlist.title=Watchlist
 watchlist.status=Showing {0} of {1} stocks

--- a/src/main/resources/i18n/messages_no.properties
+++ b/src/main/resources/i18n/messages_no.properties
@@ -404,6 +404,8 @@ gameOver.reason=Du er konkurs. Gjelden er større enn alt du eier.
 gameOver.context=Uke {0} - du skylder {1}, men har bare {2} i kontanter og aksjer til sammen.
 gameOver.review=Se over spillet
 gameOver.newGame=Start nytt spill
+gameOver.dialogHeader=Spillet er over - start et nytt spill?
+gameOver.dialogContent=Du kan lagre fremdriften eller selge gjenværende aksjer før du starter på nytt.
 # Dashboard - Watchlist
 watchlist.title=Overvåkningsliste
 watchlist.status=Viser {0} av {1} aksjer

--- a/src/main/resources/i18n/messages_no.properties
+++ b/src/main/resources/i18n/messages_no.properties
@@ -497,3 +497,5 @@ newGame.startNewWithoutSaving=Start nytt uten å lagre
 # Toast-meldinger
 toast.gameSaved=Spillet er lagret
 toast.gameSaveFailed=Kunne ikke lagre spillet - prøv igjen eller velg en annen plassering
+toast.scoreUpdated=Poengsum oppdatert
+toast.scoreUpdateFailed=Kunne ikke oppdatere poengsummen - prøv igjen

--- a/src/test/java/edu/ntnu/idatt2003/millions/service/GameServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/service/GameServiceTest.java
@@ -742,6 +742,20 @@ class GameServiceTest {
             gameService.sellAllAndExit();
             assertTrue(observer.updateCount > before);
         }
+
+        @Test
+        @DisplayName("works after declareGameOver — records BANKRUPTCY, not RETIRED")
+        void sellAllAndExitAfterGameOver_recordsBankruptcy() {
+            gameService.buy("EQNR", new BigDecimal("3"));
+            gameService.declareGameOver();
+            assertTrue(gameService.isGameOver());
+
+            assertDoesNotThrow(() -> gameService.sellAllAndExit());
+
+            assertTrue(gameService.getPlayer().getPortfolio().getShares().isEmpty());
+            assertEquals(1, lbService.getAllEntries().size());
+            assertEquals(Outcome.BANKRUPTCY, lbService.getAllEntries().get(0).outcome());
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Summary

- **Game over → new game now prompts to save**: clicking "Start new game" on the GameOverModal opens the EndGameDialog (same as the normal new-game/exit flows) so the player can save or sell before leaving
- **Game-over state persists across save/load**: the `gameOver` flag is written to and read from the save file, so loading a bankrupt save correctly disables all trading and week-advance buttons
- **Leaderboard records correct outcome**: `saveGame()` and `recordLeaderboardEntry()` were hardcoded to `Outcome.ACTIVE`; they now use `gameOver ? BANKRUPTCY : ACTIVE`
- **"Sell all" works from a bankrupt game**: `sellAllAndExit()` called `GameService.sell()` which guards against `gameOver` and threw `IllegalStateException`; now calls `exchange.sell()` directly (same path as forced sale). Also records `BANKRUPTCY` instead of `RETIRED` when the game was already over
