### PR TITLE
feat: centralise number formatting in a locale-aware MoneyFormatter

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/millions/util/ChangeFormatter.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/util/ChangeFormatter.java
@@ -24,9 +24,6 @@ public class ChangeFormatter {
     private static final DecimalFormat PERCENT_FORMAT =
             new DecimalFormat("+#,##0.0;-#,##0.0", SYMBOLS);
 
-    private static final DecimalFormat AMOUNT_FORMAT =
-            new DecimalFormat("#,##0.00", SYMBOLS);
-
     private ChangeFormatter() {
         // Utility class – should not be instantiated
     }
@@ -78,7 +75,7 @@ public class ChangeFormatter {
      * @throws NullPointerException if value is null
      */
     public static Label styledAmount(BigDecimal value, String... cssClasses) {
-        String formatted = (value.signum() >= 0 ? "+" : "") + AMOUNT_FORMAT.format(value);
+        String formatted = (value.signum() >= 0 ? "+" : "") + MoneyFormatter.format(value);
         Label label = new Label(formatted);
         label.getStyleClass().addAll(List.of(cssClasses));
         ColourChange.applyChangeStyle(label, value);
@@ -95,6 +92,6 @@ public class ChangeFormatter {
      * @throws NullPointerException if value is null
      */
     public static String formatPlain(BigDecimal value) {
-        return AMOUNT_FORMAT.format(value);
+        return MoneyFormatter.format(value);
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/util/CurrencyFormatter.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/util/CurrencyFormatter.java
@@ -1,9 +1,7 @@
 package edu.ntnu.idatt2003.millions.util;
 
 import java.math.BigDecimal;
-import java.text.NumberFormat;
 import java.util.Currency;
-import java.util.Locale;
 import java.util.Objects;
 
 /**
@@ -14,15 +12,6 @@ import java.util.Objects;
  * Language-based display currency is tracked separately.</p>
  */
 public class CurrencyFormatter {
-
-    private static final Currency NOK_CURRENCY = Currency.getInstance("NOK");
-    private static final NumberFormat FORMAT;
-
-    static {
-        FORMAT = NumberFormat.getNumberInstance(Locale.of("no"));
-        FORMAT.setMinimumFractionDigits(2);
-        FORMAT.setMaximumFractionDigits(2);
-    }
 
     private CurrencyFormatter() {
         // Utility class - should not be instantiated
@@ -37,7 +26,7 @@ public class CurrencyFormatter {
      */
     public static String format(BigDecimal amount) {
         Objects.requireNonNull(amount, "Amount cannot be null");
-        return FORMAT.format(amount) + " NOK";
+        return MoneyFormatter.format(amount) + " NOK";
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/util/MoneyFormatter.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/util/MoneyFormatter.java
@@ -1,0 +1,51 @@
+package edu.ntnu.idatt2003.millions.util;
+
+import java.math.BigDecimal;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Formats monetary amounts as plain number strings using the convention of
+ * the currently active UI language (grouping and decimal separators follow the
+ * locale; always two decimals; no currency suffix).
+ *
+ * <p>Single source of truth for amount formatting. Callers append any currency
+ * code or symbol themselves.</p>
+ *
+ * <p>The active locale is read from {@link LanguageManager} on each call, so a
+ * language switch is reflected the next time a value is formatted (after the
+ * observer-driven UI refresh).</p>
+ *
+ * <p>One {@link DecimalFormat} is cached per locale. {@code DecimalFormat} is not
+ * thread-safe; consistent with existing usage — all formatting runs on the
+ * JavaFX Application Thread.</p>
+ */
+public final class MoneyFormatter {
+
+    private static final Map<Locale, DecimalFormat> CACHE = new ConcurrentHashMap<>();
+
+    private MoneyFormatter() {
+        // Utility class — no instances
+    }
+
+    /**
+     * Formats the amount using the active UI language convention.
+     *
+     * <p>Examples: {@code 5000.5} → {@code "5 000,50"} (Norwegian) or
+     * {@code "5,000.50"} (English). No currency suffix is added.</p>
+     *
+     * @param amount the amount to format, must not be null
+     * @return the formatted number string
+     */
+    public static String format(BigDecimal amount) {
+        Locale locale = LanguageManager.getCurrentLanguage().locale;
+        return CACHE.computeIfAbsent(locale, MoneyFormatter::buildFormat).format(amount);
+    }
+
+    private static DecimalFormat buildFormat(Locale locale) {
+        return new DecimalFormat("#,##0.00", new DecimalFormatSymbols(locale));
+    }
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/util/TableCells.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/util/TableCells.java
@@ -7,10 +7,6 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.GridPane;
 
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
-import java.util.Locale;
-
 /**
  * Stateless helper that builds the table primitives shared by every
  * dashboard table card.
@@ -43,18 +39,6 @@ import java.util.Locale;
  * class.</p>
  */
 public final class TableCells {
-
-    /**
-     * Number format shared by every table in the dashboard.
-     * Norwegian locale gives comma decimal separator and space thousands
-     * separator (e.g. {@code 1 234,56}).
-     */
-    public static final DecimalFormat NUMBER_FORMAT;
-
-    static {
-        DecimalFormatSymbols symbols = new DecimalFormatSymbols(Locale.forLanguageTag("nb-NO"));
-        NUMBER_FORMAT = new DecimalFormat("#,##0.00", symbols);
-    }
 
     private TableCells() {
         // Utility class — should not be instantiated.

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/card/ActiveLoansCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/card/ActiveLoansCard.java
@@ -5,6 +5,7 @@ import edu.ntnu.idatt2003.millions.model.loan.Loan;
 import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.util.CurrencyFormatter;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
+import edu.ntnu.idatt2003.millions.util.MoneyFormatter;
 import edu.ntnu.idatt2003.millions.util.TableCells;
 import edu.ntnu.idatt2003.millions.view.component.StyledText;
 import edu.ntnu.idatt2003.millions.view.component.card.Card;
@@ -142,11 +143,11 @@ public class ActiveLoansCard extends Card {
 
         table.addRow(row,
                 TableCells.data(loanLabel),
-                TableCells.data(TableCells.NUMBER_FORMAT.format(weeklyRate) + " %"),
+                TableCells.data(MoneyFormatter.format(weeklyRate) + " %"),
                 TableCells.data(weeksLeftText),
-                TableCells.data(TableCells.NUMBER_FORMAT.format(loan.weeklyInterest())
+                TableCells.data(MoneyFormatter.format(loan.weeklyInterest())
                         + " " + CurrencyFormatter.symbol("NOK")),
-                TableCells.data(TableCells.NUMBER_FORMAT.format(loan.principal())
+                TableCells.data(MoneyFormatter.format(loan.principal())
                         + " " + CurrencyFormatter.symbol("NOK")),
                 buildActionCell(loan, typeIndex)
         );
@@ -174,13 +175,13 @@ public class ActiveLoansCard extends Card {
                 .map(Loan::weeklyInterest)
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
         Label weeklyCostLabel = new Label(
-                TableCells.NUMBER_FORMAT.format(totalWeeklyCost)
+                MoneyFormatter.format(totalWeeklyCost)
                         + " " + CurrencyFormatter.symbol("NOK"));
         weeklyCostLabel.getStyleClass().addAll("holdings-cell", "bold");
         totalGrid.add(weeklyCostLabel, TOTAL_COL_WEEKLY_COST, 1);
 
         Label remainingLabel = new Label(
-                TableCells.NUMBER_FORMAT.format(gameService.getPlayer().getTotalDebt())
+                MoneyFormatter.format(gameService.getPlayer().getTotalDebt())
                         + " " + CurrencyFormatter.symbol("NOK"));
         remainingLabel.getStyleClass().addAll("holdings-cell", "bold");
         totalGrid.add(remainingLabel, TOTAL_COL_REMAINING, 1);

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/card/AvailableLoansCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/card/AvailableLoansCard.java
@@ -6,7 +6,7 @@ import edu.ntnu.idatt2003.millions.model.loan.LoanRiskLevel;
 import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.util.CurrencyFormatter;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
-import edu.ntnu.idatt2003.millions.util.TableCells;
+import edu.ntnu.idatt2003.millions.util.MoneyFormatter;
 import edu.ntnu.idatt2003.millions.view.component.card.Card;
 import edu.ntnu.idatt2003.millions.view.component.StyledText;
 import javafx.event.EventHandler;
@@ -137,7 +137,7 @@ public class AvailableLoansCard extends Card {
         VBox keyValues = new VBox(6);
         keyValues.getChildren().addAll(
                 buildKeyValueRow("loans.offer.rate",
-                        TableCells.NUMBER_FORMAT.format(
+                        MoneyFormatter.format(
                                 offer.weeklyInterestRate().multiply(BigDecimal.valueOf(100))) + "%"),
                 buildKeyValueRow("loans.offer.term",
                         MessageFormat.format(LanguageManager.get("loans.offer.weeks"), offer.termWeeks())),

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/card/AverageInterestRateCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/card/AverageInterestRateCard.java
@@ -2,7 +2,7 @@ package edu.ntnu.idatt2003.millions.view.dashboard.loans.card;
 
 import edu.ntnu.idatt2003.millions.model.loan.Loan;
 import edu.ntnu.idatt2003.millions.service.GameService;
-import edu.ntnu.idatt2003.millions.util.TableCells;
+import edu.ntnu.idatt2003.millions.util.MoneyFormatter;
 import edu.ntnu.idatt2003.millions.view.component.InfoTooltip;
 import edu.ntnu.idatt2003.millions.view.component.StyledText;
 import edu.ntnu.idatt2003.millions.view.component.card.WidgetCard;
@@ -52,6 +52,6 @@ public class AverageInterestRateCard extends WidgetCard {
                 .divide(totalPrincipal, 4, RoundingMode.HALF_UP)
                 .multiply(BigDecimal.valueOf(100))
                 .setScale(2, RoundingMode.HALF_UP);
-        valueLabel.setText(TableCells.NUMBER_FORMAT.format(avgWeeklyRate) + " %");
+        valueLabel.setText(MoneyFormatter.format(avgWeeklyRate) + " %");
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/dialog/LoanApplicationDialog.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/dialog/LoanApplicationDialog.java
@@ -18,11 +18,10 @@ import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 
+import edu.ntnu.idatt2003.millions.util.MoneyFormatter;
+
 import java.math.BigDecimal;
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
 import java.text.MessageFormat;
-import java.util.Locale;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -46,13 +45,6 @@ import java.util.function.Function;
  * The dialog never touches {@code GameService} directly.</p>
  */
 public class LoanApplicationDialog extends Modal {
-
-    private static final DecimalFormat NUMBER_FORMAT;
-
-    static {
-        DecimalFormatSymbols symbols = new DecimalFormatSymbols(Locale.forLanguageTag("nb-NO"));
-        NUMBER_FORMAT = new DecimalFormat("#,##0.00", symbols);
-    }
 
     private final LoanOffer offer;
     private final Function<BigDecimal, Optional<String>> validateCallback;
@@ -126,12 +118,12 @@ public class LoanApplicationDialog extends Modal {
         SummaryBox info = new SummaryBox();
         info.setSectionTitle(LanguageManager.get("loans.offer." + offer.id() + ".name"));
         info.addRow(LanguageManager.get("loans.offer.rate"),
-                NUMBER_FORMAT.format(
+                MoneyFormatter.format(
                         offer.weeklyInterestRate().multiply(BigDecimal.valueOf(100))) + "%");
         info.addRow(LanguageManager.get("loans.offer.term"),
                 MessageFormat.format(LanguageManager.get("loans.offer.weeks"), offer.termWeeks()));
         info.addRow(LanguageManager.get("loans.offer.maxAmount"),
-                NUMBER_FORMAT.format(offer.maxPrincipal()) + " NOK");
+                MoneyFormatter.format(offer.maxPrincipal()) + " NOK");
         return info;
     }
 
@@ -140,8 +132,8 @@ public class LoanApplicationDialog extends Modal {
         StyledText labelRight = StyledText.detailLabel(
                 MessageFormat.format(
                         LanguageManager.get("loans.dialog.amount.range"),
-                        NUMBER_FORMAT.format(BigDecimal.ZERO),
-                        NUMBER_FORMAT.format(offer.maxPrincipal())));
+                        MoneyFormatter.format(BigDecimal.ZERO),
+                        MoneyFormatter.format(offer.maxPrincipal())));
         Region spacer = new Region();
         HBox.setHgrow(spacer, Priority.ALWAYS);
         HBox labelRow = new HBox(labelLeft, spacer, labelRight);
@@ -265,21 +257,21 @@ public class LoanApplicationDialog extends Modal {
     private void renderSummary(LoanPreview preview) {
         summaryBox.addRow(
                 LanguageManager.get("loans.dialog.summary.disbursed"),
-                NUMBER_FORMAT.format(preview.principal()) + " NOK");
+                MoneyFormatter.format(preview.principal()) + " NOK");
         summaryBox.addRow(
                 LanguageManager.get("loans.dialog.summary.weeklyInterest"),
-                NUMBER_FORMAT.format(preview.weeklyInterestAmount()) + " NOK");
+                MoneyFormatter.format(preview.weeklyInterestAmount()) + " NOK");
         summaryBox.addRow(
                 MessageFormat.format(
                         LanguageManager.get("loans.dialog.summary.totalInterest"), offer.termWeeks()),
-                NUMBER_FORMAT.format(preview.totalInterest()) + " NOK");
+                MoneyFormatter.format(preview.totalInterest()) + " NOK");
         summaryBox.addTotal(
                 LanguageManager.get("loans.dialog.summary.totalRepayment"),
-                NUMBER_FORMAT.format(preview.totalRepayment()) + " NOK");
+                MoneyFormatter.format(preview.totalRepayment()) + " NOK");
     }
 
     private void renderEmptySummary() {
-        String zero = NUMBER_FORMAT.format(BigDecimal.ZERO) + " NOK";
+        String zero = MoneyFormatter.format(BigDecimal.ZERO) + " NOK";
         summaryBox.addRow(LanguageManager.get("loans.dialog.summary.disbursed"), zero);
         summaryBox.addRow(LanguageManager.get("loans.dialog.summary.weeklyInterest"), zero);
         summaryBox.addRow(

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/dialog/LoanDetailsModal.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/dialog/LoanDetailsModal.java
@@ -4,7 +4,7 @@ import edu.ntnu.idatt2003.millions.controller.LoanController;
 import edu.ntnu.idatt2003.millions.model.loan.Loan;
 import edu.ntnu.idatt2003.millions.util.CurrencyFormatter;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
-import edu.ntnu.idatt2003.millions.util.TableCells;
+import edu.ntnu.idatt2003.millions.util.MoneyFormatter;
 import edu.ntnu.idatt2003.millions.view.component.Modal;
 import edu.ntnu.idatt2003.millions.view.component.ModalActions;
 import edu.ntnu.idatt2003.millions.view.component.SummaryBox;
@@ -89,9 +89,9 @@ public class LoanDetailsModal extends Modal {
         box.addRow(LanguageManager.get("loans.details.terms.principal"),
                 CurrencyFormatter.format(loan.principal()));
         box.addRow(LanguageManager.get("loans.details.terms.rate"),
-                TableCells.NUMBER_FORMAT.format(weeklyRate) + " %");
+                MoneyFormatter.format(weeklyRate) + " %");
         box.addRow(LanguageManager.get("loans.details.terms.annualRate"),
-                TableCells.NUMBER_FORMAT.format(annualRate) + " %");
+                MoneyFormatter.format(annualRate) + " %");
         box.addRow(LanguageManager.get("loans.details.terms.term"), termValue);
         box.addRow(LanguageManager.get("loans.details.terms.takenInWeek"),
                 String.valueOf(loan.takenAtWeek()));

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/dialog/LoanRepaymentReceipt.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/dialog/LoanRepaymentReceipt.java
@@ -14,22 +14,14 @@ import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 import org.kordamp.ikonli.javafx.FontIcon;
 
+import edu.ntnu.idatt2003.millions.util.MoneyFormatter;
+
 import java.math.BigDecimal;
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
-import java.util.Locale;
 
 /**
  * Receipt shown after a successful loan repayment.
  */
 public class LoanRepaymentReceipt extends Modal {
-
-    private static final DecimalFormat NUMBER_FORMAT;
-
-    static {
-        DecimalFormatSymbols symbols = new DecimalFormatSymbols(Locale.forLanguageTag("nb-NO"));
-        NUMBER_FORMAT = new DecimalFormat("#,##0.00", symbols);
-    }
 
     private final Loan loan;
     private final int loanIndex;
@@ -106,24 +98,24 @@ public class LoanRepaymentReceipt extends Modal {
         SummaryBox summary = new SummaryBox();
         summary.addRow(
                 LanguageManager.get("receipt.loan.repay.summary.amountPaid"),
-                NUMBER_FORMAT.format(loan.principal()) + " NOK");
+                MoneyFormatter.format(loan.principal()) + " NOK");
         summary.addRow(
                 LanguageManager.get("receipt.loan.repay.summary.interestSaved"),
-                NUMBER_FORMAT.format(loan.interestSaved(currentWeek)) + " NOK",
+                MoneyFormatter.format(loan.interestSaved(currentWeek)) + " NOK",
                 "positive");
         return summary;
     }
 
     private VBox buildBalanceSection() {
         StyledText beforeLabel = StyledText.detailLabel(LanguageManager.get("receipt.balance.before"));
-        StyledText beforeValue = StyledText.detailValue(NUMBER_FORMAT.format(balanceBefore) + " NOK");
+        StyledText beforeValue = StyledText.detailValue(MoneyFormatter.format(balanceBefore) + " NOK");
         Region spacer1 = new Region();
         HBox.setHgrow(spacer1, Priority.ALWAYS);
         HBox beforeRow = new HBox(beforeLabel, spacer1, beforeValue);
         beforeRow.getStyleClass().add("modal-balance-row");
 
         StyledText afterLabel = StyledText.detailLabel(LanguageManager.get("receipt.balance.after"));
-        StyledText afterValue = StyledText.detailValue(NUMBER_FORMAT.format(balanceAfter) + " NOK");
+        StyledText afterValue = StyledText.detailValue(MoneyFormatter.format(balanceAfter) + " NOK");
         Region spacer2 = new Region();
         HBox.setHgrow(spacer2, Priority.ALWAYS);
         HBox afterRow = new HBox(afterLabel, spacer2, afterValue);

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/dialog/RepayLoanDialog.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/dialog/RepayLoanDialog.java
@@ -14,12 +14,11 @@ import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 
+import edu.ntnu.idatt2003.millions.util.MoneyFormatter;
+
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
 import java.text.MessageFormat;
-import java.util.Locale;
 import java.util.Optional;
 import java.util.function.Consumer;
 
@@ -36,13 +35,6 @@ import java.util.function.Consumer;
  * The dialog never touches {@code GameService} directly.</p>
  */
 public class RepayLoanDialog extends Modal {
-
-    private static final DecimalFormat NUMBER_FORMAT;
-
-    static {
-        DecimalFormatSymbols symbols = new DecimalFormatSymbols(Locale.forLanguageTag("nb-NO"));
-        NUMBER_FORMAT = new DecimalFormat("#,##0.00", symbols);
-    }
 
     private final Loan loan;
     private final int loanIndex;
@@ -139,7 +131,7 @@ public class RepayLoanDialog extends Modal {
                 weeksLeftText);
         VBox col3 = buildInfoColumn(
                 LanguageManager.get("loans.repay.info.weeklyInterest"),
-                NUMBER_FORMAT.format(weeklyRate) + "%");
+                MoneyFormatter.format(weeklyRate) + "%");
 
         HBox strip = new HBox(col1, col2, col3);
         strip.getStyleClass().add("modal-summary");
@@ -158,16 +150,16 @@ public class RepayLoanDialog extends Modal {
         SummaryBox summary = new SummaryBox();
         summary.addRow(
                 LanguageManager.get("loans.repay.summary.remaining"),
-                NUMBER_FORMAT.format(loan.principal()) + " NOK");
+                MoneyFormatter.format(loan.principal()) + " NOK");
         summary.addRow(
                 LanguageManager.get("loans.repay.summary.interestPaid"),
-                NUMBER_FORMAT.format(loan.interestPaid(currentWeek)) + " NOK");
+                MoneyFormatter.format(loan.interestPaid(currentWeek)) + " NOK");
         summary.addRow(
                 LanguageManager.get("loans.repay.summary.interestSaved"),
-                NUMBER_FORMAT.format(loan.interestSaved(currentWeek)) + " NOK", "positive");
+                MoneyFormatter.format(loan.interestSaved(currentWeek)) + " NOK", "positive");
         summary.addTotal(
                 LanguageManager.get("loans.repay.summary.toPay"),
-                NUMBER_FORMAT.format(loan.principal()) + " NOK");
+                MoneyFormatter.format(loan.principal()) + " NOK");
         return summary;
     }
 
@@ -175,10 +167,10 @@ public class RepayLoanDialog extends Modal {
         SummaryBox balance = new SummaryBox();
         balance.addRow(
                 LanguageManager.get("loans.repay.balance.available"),
-                NUMBER_FORMAT.format(availableCash) + " NOK");
+                MoneyFormatter.format(availableCash) + " NOK");
         balance.addTotal(
                 LanguageManager.get("loans.repay.balance.after"),
-                NUMBER_FORMAT.format(availableCash.subtract(loan.principal())) + " NOK");
+                MoneyFormatter.format(availableCash.subtract(loan.principal())) + " NOK");
         return balance;
     }
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/HoldingsCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/HoldingsCard.java
@@ -9,6 +9,7 @@ import edu.ntnu.idatt2003.millions.service.PortfolioService;
 import edu.ntnu.idatt2003.millions.util.ChangeFormatter;
 import edu.ntnu.idatt2003.millions.util.CurrencyFormatter;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
+import edu.ntnu.idatt2003.millions.util.MoneyFormatter;
 import edu.ntnu.idatt2003.millions.util.TableCells;
 import edu.ntnu.idatt2003.millions.view.component.Pagination;
 import edu.ntnu.idatt2003.millions.view.component.StyledText;
@@ -192,7 +193,7 @@ public class HoldingsCard extends SortableTableCard<Share, HoldingsSort.SortColu
         totalLabel.getStyleClass().addAll("holdings-cell", "bold");
         totalGrid.add(totalLabel, TOTAL_COL_COMPANY, 1);
 
-        Label valueNok = new Label(TableCells.NUMBER_FORMAT.format(
+        Label valueNok = new Label(MoneyFormatter.format(
                 portfolioService.getValue(gameService.getPlayer(), gameService.getCurrencyConverter()))
                 + " " + CurrencyFormatter.symbol("NOK"));
         valueNok.getStyleClass().addAll("holdings-cell", "bold");
@@ -225,9 +226,9 @@ public class HoldingsCard extends SortableTableCard<Share, HoldingsSort.SortColu
         table.addRow(row,
                 buildActionButtons(share),
                 TableCells.data(stock.getSymbol() + ", " + stock.getCompany()),
-                TableCells.data(TableCells.NUMBER_FORMAT.format(share.getQuantity())),
+                TableCells.data(MoneyFormatter.format(share.getQuantity())),
                 coloredPercentCell(stock.getWeeklyChangePercent()),
-                TableCells.data(TableCells.NUMBER_FORMAT.format(
+                TableCells.data(MoneyFormatter.format(
                         portfolioService.getShareValueInNok(share, gameService.getCurrencyConverter()))
                         + " " + CurrencyFormatter.symbol("NOK")),
                 coloredPercentCell(share.getReturnPercent()),

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/dialog/AbstractSellDialog.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/dialog/AbstractSellDialog.java
@@ -4,6 +4,7 @@ import edu.ntnu.idatt2003.millions.controller.TradeController;
 import edu.ntnu.idatt2003.millions.model.stock.Share;
 import edu.ntnu.idatt2003.millions.model.transaction.TransactionPreview;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
+import edu.ntnu.idatt2003.millions.util.MoneyFormatter;
 
 import java.math.BigDecimal;
 import java.text.MessageFormat;
@@ -44,7 +45,7 @@ public abstract class AbstractSellDialog extends TransactionDialog {
     @Override
     protected String getStockHint() {
         return MessageFormat.format(LanguageManager.get("dialog.stock.salesPriceHint"),
-                NUMBER_FORMAT.format(stock.getSalesPrice()),
+                MoneyFormatter.format(stock.getSalesPrice()),
                 stock.getCurrency().getCurrencyCode());
     }
 
@@ -74,15 +75,15 @@ public abstract class AbstractSellDialog extends TransactionDialog {
         TransactionPreview preview = controller.previewSell(share, quantity);
 
         summaryBox.addRow(LanguageManager.get("dialog.summary.gross"),
-                NUMBER_FORMAT.format(preview.gross()) + " " + currencyCode());
+                MoneyFormatter.format(preview.gross()) + " " + currencyCode());
         summaryBox.addRow(LanguageManager.get("dialog.summary.commissionSell"),
-                "\u2212" + NUMBER_FORMAT.format(preview.commission()) + " " + currencyCode());
+                "\u2212" + MoneyFormatter.format(preview.commission()) + " " + currencyCode());
         summaryBox.addRow(LanguageManager.get("dialog.summary.tax"),
-                "\u2212" + NUMBER_FORMAT.format(preview.tax()) + " " + currencyCode());
+                "\u2212" + MoneyFormatter.format(preview.tax()) + " " + currencyCode());
         summaryBox.addTotal(LanguageManager.get("dialog.summary.totalReceived"),
-                NUMBER_FORMAT.format(preview.total()) + " " + currencyCode());
+                MoneyFormatter.format(preview.total()) + " " + currencyCode());
         if (!stock.getCurrency().equals(NOK)) {
-            summaryBox.addConversion("= " + NUMBER_FORMAT.format(preview.totalInNok()) + " NOK");
+            summaryBox.addConversion("= " + MoneyFormatter.format(preview.totalInNok()) + " NOK");
         }
 
         renderProfitLoss(preview);
@@ -97,19 +98,19 @@ public abstract class AbstractSellDialog extends TransactionDialog {
         String pctSign = positive ? "+" : "";
 
         String label = LanguageManager.get(positive ? "dialog.profit.gain" : "dialog.profit.loss");
-        String primaryValue = sign + NUMBER_FORMAT.format(preview.profit().abs()) + " " + currencyCode()
+        String primaryValue = sign + MoneyFormatter.format(preview.profit().abs()) + " " + currencyCode()
                 + " (" + pctSign + preview.profitPercent().toPlainString() + "%)";
 
         String secondaryValue = null;
         if (!stock.getCurrency().equals(NOK) && preview.profitInNok() != null) {
-            secondaryValue = "= " + sign + NUMBER_FORMAT.format(preview.profitInNok().abs()) + " NOK";
+            secondaryValue = "= " + sign + MoneyFormatter.format(preview.profitInNok().abs()) + " NOK";
         }
         setTransactionInfo(label, primaryValue, secondaryValue, positive);
     }
 
     private void renderBalanceAfter(TransactionPreview preview) {
         balanceAfterValue.setText(
-                NUMBER_FORMAT.format(preview.balanceAfter()) + " NOK");
+                MoneyFormatter.format(preview.balanceAfter()) + " NOK");
         balanceAfterValue.getStyleClass().removeAll("positive", "negative");
     }
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/dialog/BuyDialog.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/dialog/BuyDialog.java
@@ -4,6 +4,7 @@ import edu.ntnu.idatt2003.millions.controller.TradeController;
 import edu.ntnu.idatt2003.millions.model.stock.Stock;
 import edu.ntnu.idatt2003.millions.model.transaction.TransactionPreview;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
+import edu.ntnu.idatt2003.millions.util.MoneyFormatter;
 
 import java.math.BigDecimal;
 import java.text.MessageFormat;
@@ -32,7 +33,7 @@ public class BuyDialog extends TransactionDialog {
     @Override
     protected String getStockHint() {
         return MessageFormat.format(LanguageManager.get("dialog.stock.priceHint"),
-                NUMBER_FORMAT.format(stock.getSalesPrice()),
+                MoneyFormatter.format(stock.getSalesPrice()),
                 stock.getCurrency().getCurrencyCode());
     }
 
@@ -74,17 +75,17 @@ public class BuyDialog extends TransactionDialog {
         }
 
         summaryBox.addRow(LanguageManager.get("dialog.summary.gross"),
-                NUMBER_FORMAT.format(preview.gross()) + " " + currencyCode());
+                MoneyFormatter.format(preview.gross()) + " " + currencyCode());
         summaryBox.addRow(LanguageManager.get("dialog.summary.commissionBuy"),
-                NUMBER_FORMAT.format(preview.commission()) + " " + currencyCode());
+                MoneyFormatter.format(preview.commission()) + " " + currencyCode());
         summaryBox.addTotal(LanguageManager.get("dialog.summary.totalCost"),
-                NUMBER_FORMAT.format(preview.total()) + " " + currencyCode());
+                MoneyFormatter.format(preview.total()) + " " + currencyCode());
         if (!stock.getCurrency().equals(NOK)) {
-            summaryBox.addConversion("= " + NUMBER_FORMAT.format(preview.totalInNok()) + " NOK");
+            summaryBox.addConversion("= " + MoneyFormatter.format(preview.totalInNok()) + " NOK");
         }
 
         balanceAfterValue.setText(
-                NUMBER_FORMAT.format(preview.balanceAfter()) + " NOK");
+                MoneyFormatter.format(preview.balanceAfter()) + " NOK");
 
         if (preview.balanceAfter().signum() < 0) {
             balanceAfterValue.getStyleClass().removeAll("positive", "negative");
@@ -98,16 +99,16 @@ public class BuyDialog extends TransactionDialog {
     }
 
     private void renderEmptySummary() {
-        String zero = NUMBER_FORMAT.format(BigDecimal.ZERO) + " " + currencyCode();
+        String zero = MoneyFormatter.format(BigDecimal.ZERO) + " " + currencyCode();
         summaryBox.addRow(LanguageManager.get("dialog.summary.gross"), zero);
         summaryBox.addRow(LanguageManager.get("dialog.summary.commissionBuy"), zero);
         summaryBox.addTotal(LanguageManager.get("dialog.summary.totalCost"), zero);
         if (!stock.getCurrency().equals(NOK)) {
-            summaryBox.addConversion("= " + NUMBER_FORMAT.format(BigDecimal.ZERO) + " NOK");
+            summaryBox.addConversion("= " + MoneyFormatter.format(BigDecimal.ZERO) + " NOK");
         }
         balanceAfterValue.getStyleClass().removeAll("positive", "negative");
         balanceAfterValue.setText(
-                NUMBER_FORMAT.format(controller.getCurrentBalance()) + " NOK");
+                MoneyFormatter.format(controller.getCurrentBalance()) + " NOK");
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/dialog/BuyReceipt.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/dialog/BuyReceipt.java
@@ -3,6 +3,7 @@ package edu.ntnu.idatt2003.millions.view.dashboard.portfolio.dialog;
 import edu.ntnu.idatt2003.millions.model.transaction.Transaction;
 import edu.ntnu.idatt2003.millions.model.transaction.TransactionPreview;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
+import edu.ntnu.idatt2003.millions.util.MoneyFormatter;
 
 import java.math.BigDecimal;
 import java.util.Currency;
@@ -43,13 +44,13 @@ public class BuyReceipt extends TransactionReceipt {
     @Override
     protected void renderSummary() {
         summaryBox.addRow(LanguageManager.get("receipt.summary.gross"),
-                NUMBER_FORMAT.format(preview.gross()) + " " + currencyCode());
+                MoneyFormatter.format(preview.gross()) + " " + currencyCode());
         summaryBox.addRow(LanguageManager.get("receipt.summary.commissionBuy"),
-                NUMBER_FORMAT.format(preview.commission()) + " " + currencyCode());
+                MoneyFormatter.format(preview.commission()) + " " + currencyCode());
         summaryBox.addTotal(LanguageManager.get("receipt.summary.totalCost"),
-                NUMBER_FORMAT.format(preview.total()) + " " + currencyCode());
+                MoneyFormatter.format(preview.total()) + " " + currencyCode());
         if (!transaction.getShare().getStock().getCurrency().equals(NOK)) {
-            summaryBox.addConversion("= " + NUMBER_FORMAT.format(preview.totalInNok()) + " NOK");
+            summaryBox.addConversion("= " + MoneyFormatter.format(preview.totalInNok()) + " NOK");
         }
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/dialog/SellAllDialog.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/dialog/SellAllDialog.java
@@ -3,6 +3,7 @@ package edu.ntnu.idatt2003.millions.view.dashboard.portfolio.dialog;
 import edu.ntnu.idatt2003.millions.controller.TradeController;
 import edu.ntnu.idatt2003.millions.model.stock.Share;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
+import edu.ntnu.idatt2003.millions.util.MoneyFormatter;
 import edu.ntnu.idatt2003.millions.view.component.StyledText;
 import javafx.scene.control.Label;
 import javafx.scene.layout.VBox;
@@ -33,7 +34,7 @@ public class SellAllDialog extends AbstractSellDialog {
 
         Label quantity = new Label(MessageFormat.format(
                 LanguageManager.get("dialog.quantity.allShares"),
-                NUMBER_FORMAT.format(share.getQuantity())));
+                MoneyFormatter.format(share.getQuantity())));
         quantity.getStyleClass().add("modal-section-value");
 
         return new VBox(4, label, quantity);

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/dialog/SellDialog.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/dialog/SellDialog.java
@@ -4,6 +4,7 @@ import edu.ntnu.idatt2003.millions.controller.TradeController;
 import edu.ntnu.idatt2003.millions.model.stock.Share;
 import edu.ntnu.idatt2003.millions.model.transaction.TransactionPreview;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
+import edu.ntnu.idatt2003.millions.util.MoneyFormatter;
 import edu.ntnu.idatt2003.millions.view.component.StyledText;
 import javafx.scene.control.Button;
 import javafx.scene.layout.HBox;
@@ -39,7 +40,7 @@ public class SellDialog extends AbstractSellDialog {
 
         StyledText owned = StyledText.detailLabel(MessageFormat.format(
                 LanguageManager.get("dialog.quantity.owned"),
-                NUMBER_FORMAT.format(share.getQuantity())));
+                MoneyFormatter.format(share.getQuantity())));
 
         Region spacer = new Region();
         HBox.setHgrow(spacer, Priority.ALWAYS);
@@ -80,7 +81,7 @@ public class SellDialog extends AbstractSellDialog {
             setTransactionInfo(null, null, null, false);
             showError(MessageFormat.format(
                     LanguageManager.get("dialog.quantity.notEnoughShares"),
-                    NUMBER_FORMAT.format(share.getQuantity())));
+                    MoneyFormatter.format(share.getQuantity())));
             return;
         }
 
@@ -98,16 +99,16 @@ public class SellDialog extends AbstractSellDialog {
     }
 
     private void renderEmptySummary() {
-        String zero = NUMBER_FORMAT.format(BigDecimal.ZERO) + " " + currencyCode();
+        String zero = MoneyFormatter.format(BigDecimal.ZERO) + " " + currencyCode();
         summaryBox.addRow(LanguageManager.get("dialog.summary.gross"), zero);
         summaryBox.addRow(LanguageManager.get("dialog.summary.commissionSell"), zero);
         summaryBox.addRow(LanguageManager.get("dialog.summary.tax"), zero);
         summaryBox.addTotal(LanguageManager.get("dialog.summary.totalReceived"), zero);
         if (!stock.getCurrency().equals(NOK)) {
-            summaryBox.addConversion("= " + NUMBER_FORMAT.format(BigDecimal.ZERO) + " NOK");
+            summaryBox.addConversion("= " + MoneyFormatter.format(BigDecimal.ZERO) + " NOK");
         }
         balanceAfterValue.getStyleClass().removeAll("positive", "negative");
         balanceAfterValue.setText(
-                NUMBER_FORMAT.format(controller.getCurrentBalance()) + " NOK");
+                MoneyFormatter.format(controller.getCurrentBalance()) + " NOK");
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/dialog/SellReceipt.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/dialog/SellReceipt.java
@@ -3,6 +3,7 @@ package edu.ntnu.idatt2003.millions.view.dashboard.portfolio.dialog;
 import edu.ntnu.idatt2003.millions.model.transaction.Transaction;
 import edu.ntnu.idatt2003.millions.model.transaction.TransactionPreview;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
+import edu.ntnu.idatt2003.millions.util.MoneyFormatter;
 import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
@@ -48,15 +49,15 @@ public class SellReceipt extends TransactionReceipt {
     @Override
     protected void renderSummary() {
         summaryBox.addRow(LanguageManager.get("receipt.summary.gross"),
-                NUMBER_FORMAT.format(preview.gross()) + " " + currencyCode());
+                MoneyFormatter.format(preview.gross()) + " " + currencyCode());
         summaryBox.addRow(LanguageManager.get("receipt.summary.commissionSell"),
-                "−" + NUMBER_FORMAT.format(preview.commission()) + " " + currencyCode());
+                "−" + MoneyFormatter.format(preview.commission()) + " " + currencyCode());
         summaryBox.addRow(LanguageManager.get("receipt.summary.tax"),
-                "−" + NUMBER_FORMAT.format(preview.tax()) + " " + currencyCode());
+                "−" + MoneyFormatter.format(preview.tax()) + " " + currencyCode());
         summaryBox.addTotal(LanguageManager.get("receipt.summary.totalReceived"),
-                NUMBER_FORMAT.format(preview.total()) + " " + currencyCode());
+                MoneyFormatter.format(preview.total()) + " " + currencyCode());
         if (!transaction.getShare().getStock().getCurrency().equals(NOK)) {
-            summaryBox.addConversion("= " + NUMBER_FORMAT.format(preview.totalInNok()) + " NOK");
+            summaryBox.addConversion("= " + MoneyFormatter.format(preview.totalInNok()) + " NOK");
         }
     }
 
@@ -74,7 +75,7 @@ public class SellReceipt extends TransactionReceipt {
         Label labelNode = new Label(LanguageManager.get(
                 positive ? "receipt.profit.gain" : "receipt.profit.loss"));
         Label primaryNode = new Label(
-                sign + NUMBER_FORMAT.format(profit.abs()) + " " + currencyCode()
+                sign + MoneyFormatter.format(profit.abs()) + " " + currencyCode()
                 + " (" + pctSign + profitPercent.toPlainString() + "%)");
         primaryNode.getStyleClass().add(valueClass);
 
@@ -87,7 +88,7 @@ public class SellReceipt extends TransactionReceipt {
         if (!transaction.getShare().getStock().getCurrency().equals(NOK)
                 && preview.profitInNok() != null) {
             Label secondaryNode = new Label(
-                    "= " + sign + NUMBER_FORMAT.format(preview.profitInNok().abs()) + " NOK");
+                    "= " + sign + MoneyFormatter.format(preview.profitInNok().abs()) + " NOK");
             secondaryNode.getStyleClass().addAll("modal-summary-conversion-text", valueClass);
             Region spacer2 = new Region();
             HBox.setHgrow(spacer2, Priority.ALWAYS);

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/dialog/ShareDetailsModal.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/dialog/ShareDetailsModal.java
@@ -14,12 +14,11 @@ import javafx.scene.control.Button;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 
+import edu.ntnu.idatt2003.millions.util.MoneyFormatter;
+
 import java.math.BigDecimal;
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
 import java.text.MessageFormat;
 import java.util.Currency;
-import java.util.Locale;
 
 /**
  * Read-only details modal for a single share position. Shows the position
@@ -28,13 +27,7 @@ import java.util.Locale;
  */
 public class ShareDetailsModal extends Modal {
 
-    private static final DecimalFormat NUMBER_FORMAT;
     private static final Currency NOK = Currency.getInstance("NOK");
-
-    static {
-        DecimalFormatSymbols symbols = new DecimalFormatSymbols(Locale.forLanguageTag("nb-NO"));
-        NUMBER_FORMAT = new DecimalFormat("#,##0.00", symbols);
-    }
 
     private final Share share;
     private final TradeController controller;
@@ -63,7 +56,7 @@ public class ShareDetailsModal extends Modal {
         String hint = MessageFormat.format(
                 LanguageManager.get("details.stock.hint"),
                 currencyCode,
-                NUMBER_FORMAT.format(stock.getSalesPrice()));
+                MoneyFormatter.format(stock.getSalesPrice()));
 
         boolean gameOver = controller.isGameOver();
 
@@ -108,14 +101,14 @@ public class ShareDetailsModal extends Modal {
         box.setSectionTitle(LanguageManager.get("details.section.position"));
         box.addRow(
                 LanguageManager.get("details.row.quantity"),
-                NUMBER_FORMAT.format(share.getQuantity()));
+                MoneyFormatter.format(share.getQuantity()));
         box.addRow(
                 LanguageManager.get("details.row.avgPrice"),
-                NUMBER_FORMAT.format(share.getPurchasePrice()) + " " + currencyCode,
+                MoneyFormatter.format(share.getPurchasePrice()) + " " + currencyCode,
                 null, "tooltip.details.gav");
         box.addRow(
                 LanguageManager.get("details.row.cost"),
-                NUMBER_FORMAT.format(share.getCost()) + " " + currencyCode);
+                MoneyFormatter.format(share.getCost()) + " " + currencyCode);
         return box;
     }
 
@@ -125,22 +118,22 @@ public class ShareDetailsModal extends Modal {
         if (isForeign) {
             box.addRow(
                     LanguageManager.get("details.row.marketValue"),
-                    NUMBER_FORMAT.format(share.getCurrentValue()) + " " + currencyCode,
+                    MoneyFormatter.format(share.getCurrentValue()) + " " + currencyCode,
                     null, "tooltip.details.marketValue");
             box.addRow(
                     LanguageManager.get("details.row.marketValueNok"),
-                    NUMBER_FORMAT.format(portfolioService.getShareValueInNok(
+                    MoneyFormatter.format(portfolioService.getShareValueInNok(
                             share, controller.getCurrencyConverter())) + " NOK",
                     null, "tooltip.details.marketValueNok");
         } else {
             box.addRow(
                     LanguageManager.get("details.row.marketValue"),
-                    NUMBER_FORMAT.format(share.getCurrentValue()) + " NOK",
+                    MoneyFormatter.format(share.getCurrentValue()) + " NOK",
                     null, "tooltip.details.marketValue");
         }
         box.addRow(
                 LanguageManager.get("details.row.liquidationValue"),
-                NUMBER_FORMAT.format(portfolioService.getLiquidationValueInNok(
+                MoneyFormatter.format(portfolioService.getLiquidationValueInNok(
                         share, controller.getCurrencyConverter())) + " NOK",
                 null, "tooltip.details.liquidation");
         return box;
@@ -153,7 +146,7 @@ public class ShareDetailsModal extends Modal {
         BigDecimal returnNative = share.getReturnNative();
         boolean positiveNative = returnNative.signum() >= 0;
         String signNative = positiveNative ? "+" : "−";
-        String returnNativeStr = signNative + NUMBER_FORMAT.format(returnNative.abs());
+        String returnNativeStr = signNative + MoneyFormatter.format(returnNative.abs());
 
         if (isForeign) {
             String returnNativeLabel = MessageFormat.format(
@@ -170,7 +163,7 @@ public class ShareDetailsModal extends Modal {
             String signNok = positiveNok ? "+" : "−";
             box.addRow(
                     LanguageManager.get("details.row.returnNok"),
-                    signNok + NUMBER_FORMAT.format(returnNok.abs()) + " NOK",
+                    signNok + MoneyFormatter.format(returnNok.abs()) + " NOK",
                     positiveNok ? "positive" : "negative",
                     "tooltip.shared.returnNok");
         } else {

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/dialog/TransactionDialog.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/dialog/TransactionDialog.java
@@ -16,10 +16,9 @@ import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 
+import edu.ntnu.idatt2003.millions.util.MoneyFormatter;
+
 import java.math.BigDecimal;
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
-import java.util.Locale;
 
 /**
  * Abstract base class for transaction dialogs (buy, sell, sell all).
@@ -28,13 +27,6 @@ import java.util.Locale;
  * rows, and confirmation logic.
  */
 public abstract class TransactionDialog extends Modal {
-
-    protected static final DecimalFormat NUMBER_FORMAT;
-
-    static {
-        DecimalFormatSymbols symbols = new DecimalFormatSymbols(Locale.forLanguageTag("nb-NO"));
-        NUMBER_FORMAT = new DecimalFormat("#,##0.00", symbols);
-    }
 
     protected final TradeController controller;
     protected final Stock stock;
@@ -152,7 +144,7 @@ public abstract class TransactionDialog extends Modal {
     private VBox buildBalanceSection() {
         StyledText availableLabel = StyledText.detailLabel(LanguageManager.get("dialog.balance.available"));
         StyledText availableValue = StyledText.detailValue(
-                NUMBER_FORMAT.format(controller.getCurrentBalance()) + " NOK");
+                MoneyFormatter.format(controller.getCurrentBalance()) + " NOK");
         Region spacer1 = new Region();
         HBox.setHgrow(spacer1, Priority.ALWAYS);
         HBox availableRow = new HBox(availableLabel, spacer1, availableValue);

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/dialog/TransactionReceipt.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/dialog/TransactionReceipt.java
@@ -14,10 +14,9 @@ import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 
+import edu.ntnu.idatt2003.millions.util.MoneyFormatter;
+
 import java.math.BigDecimal;
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
-import java.util.Locale;
 
 /**
  * Abstract base class for transaction receipts (buy, sell).
@@ -29,13 +28,6 @@ import java.util.Locale;
  * transaction type, and any extra content (e.g. profit or loss for sales).</p>
  */
 public abstract class TransactionReceipt extends Modal {
-
-    protected static final DecimalFormat NUMBER_FORMAT;
-
-    static {
-        DecimalFormatSymbols symbols = new DecimalFormatSymbols(Locale.forLanguageTag("nb-NO"));
-        NUMBER_FORMAT = new DecimalFormat("#,##0.00", symbols);
-    }
 
     protected final Transaction transaction;
     protected final BigDecimal balanceBefore;
@@ -130,9 +122,9 @@ public abstract class TransactionReceipt extends Modal {
         row.getStyleClass().add("modal-meta-row");
         row.getChildren().addAll(
                 buildMetaCell(LanguageManager.get("receipt.meta.quantity"),
-                        NUMBER_FORMAT.format(transaction.getShare().getQuantity())),
+                        MoneyFormatter.format(transaction.getShare().getQuantity())),
                 buildMetaCell(getPriceLabel(),
-                        NUMBER_FORMAT.format(getPrice()) + " " + currencyCode()),
+                        MoneyFormatter.format(getPrice()) + " " + currencyCode()),
                 buildMetaCell(LanguageManager.get("receipt.meta.week"),
                         String.valueOf(transaction.getWeek()))
         );
@@ -148,14 +140,14 @@ public abstract class TransactionReceipt extends Modal {
 
     private VBox buildBalanceSection() {
         StyledText beforeLabel = StyledText.detailLabel(LanguageManager.get("receipt.balance.before"));
-        StyledText beforeValue = StyledText.detailValue(NUMBER_FORMAT.format(balanceBefore) + " NOK");
+        StyledText beforeValue = StyledText.detailValue(MoneyFormatter.format(balanceBefore) + " NOK");
         Region spacer1 = new Region();
         HBox.setHgrow(spacer1, Priority.ALWAYS);
         HBox beforeRow = new HBox(beforeLabel, spacer1, beforeValue);
         beforeRow.getStyleClass().add("modal-balance-row");
 
         StyledText afterLabel = StyledText.detailLabel(LanguageManager.get("receipt.balance.after"));
-        StyledText afterValue = StyledText.detailValue(NUMBER_FORMAT.format(balanceAfter) + " NOK");
+        StyledText afterValue = StyledText.detailValue(MoneyFormatter.format(balanceAfter) + " NOK");
         Region spacer2 = new Region();
         HBox.setHgrow(spacer2, Priority.ALWAYS);
         HBox afterRow = new HBox(afterLabel, spacer2, afterValue);

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/card/TransactionsCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/card/TransactionsCard.java
@@ -9,6 +9,7 @@ import edu.ntnu.idatt2003.millions.service.TransactionStatsService;
 import edu.ntnu.idatt2003.millions.util.ChangeFormatter;
 import edu.ntnu.idatt2003.millions.util.CurrencyFormatter;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
+import edu.ntnu.idatt2003.millions.util.MoneyFormatter;
 import edu.ntnu.idatt2003.millions.util.TableCells;
 import edu.ntnu.idatt2003.millions.view.component.Pagination;
 import edu.ntnu.idatt2003.millions.view.component.SearchBar;
@@ -218,10 +219,10 @@ public class TransactionsCard extends SortableTableCard<Transaction, Transaction
                         LanguageManager.get("transactions.weekValue"), transaction.getWeek())),
                 TableCells.data(stock.getSymbol() + ", " + stock.getCompany()),
                 typeBadge(transaction),
-                TableCells.data(TableCells.NUMBER_FORMAT.format(stats.quantity())),
-                TableCells.data(TableCells.NUMBER_FORMAT.format(stats.pricePerShare())
+                TableCells.data(MoneyFormatter.format(stats.quantity())),
+                TableCells.data(MoneyFormatter.format(stats.pricePerShare())
                         + " " + CurrencyFormatter.symbol(stats.nativeCurrencyCode())),
-                TableCells.data(TableCells.NUMBER_FORMAT.format(stats.commissionNok())
+                TableCells.data(MoneyFormatter.format(stats.commissionNok())
                         + " " + CurrencyFormatter.symbol("NOK")),
                 taxCell(stats),
                 amountCell(stats.amountNok())
@@ -266,7 +267,7 @@ public class TransactionsCard extends SortableTableCard<Transaction, Transaction
         if (stats.taxNok().signum() == 0) {
             return TableCells.data("–");
         }
-        return TableCells.data(TableCells.NUMBER_FORMAT.format(stats.taxNok())
+        return TableCells.data(MoneyFormatter.format(stats.taxNok())
                 + " " + CurrencyFormatter.symbol("NOK"));
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/card/TransactionsSummaryCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/card/TransactionsSummaryCard.java
@@ -5,6 +5,7 @@ import edu.ntnu.idatt2003.millions.service.TransactionStatsService;
 import edu.ntnu.idatt2003.millions.model.transaction.Transaction;
 import edu.ntnu.idatt2003.millions.model.transaction.TransactionArchive;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
+import edu.ntnu.idatt2003.millions.util.MoneyFormatter;
 import edu.ntnu.idatt2003.millions.util.TableCells;
 import edu.ntnu.idatt2003.millions.view.component.card.Card;
 import edu.ntnu.idatt2003.millions.view.component.StyledText;
@@ -149,13 +150,13 @@ public class TransactionsSummaryCard extends Card {
     /**
      * Signed NOK amount. Positives are rendered with an explicit
      * {@code +} so sale inflows read as "+1 234,56 NOK"; negatives
-     * keep the minus produced by {@link TableCells#NUMBER_FORMAT};
+     * keep the minus produced by {@link edu.ntnu.idatt2003.millions.util.MoneyFormatter};
      * zero is unsigned. No color modifiers — the summary keeps a
      * neutral palette and only weight distinguishes the total row.
      */
     private Label rowValue(BigDecimal amount, boolean bold) {
         String sign = amount.signum() > 0 ? "+" : "";
-        String text = sign + TableCells.NUMBER_FORMAT.format(amount) + " NOK";
+        String text = sign + MoneyFormatter.format(amount) + " NOK";
         Label label = TableCells.data(text);
         if (bold) {
             label.getStyleClass().add("bold");

--- a/src/test/java/edu/ntnu/idatt2003/millions/util/CurrencyFormatterTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/util/CurrencyFormatterTest.java
@@ -1,5 +1,7 @@
 package edu.ntnu.idatt2003.millions.util;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -18,6 +20,17 @@ import static org.junit.jupiter.api.Assertions.*;
  * </p>
  */
 class CurrencyFormatterTest {
+
+    @BeforeEach
+    void setNorwegian() {
+        // Pin to Norwegian so locale-sensitive assertions are deterministic.
+        LanguageManager.setLanguage(Language.NORWEGIAN);
+    }
+
+    @AfterEach
+    void resetToNorwegian() {
+        LanguageManager.setLanguage(Language.NORWEGIAN);
+    }
 
     @Nested
     @DisplayName("format()")

--- a/src/test/java/edu/ntnu/idatt2003/millions/util/MoneyFormatterTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/util/MoneyFormatterTest.java
@@ -1,0 +1,153 @@
+package edu.ntnu.idatt2003.millions.util;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("MoneyFormatter")
+class MoneyFormatterTest {
+
+    @AfterEach
+    void resetToNorwegian() {
+        LanguageManager.setLanguage(Language.NORWEGIAN);
+    }
+
+    @Nested
+    @DisplayName("Norwegian locale")
+    class NorwegianLocale {
+
+        @BeforeEach
+        void setNorwegian() {
+            LanguageManager.setLanguage(Language.NORWEGIAN);
+        }
+
+        @Test
+        @DisplayName("uses comma as decimal separator")
+        void commaAsDecimalSeparator() {
+            String result = MoneyFormatter.format(new BigDecimal("1234.56"));
+            assertTrue(result.contains(","), "Expected comma decimal separator, got: " + result);
+        }
+
+        @Test
+        @DisplayName("does not use comma as thousands separator")
+        void noCommaAsThousandsSeparator() {
+            String result = MoneyFormatter.format(new BigDecimal("1234.56"));
+            assertFalse(result.contains("1,234"), "Expected non-comma grouping, got: " + result);
+        }
+
+        @Test
+        @DisplayName("always formats with two decimal places")
+        void twoDecimalPlaces() {
+            String result = MoneyFormatter.format(new BigDecimal("5000.50"));
+            assertTrue(result.endsWith(",50"), "Expected two decimals with comma, got: " + result);
+        }
+
+        @Test
+        @DisplayName("formats zero with two decimal places")
+        void zeroHasTwoDecimals() {
+            String result = MoneyFormatter.format(BigDecimal.ZERO);
+            assertTrue(result.contains(",00"), "Expected 0,00, got: " + result);
+        }
+
+        @Test
+        @DisplayName("formats negative value with leading minus")
+        void negativeValue() {
+            String result = MoneyFormatter.format(new BigDecimal("-500.00"));
+            assertTrue(result.startsWith("-"), "Expected minus sign, got: " + result);
+        }
+
+        @Test
+        @DisplayName("formats large value with grouping")
+        void largeValueHasGrouping() {
+            String result = MoneyFormatter.format(new BigDecimal("1000000.00"));
+            assertNotNull(result);
+            assertFalse(result.isBlank());
+            assertFalse(result.contains("1000000"), "Expected grouping separators, got: " + result);
+        }
+
+        @Test
+        @DisplayName("rounds to two decimals")
+        void roundsToTwoDecimals() {
+            String result = MoneyFormatter.format(new BigDecimal("1.005"));
+            assertTrue(result.contains(","), "Expected comma decimal, got: " + result);
+        }
+    }
+
+    @Nested
+    @DisplayName("English locale")
+    class EnglishLocale {
+
+        @BeforeEach
+        void setEnglish() {
+            LanguageManager.setLanguage(Language.ENGLISH);
+        }
+
+        @Test
+        @DisplayName("uses dot as decimal separator")
+        void dotAsDecimalSeparator() {
+            String result = MoneyFormatter.format(new BigDecimal("1234.56"));
+            assertTrue(result.contains("."), "Expected dot decimal separator, got: " + result);
+        }
+
+        @Test
+        @DisplayName("uses comma as thousands separator")
+        void commaAsThousandsSeparator() {
+            String result = MoneyFormatter.format(new BigDecimal("1234.56"));
+            assertTrue(result.contains("1,234"), "Expected comma grouping, got: " + result);
+        }
+
+        @Test
+        @DisplayName("always formats with two decimal places")
+        void twoDecimalPlaces() {
+            String result = MoneyFormatter.format(new BigDecimal("5000.50"));
+            assertTrue(result.endsWith(".50"), "Expected two decimals with dot, got: " + result);
+        }
+
+        @Test
+        @DisplayName("formats zero with two decimal places")
+        void zeroHasTwoDecimals() {
+            String result = MoneyFormatter.format(BigDecimal.ZERO);
+            assertTrue(result.contains(".00"), "Expected 0.00, got: " + result);
+        }
+
+        @Test
+        @DisplayName("formats negative value with leading minus")
+        void negativeValue() {
+            String result = MoneyFormatter.format(new BigDecimal("-500.00"));
+            assertTrue(result.startsWith("-"), "Expected minus sign, got: " + result);
+        }
+
+        @Test
+        @DisplayName("formats large value with grouping")
+        void largeValueHasGrouping() {
+            String result = MoneyFormatter.format(new BigDecimal("1000000.00"));
+            assertTrue(result.contains("1,000,000"), "Expected comma grouping, got: " + result);
+        }
+    }
+
+    @Nested
+    @DisplayName("locale switch")
+    class LocaleSwitch {
+
+        @Test
+        @DisplayName("reflects language change on next call without restarting")
+        void reflectsLanguageChangeImmediately() {
+            LanguageManager.setLanguage(Language.NORWEGIAN);
+            String norwegian = MoneyFormatter.format(new BigDecimal("1234.56"));
+
+            LanguageManager.setLanguage(Language.ENGLISH);
+            String english = MoneyFormatter.format(new BigDecimal("1234.56"));
+
+            assertNotEquals(norwegian, english,
+                    "Norwegian and English formats should differ");
+            assertTrue(norwegian.contains(","), "Norwegian should have comma decimal");
+            assertTrue(english.contains("."), "English should have dot decimal");
+        }
+    }
+}


### PR DESCRIPTION
## Background
 
An audit of the codebase found the same monetary formatting logic
declared independently in multiple places: seven separate
`DecimalFormat("#,##0.00")` instances (one public field on
`TableCells`, six private/protected `NUMBER_FORMAT` fields across
loan and portfolio dialogs/receipts), plus a fourth variant in
`CurrencyFormatter` using `NumberFormat`, and a third literal copy
in `ChangeFormatter.AMOUNT_FORMAT`.
 
Every one of these produced the same output for the same input.
The duplication meant any change to monetary formatting - locale,
decimal precision, grouping - had to be applied in many places,
and in practice never had been: the formatting was hardcoded
Norwegian everywhere regardless of the selected UI language.
 
## What changed
 
A new `util/MoneyFormatter` is now the single source of truth for
amount formatting. It exposes one method, `format(BigDecimal)`,
and reads the active locale from `LanguageManager` on each call so
formatting follows the chosen UI language. One `DecimalFormat` is
cached per locale rather than rebuilt on every call.
 
All four former sources now route through it:
 
- The six private/protected `NUMBER_FORMAT` fields are deleted;
  their call sites call `MoneyFormatter.format(...)`. Suffix logic
  (`+ " NOK"`, `+ " " + currencyCode`, `+ "%"`) is unchanged - the
  formatter only handles the number, callers still own the suffix.
- `TableCells.NUMBER_FORMAT` is removed and its 8+ callers migrated.
- `ChangeFormatter.formatPlain` delegates to `MoneyFormatter`;
  the redundant `AMOUNT_FORMAT` field is gone. `PERCENT_FORMAT` is
  deliberately left alone - it is a genuinely different pattern
  (signed, one decimal) for deltas, not duplication.
- `CurrencyFormatter.format` now delegates the numeric part to
  `MoneyFormatter` and appends `" NOK"`, so NOK display is
  locale-aware too.
## Behaviour change (intentional)
 
This is not an output-neutral refactor. It is deliberate:
 
- Norwegian UI: output is byte-identical to before (`5 000,00`).
- English UI: amounts now format as `5,000.00` instead of the
  previously hardcoded `5 000,00`.
The `NOK` suffix is unchanged in all languages - it is an ISO
currency code, not a translatable string, so `5,000.00 NOK` in
English is expected and correct.
 
## Design rationale
 
The motivation is not "less code" but responsibility and coupling.
Before, "how a monetary amount is rendered" was a decision
re-made independently in every dialog, receipt and table cell.
That is low cohesion (each view class carried formatting policy
that is not its responsibility) and a latent consistency risk
(four implementations that happened to agree, with nothing
enforcing that they stay in agreement).
 
Concentrating the policy in one class gives it a single owner.
Call sites depend on an intention (`MoneyFormatter.format`) rather
than on an implementation detail. Notably, the previous "obvious"
shortcut - having loan dialogs reuse `TableCells.NUMBER_FORMAT` -
would have replaced duplication with an awkward dependency (a loan
dialog reaching into a table-cell utility for an unrelated
concern). A dedicated formatter avoids both the duplication and
the inappropriate coupling.
 
The consolidation also made a feature improvement cheap. Before,
locale-aware number formatting was effectively infeasible: it
would have meant changing 30+ scattered declarations and threading
the active locale to each. After, it was a change in one class.
This is a concrete illustration of why low coupling and a single
source of truth have practical value, not only theoretical
tidiness - the centralisation is what made the improvement
tractable.
 
## Tests
 
- New `MoneyFormatterTest`, parametrised by locale, asserts the
  Norwegian convention (space grouping, comma decimal) and the
  English convention (comma grouping, dot decimal), plus negative,
  zero, large-grouping and rounding cases.
- Existing tests that assert on formatted strings are now
  locale-sensitive and have been updated to set the language
  deterministically in their Arrange phase rather than relying on
  whatever the default happened to be. This is itself a useful
  observation: formatting assertions must control locale
  explicitly to be deterministic.
- Full suite passes. Manual verification across a loan dialog,
  transaction receipt, holdings cell, net-worth card and status
  footer confirms numbers reformat correctly when the language is
  switched and the observer-driven refresh fires.
## Files
 
- New: `util/MoneyFormatter.java`, `test/.../MoneyFormatterTest.java`
- Removed `DecimalFormat`/`NumberFormat` amount declarations from:
  `TableCells`, `RepayLoanDialog`, `LoanRepaymentReceipt`,
  `LoanApplicationDialog`, `ShareDetailsModal`, `TransactionReceipt`,
  `TransactionDialog`, `ChangeFormatter` (AMOUNT_FORMAT only),
  `CurrencyFormatter` (internal formatting)
- Call sites in all of the above plus the 8+ `TableCells.NUMBER_FORMAT`
  consumers updated to `MoneyFormatter.format(...)`
## Out of scope
 
- `ChangeFormatter.PERCENT_FORMAT` - a distinct signed/one-decimal
  pattern, not part of this consolidation.
- Currency-aware formatting (different decimal counts per currency,
  symbol placement). Callers still append currency suffixes
  themselves; introducing real currency-awareness would be a
  separate, deliberate change against its own requirements.