### PR TITLE
refactor: soc and convention cleanup

### DIFF
--- a/docs/test_conventions.md
+++ b/docs/test_conventions.md
@@ -1,0 +1,266 @@
+# Testing conventions for this project
+
+## Purpose
+
+These conventions exist so unit tests verify that code does what
+it is *supposed* to do (per the assignment specification and
+domain rules), not merely that it does what it currently does.
+A test derived from reading the implementation is circular: it
+will pass even when the implementation is wrong.
+
+The grading rubric weights this explicitly. A-level requires:
+descriptive test names, Arrange-Act-Assert, tests for the
+business-critical classes, **strong negative tests for all tested
+classes**, exception testing, lifecycle methods (@BeforeEach
+etc.) where appropriate, and for file reading: **test parsing,
+not file access**.
+
+## What to test (and what not to)
+
+**Test (business-critical):** the domain logic that, if wrong,
+breaks the game's core promises. Calculators (purchase/sale
+gross, commission, tax, total), Transaction commit rules
+(insufficient funds rejected, double-commit rejected, sale of
+unowned share rejected), Player money/portfolio/archive
+behaviour, Exchange buy/sell/advance, statistics
+(TransactionStatsService, net worth, status thresholds),
+file *parsing* (CSV format rules), and the read services.
+
+**Do not write dedicated tests for:** trivial getters/setters,
+records' generated accessors, or pure delegation with no logic.
+Getters are exercised *indirectly* by the behavioural tests that
+assert on the state they expose - that indirect coverage is
+sufficient. A test whose body is `assertEquals(x, obj.getX())`
+right after `new Obj(x)` tests the language, not the code.
+
+**Do not test the GUI/view layer with unit tests.** JavaFX view
+behaviour is out of scope for unit testing here.
+
+## Derive expected values from the SPEC, not the code
+
+This is the most important rule. When writing an assertion, the
+expected value must come from the assignment specification or
+domain rule, computed independently - never by running the method
+mentally and asserting it returns what it returns.
+
+Example - SaleCalculator tax (spec: "30% skatt på gevinst",
+gevinst = bruttoverdi - avgift - kjøpskostnader):
+
+- WRONG (circular): read calculateTax(), see the formula, assert
+  it returns that formula's output.
+- RIGHT (spec-derived): purchase price 100, sale price 200,
+  quantity 10. Gross = 2000. Commission (1%) = 20. Purchase cost
+  = 1000. Gain = 2000 - 20 - 1000 = 980. Expected tax = 30% of
+  980 = 294. Assert calculateTax() == 294. If the code computes
+  gain differently, this test fails - which is the point.
+  Hand-compute expected values in the test (or as a comment showing
+  the derivation) so a reviewer can see the value came from the
+  spec, not the implementation.
+
+## Negative and edge-case tests are mandatory, not optional
+
+For every tested class, include negative tests. The rubric
+explicitly rewards "svært gode negative tester for alle klassene
+som testes". For each behaviour ask:
+
+- What inputs are invalid? (null, negative quantity, zero, blank
+  symbol, empty list) - assert the documented exception is
+  thrown, with assertThrows, and check the exception type
+  specifically.
+- What are the boundaries? (exactly enough money vs one øre too
+  little; threshold met exactly vs just under; one price in
+  history vs none; first/last week)
+- What are the "this should be rejected" rules from the spec?
+  (buy with insufficient funds, sell unowned share, commit a
+  transaction twice) - each gets its own negative test.
+  A class with only happy-path tests does not meet the A bar no
+  matter how many it has.
+
+## Structure and naming - the project's established convention
+
+New test classes MUST match the convention already used across
+the existing suite. Do not invent a different style; consistency
+is itself graded ("gode beskrivende navn", uniform structure).
+The convention, derived from the existing tests, is:
+
+### Outer test class
+
+- Named `<ClassUnderTest>Test`, package-private (`class`, no
+  `public`), in the mirrored package under `src/test/java`.
+- Class-level JavaDoc that opens with a `{@link ClassUnderTest}`
+  reference, one or two sentences on what is covered, and the
+  sentence "All tests follow the AAA pattern." (Short utility/
+  record classes may use a one-line JavaDoc instead.)
+- Shared fixture built in a `@BeforeEach void setUp()` in the
+  outer class. Constants (currencies, valid sample values) as
+  `private static final` fields. Reusable construction helpers
+  as `private static` methods (e.g. `nokStock(...)`,
+  `makeShare(...)`); a BigDecimal equality helper
+  `assertBigDecimalEquals` where money/precision is compared.
+### @Nested grouping
+
+- Grouping is done with `@Nested`, always. One `@Nested` class
+  per public method under test, named in PascalCase after the
+  method (`CalculateGross`, `Buy`, `GetNetWorth`, `Constructor`),
+  annotated with `@DisplayName("methodName()")` - the display
+  name is the method signature with parentheses.
+- Cross-cutting behaviour that isn't tied to a single method gets
+  a concept-named `@Nested` instead (`GavConsolidation`,
+  `FrozenValues`, `LiquidationMethods`, `Loans`, `Watchlist`).
+  This applies to pure validation/record classes too: group their
+  constructor checks and behaviour in `@Nested` classes the same
+  way (as `LoanOfferTest` and `WatchlistEntryTest` do) - a record
+  having no "real" methods is not a reason to fall back to flat
+  tests.
+- A `@Nested` group may declare its OWN `@BeforeEach` (with a
+  distinct name like `setUpOffer()`, `setUpEntry()`) when that
+  group needs extra setup the rest of the class doesn't. Never
+  introduce state that makes tests order-dependent; every test
+  must pass in isolation and in any order.
+- Do NOT use `// ---- ... ----` comment banners to group flat
+  `@Test` methods. The banner is just a manual stand-in for
+  grouping; once `@Nested` is used the banner duplicates what the
+  group already expresses and becomes noise. A few early classes
+  (`LeaderboardEntryTest`, `JsonLeaderboardFileHandlerTest`) use
+  the banner-and-flat-test form - this is a known pre-existing
+  deviation, not a sanctioned alternative. Do not use it in new
+  code; do not mechanically rewrite those existing classes (same
+  reasoning as the naming deviation below - working tests are not
+  rearranged near the deadline; this is a stated, deliberate
+  choice in the report).
+### Two-layer test naming
+
+Every `@Test` carries BOTH:
+
+- `@DisplayName` in natural language, starting "Should " and
+  stating the expected outcome and condition
+  (`"Should return 30% of profit when sale is profitable"`,
+  `"Should throw exception when quantity is negative"`).
+- A camelCase method name, no underscores, that compresses the
+  same statement (`returnsThirtyPercentOfProfitWhenProfitable`,
+  `throwsExceptionWhenQuantityIsNegative`).
+  This is the single required form for all NEW test classes. It is
+  the dominant style in the existing suite - the form used by every
+  core domain test (calculators, Exchange, Player's main body,
+  Portfolio, Stock, Share, Purchase, Sale, TransactionArchive,
+  GameService) - and is the project standard.
+
+The underscore form `method_scenario`
+(`markAsRead_returnsNewInstanceWithReadFlag`) appears in a number
+of mostly smaller or later-added classes (the notification and
+toast services, `LanguageManagerTest`, `LoanTest`, the loan/save
+exception tests) and - importantly - inside two `@Nested` groups
+of `PlayerTest` itself (`Loans`, `NotificationStorage`), which
+otherwise follows the standard. A few formatter classes use a
+third, bare form with neither "Should" nor underscores
+(`ChangeFormatterTest`, `MoneyFormatterTest`). None of these is a
+sanctioned alternative - they are pre-existing deviations. Do NOT
+use any of them in new code. Existing classes that are
+internally consistent (all-standard or all-deviation) are left
+as-is: rewriting working tests near the deadline is risk for no
+functional gain, and this is a stated, deliberate choice in the
+report. The one case worth fixing is *within-class* mixing:
+`PlayerTest` breaks the "never mix" rule below by using both
+forms in one file. Renaming its underscore-named methods onto the
+standard form is a pure, low-risk change (no logic touched) and
+is the recommended cleanup, because internal inconsistency in the
+flagship model test is the most visible to a reviewer. Within any
+single class, only ever one form may appear - never mix.
+
+### AAA
+
+- Explicit `// Arrange`, `// Act`, `// Assert` comments in every
+  test. Collapse to `// Act & Assert` when the action is a
+  one-liner inside `assertThrows` / a single assertion. Keep the
+  phases visually separated.
+- One logical behaviour per test. Multiple asserts are fine when
+  they verify one behaviour (state after a buy: money decreased
+  AND share added AND archived); do not test unrelated
+  behaviours in one method.
+### BigDecimal assertions
+
+Never assert BigDecimal equality with raw `assertEquals(a, b)`
+when scale may differ - use `assertEquals(0, a.compareTo(b))` or
+the `assertBigDecimalEquals` helper. (Raw equals is only
+acceptable where the exact scale is itself the contract being
+tested, e.g. a scale-preservation test.)
+
+## Lifecycle annotations - only where they earn their place
+
+The rubric rewards "@BeforeAll, @BeforeEach osv - **der det er
+hensiktsmessig**" (where appropriate). The emphasis is on
+*appropriate*. Over-use is as wrong as under-use, and a reviewer
+who sees a `@BeforeEach` that half the tests ignore, or shared
+mutable state that makes tests order-dependent, reads it as a
+misunderstanding of what these annotations are for. Use them as
+follows:
+
+- **@BeforeEach** - the default and by far the most common here.
+  Use it to build the fresh fixture each test needs (a new
+  `Player`, `Portfolio`, `Exchange`, converter). It must produce
+  a clean, independent state every time. A `@Nested` group adds
+  its own `@BeforeEach` only when that group genuinely needs
+  extra setup the rest of the class doesn't (see `Loans`,
+  `Sell`, `Watchlist`). Do NOT put setup in `@BeforeEach` that
+  only some tests in scope use - construct that locally in the
+  tests that need it (the existing tests do exactly this: shared
+  state in setUp, scenario-specific objects built inside the
+  test).
+- **@BeforeAll** - only when there is genuinely expensive,
+  immutable, shared setup that it is safe to create once for the
+  whole class (e.g. a costly read-only resource). For this
+  project's model tests there is almost none: objects are cheap
+  and must be fresh per test, so @BeforeAll is usually the WRONG
+  choice - using it to share a mutable `Player`/`Exchange` across
+  tests would create order dependence and is explicitly not
+  wanted. Reach for it only with a concrete, stated reason; its
+  absence in a model test is correct, not a gap.
+- **@AfterEach / @AfterAll** - only when a test acquires
+  something that must be released (a stream, a temp resource).
+  Pure in-memory unit tests need no teardown; adding empty or
+  pointless teardown methods is noise. If a test needs
+  @AfterEach to undo shared state, that usually signals the
+  state should not have been shared in the first place - prefer
+  fixing the fixture over adding teardown.
+  The test to apply: would removing the annotation force visible
+  duplication or break isolation? If yes, it is appropriate. If it
+  changes nothing, or only exists "because the rubric lists it",
+  leave it out - the rubric rewards judgement, not mechanical
+  presence.
+
+## File reading: parsing only, never file access
+
+Per the rubric, file-reading tests must test the parsing logic,
+not disk I/O. Test the parser by feeding it an in-memory
+Reader/String/InputStream with:
+
+- valid rows
+- comment lines (#) and blank lines (must be skipped)
+- malformed rows (wrong field count, blank symbol, blank name,
+  non-numeric price, negative/zero price) - each its own negative
+  test asserting the documented exception
+- a source with zero valid rows (EmptyStockFileException)
+  Do NOT write tests that create temp files, read from the
+  filesystem, or depend on a file on disk. If the handler only
+  exposes a Path-based API, that's a design note for the report -
+  test whatever parse method takes a Reader/Stream; if none exists,
+  flag it rather than testing disk access.
+
+## Exceptions
+
+- Use assertThrows and assert the specific exception type, not a
+  broad superclass.
+- Where the project has custom exceptions, assert the custom
+  type is thrown (not a generic RuntimeException).
+- Where it makes sense, assert the exception message or a field
+  carries the expected information - but don't assert on exact
+  message strings that are i18n/locale-dependent.
+## What a good test class looks like here
+
+For a business-critical class: a @BeforeEach building the common
+fixture; happy-path tests with spec-derived expected values;
+boundary tests; one negative test per documented rejection rule
+using assertThrows with the specific exception; names matching
+the project's existing convention; AAA visible. No getter tests.
+No tests that just re-run the implementation and assert its own
+output.

--- a/leaderboard.json
+++ b/leaderboard.json
@@ -53,5 +53,16 @@
     "status": "NOVICE",
     "outcome": "BANKRUPTCY",
     "lastUpdated": "2026-05-16T04:33:47.739156800Z"
+  },
+  {
+    "sessionId": "d9cb640d-d833-4130-aaf7-572c9ae35139",
+    "playerName": "Test",
+    "startingCapital": 100000,
+    "finalNetWorth": 100350.2733,
+    "returnPercent": 0.4,
+    "weeksPlayed": 18,
+    "status": "NOVICE",
+    "outcome": "RETIRED",
+    "lastUpdated": "2026-05-16T10:15:16.965925300Z"
   }
 ]

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/ForcedSaleController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/ForcedSaleController.java
@@ -1,5 +1,6 @@
 package edu.ntnu.idatt2003.millions.controller;
 
+import edu.ntnu.idatt2003.millions.model.calculator.SalesCalculator;
 import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
 import edu.ntnu.idatt2003.millions.model.loan.InsufficientSaleProceedsException;
 import edu.ntnu.idatt2003.millions.model.player.Player;
@@ -9,7 +10,9 @@ import edu.ntnu.idatt2003.millions.view.dialog.ForcedSaleDialog;
 
 import java.math.BigDecimal;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Controller for the forced-sale flow triggered when the player cannot cover
@@ -41,9 +44,14 @@ public class ForcedSaleController {
                 .sorted(Comparator.comparing(s -> s.getStock().getWeeklyChangePercent()))
                 .toList();
 
+        Map<Share, BigDecimal> netNokByShare = new LinkedHashMap<>();
+        for (Share share : shares) {
+            netNokByShare.put(share, SalesCalculator.calculateNetNok(share, converter));
+        }
+
         ForcedSaleDialog[] ref = new ForcedSaleDialog[1];
         ref[0] = new ForcedSaleDialog(
-                shares, interestDue, maturityDue, player.getMoney(), converter, currentWeek,
+                shares, interestDue, maturityDue, player.getMoney(), netNokByShare, currentWeek,
                 selectedShares -> handleConfirm(ref[0], selectedShares, currentWeek)
         );
         ref[0].show();

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/Purchase.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/Purchase.java
@@ -49,6 +49,26 @@ public class Purchase extends Transaction {
         this.settlementAmount = settlementAmount;
     }
 
+    @Override
+    public BigDecimal getCommissionNative() {
+        return new PurchaseCalculator(getShare()).calculateCommission();
+    }
+
+    @Override
+    public BigDecimal getTaxNative() {
+        return BigDecimal.ZERO;
+    }
+
+    @Override
+    public BigDecimal getSignedTotalNative() {
+        return new PurchaseCalculator(getShare()).calculateTotal().negate();
+    }
+
+    @Override
+    public BigDecimal getPricePerShare() {
+        return getShare().getPurchasePrice();
+    }
+
     /**
      * Commits this purchase for the given player.
      * Withdraws the settlement amount from the player's balance, adds the share

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/Sale.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/Sale.java
@@ -5,6 +5,7 @@ import edu.ntnu.idatt2003.millions.model.player.Player;
 import edu.ntnu.idatt2003.millions.model.stock.Share;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Objects;
 
 /**
@@ -22,6 +23,8 @@ import java.util.Objects;
  * as a separate piece of data, add a {@code salesPriceAtCommit} field at that point.
  */
 public class Sale extends Transaction {
+
+    private static final int PRICE_SCALE = 4;
 
     private final BigDecimal gross;
     private final BigDecimal commission;
@@ -47,6 +50,26 @@ public class Sale extends Transaction {
         this.total        = calc.calculateTotal();
         this.profit       = calc.calculateProfit();
         this.profitPercent = calc.calculateProfitPercent();
+    }
+
+    @Override
+    public BigDecimal getCommissionNative() {
+        return commission;
+    }
+
+    @Override
+    public BigDecimal getTaxNative() {
+        return tax;
+    }
+
+    @Override
+    public BigDecimal getSignedTotalNative() {
+        return total;
+    }
+
+    @Override
+    public BigDecimal getPricePerShare() {
+        return gross.divide(getShare().getQuantity(), PRICE_SCALE, RoundingMode.HALF_UP);
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/Transaction.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/Transaction.java
@@ -4,6 +4,7 @@ import edu.ntnu.idatt2003.millions.model.calculator.TransactionCalculator;
 import edu.ntnu.idatt2003.millions.model.player.Player;
 import edu.ntnu.idatt2003.millions.model.stock.Share;
 
+import java.math.BigDecimal;
 import java.util.Objects;
 
 /**
@@ -103,6 +104,37 @@ public abstract class Transaction {
     protected void markAsCommitted() {
         this.committed = true;
     }
+
+    /**
+     * Returns the commission paid on this transaction in the stock's native currency.
+     *
+     * @return commission amount in native currency
+     */
+    public abstract BigDecimal getCommissionNative();
+
+    /**
+     * Returns the tax paid on this transaction in the stock's native currency.
+     * Always zero for purchases.
+     *
+     * @return tax amount in native currency
+     */
+    public abstract BigDecimal getTaxNative();
+
+    /**
+     * Returns the signed net cash flow of this transaction in the stock's native currency.
+     * Negative for purchases (outflow), positive for sales (inflow).
+     *
+     * @return signed total in native currency
+     */
+    public abstract BigDecimal getSignedTotalNative();
+
+    /**
+     * Returns the per-share price at which this transaction was executed,
+     * in the stock's native currency.
+     *
+     * @return per-share price in native currency
+     */
+    public abstract BigDecimal getPricePerShare();
 
     /**
      * Commits this transaction for the given player.

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/TransactionArchive.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/TransactionArchive.java
@@ -68,6 +68,26 @@ public class TransactionArchive {
     }
 
     /**
+     * Returns all transactions in the given inclusive week range as a fresh mutable list,
+     * in encounter order (within each week: insertion order; across weeks: low-to-high).
+     * The caller is responsible for any additional sorting.
+     *
+     * @param fromWeek the first week to include (inclusive); must be at least 1
+     * @param toWeek   the last week to include (inclusive); if less than fromWeek the
+     *                 returned list is empty
+     * @return a mutable list of transactions in the range; never null
+     * @throws IllegalArgumentException if fromWeek is less than 1
+     */
+    public List<Transaction> getTransactionsInRange(int fromWeek, int toWeek) {
+        if (fromWeek < 1) throw new IllegalArgumentException("fromWeek must be at least 1");
+        List<Transaction> list = new ArrayList<>();
+        for (int week = fromWeek; week <= toWeek; week++) {
+            list.addAll(getTransactions(week));
+        }
+        return list;
+    }
+
+    /**
      * Returns all purchase transactions that took place in the specified week.
      *
      * @param week the week number to filter by

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/TransactionArchive.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/TransactionArchive.java
@@ -88,6 +88,40 @@ public class TransactionArchive {
     }
 
     /**
+     * Counts all purchase transactions in the given inclusive week range.
+     *
+     * @param fromWeek the first week to include (inclusive); must be at least 1
+     * @param toWeek   the last week to include (inclusive); if less than fromWeek returns 0
+     * @return the number of purchases in the range
+     * @throws IllegalArgumentException if fromWeek is less than 1
+     */
+    public int countPurchasesInRange(int fromWeek, int toWeek) {
+        if (fromWeek < 1) throw new IllegalArgumentException("fromWeek must be at least 1");
+        int total = 0;
+        for (int week = fromWeek; week <= toWeek; week++) {
+            total += getPurchases(week).size();
+        }
+        return total;
+    }
+
+    /**
+     * Counts all sale transactions in the given inclusive week range.
+     *
+     * @param fromWeek the first week to include (inclusive); must be at least 1
+     * @param toWeek   the last week to include (inclusive); if less than fromWeek returns 0
+     * @return the number of sales in the range
+     * @throws IllegalArgumentException if fromWeek is less than 1
+     */
+    public int countSalesInRange(int fromWeek, int toWeek) {
+        if (fromWeek < 1) throw new IllegalArgumentException("fromWeek must be at least 1");
+        int total = 0;
+        for (int week = fromWeek; week <= toWeek; week++) {
+            total += getSales(week).size();
+        }
+        return total;
+    }
+
+    /**
      * Returns all purchase transactions that took place in the specified week.
      *
      * @param week the week number to filter by

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/TransactionArchive.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/TransactionArchive.java
@@ -153,6 +153,18 @@ public class TransactionArchive {
     }
 
     /**
+     * Returns all sale transactions in the archive regardless of week.
+     *
+     * @return an unmodifiable list of all sales
+     */
+    public List<Sale> getAllSales() {
+        return transactions.stream()
+                .filter(Sale.class::isInstance)
+                .map(Sale.class::cast)
+                .toList();
+    }
+
+    /**
      * Returns the total number of completed sales in the archive.
      *
      * @return the number of sales
@@ -172,8 +184,7 @@ public class TransactionArchive {
             java.util.function.Predicate<BigDecimal> filter,
             java.util.function.UnaryOperator<BigDecimal> mapper) {
         Map<Currency, BigDecimal> result = new HashMap<>();
-        for (Transaction transaction : transactions) {
-            if (!(transaction instanceof Sale sale)) continue;
+        for (Sale sale : getAllSales()) {
             BigDecimal profit = sale.getProfit();
             if (!filter.test(profit)) continue;
             Currency currency = sale.getShare().getStock().getCurrency();
@@ -189,12 +200,10 @@ public class TransactionArchive {
      */
     private Map<Currency, BigDecimal> sumSalesAttribute(
             java.util.function.Function<Sale, BigDecimal> extractor) {
-        Map<Currency, BigDecimal> result = new HashMap<>();
-        for (Transaction transaction : transactions) {
-            if (!(transaction instanceof Sale sale)) continue;
-            Currency currency = sale.getShare().getStock().getCurrency();
-            result.merge(currency, extractor.apply(sale), BigDecimal::add);
-        }
-        return result;
+        return getAllSales().stream()
+                .collect(java.util.stream.Collectors.toMap(
+                        sale -> sale.getShare().getStock().getCurrency(),
+                        extractor,
+                        BigDecimal::add));
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/GameService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/GameService.java
@@ -31,6 +31,8 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.math.BigDecimal;
 import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Service-layer manager for the game lifecycle: creates new games, loads and
@@ -47,6 +49,8 @@ import java.util.*;
  *
  */
 public class GameService {
+
+    private static final Logger LOGGER = Logger.getLogger(GameService.class.getName());
 
     private static final String DEFAULT_EXCHANGE_NAME = "MainExchange";
     private static final String DEFAULT_STOCK_RESOURCE = "/data/sp500.csv";
@@ -117,8 +121,10 @@ public class GameService {
             if (currentSaveFile != null) {
                 try {
                     gameFileHandler.saveGame(player, exchange, gameOver, currentSaveFile);
-                } catch (Exception e) {
-                    System.err.println("Could not write save file on bankruptcy: " + e.getMessage());
+                } catch (UncheckedIOException e) {
+                    LOGGER.log(Level.WARNING, "Could not write save file on bankruptcy", e);
+                } catch (RuntimeException e) {
+                    LOGGER.log(Level.SEVERE, "Unexpected error writing save file on bankruptcy", e);
                 }
             }
         }
@@ -144,7 +150,7 @@ public class GameService {
             leaderboardService.recordOrUpdate(player, exchange, exchange.getCurrencyConverter(),
                     gameOver ? Outcome.BANKRUPTCY : Outcome.ACTIVE);
         } catch (RuntimeException e) {
-            System.err.println("Could not update leaderboard after save: " + e.getMessage());
+            LOGGER.log(Level.WARNING, "Could not update leaderboard after save", e);
         }
     }
 
@@ -501,8 +507,10 @@ public class GameService {
         if (currentSaveFile != null) {
             try {
                 gameFileHandler.saveGame(player, exchange, gameOver, currentSaveFile);
-            } catch (Exception e) {
-                System.err.println("Could not write save file on retire: " + e.getMessage());
+            } catch (UncheckedIOException e) {
+                LOGGER.log(Level.WARNING, "Could not write save file on retire", e);
+            } catch (RuntimeException e) {
+                LOGGER.log(Level.SEVERE, "Unexpected error writing save file on retire", e);
             }
         }
         notifyObservers();

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/LeaderboardService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/LeaderboardService.java
@@ -9,11 +9,14 @@ import edu.ntnu.idatt2003.millions.model.leaderboard.Outcome;
 import edu.ntnu.idatt2003.millions.model.player.Player;
 
 import java.io.File;
+import java.io.UncheckedIOException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Service that owns the leaderboard's persistence and ranking rules.
@@ -37,6 +40,8 @@ import java.util.Objects;
  * configurable via the DI constructor so tests can use a temp file.
  */
 public class LeaderboardService {
+
+    private static final Logger LOGGER = Logger.getLogger(LeaderboardService.class.getName());
 
     /**
      * Default leaderboard file name. Relative to the working directory, which
@@ -76,10 +81,10 @@ public class LeaderboardService {
      * never locks — a later save can overwrite a {@link Outcome#BANKRUPTCY} entry
      * with {@link Outcome#ACTIVE} if the player reloads and continues playing.</p>
      *
-     * <p>Failures to read or write the leaderboard file are swallowed silently
-     * (logged to stderr) rather than propagated. The leaderboard is a
-     * non-essential auxiliary feature; a corrupt or unwriteable file should not
-     * crash an in-progress save or game-over flow.</p>
+     * <p>Failures to read or write the leaderboard file are logged at WARNING
+     * and swallowed rather than propagated. The leaderboard is a non-essential
+     * auxiliary feature; a corrupt or unwriteable file should not crash an
+     * in-progress save or game-over flow.</p>
      *
      * @param player    the active player
      * @param exchange  the active exchange (used for week number)
@@ -106,9 +111,8 @@ public class LeaderboardService {
                 entries.add(snapshot);
             }
             fileHandler.writeAll(entries, file);
-        } catch (RuntimeException e) {
-            // Leaderboard is auxiliary — never let it crash save or game-over.
-            System.err.println("Could not update leaderboard: " + e.getMessage());
+        } catch (IllegalStateException | UncheckedIOException e) {
+            LOGGER.log(Level.WARNING, "Could not update leaderboard", e);
         }
     }
 
@@ -140,8 +144,8 @@ public class LeaderboardService {
         List<LeaderboardEntry> entries;
         try {
             entries = readMutable();
-        } catch (RuntimeException e) {
-            System.err.println("Could not read leaderboard: " + e.getMessage());
+        } catch (IllegalStateException e) {
+            LOGGER.log(Level.WARNING, "Could not read leaderboard", e);
             return List.of();
         }
         entries.sort(Comparator

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/TransactionStatsService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/TransactionStatsService.java
@@ -1,14 +1,10 @@
 package edu.ntnu.idatt2003.millions.service;
 
-import edu.ntnu.idatt2003.millions.model.calculator.PurchaseCalculator;
 import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
 import edu.ntnu.idatt2003.millions.model.stock.Share;
-import edu.ntnu.idatt2003.millions.model.transaction.Purchase;
-import edu.ntnu.idatt2003.millions.model.transaction.Sale;
 import edu.ntnu.idatt2003.millions.model.transaction.Transaction;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.Currency;
 import java.util.List;
 
@@ -25,28 +21,17 @@ import java.util.List;
  * computation crosses {@link Transaction}, {@link Share}, the calculator
  * tied to its subclass, and the active {@link CurrencyConverter}.</p>
  *
- * <p>Two pieces of irregularity are encapsulated here so the view doesn't
- * have to know about them:</p>
- * <ul>
- *   <li><b>Frozen vs. recomputed values.</b> {@link Sale} freezes its
- *       financial figures at construction so they survive serialisation,
- *       while {@link Purchase} keeps its {@code calculator} as a transient
- *       field which is null after loading a saved game. A fresh
- *       {@link PurchaseCalculator} is built from the share to recover
- *       commission and total for purchases.</li>
- *   <li><b>Currency conversion.</b> Native-currency values are converted
- *       to NOK so the table can stay denominated in one currency. Both
- *       the native and the NOK value are returned so views can show NOK
- *       in the main cell and the native amount in a tooltip.</li>
- * </ul>
+ * <p>Native-currency values are converted to NOK so the table stays denominated
+ * in one currency. Both native and NOK figures are returned so views can show
+ * NOK in the cell and the native amount in a tooltip without recomputing.
+ * Subtype-specific financial values (commission, tax, signed total, price per
+ * share) are accessed through polymorphic methods on {@link Transaction}, keeping
+ * this service free of {@code instanceof} dispatch.</p>
  */
 public class TransactionStatsService {
 
     /** Currency every NOK-denominated value is converted to. */
     private static final Currency NOK = Currency.getInstance("NOK");
-
-    /** Scale used when dividing gross by quantity to recover per-share price. */
-    private static final int PRICE_SCALE = 4;
 
     /**
      * Computes the display values for a single transaction row.
@@ -59,10 +44,21 @@ public class TransactionStatsService {
         Share share = transaction.getShare();
         Currency nativeCurrency = share.getStock().getCurrency();
 
-        if (transaction instanceof Sale sale) {
-            return statsForSale(sale, share, nativeCurrency, converter);
-        }
-        return statsForPurchase(share, nativeCurrency, converter);
+        BigDecimal commissionNative = transaction.getCommissionNative();
+        BigDecimal taxNative = transaction.getTaxNative();
+        BigDecimal commissionNok = converter.convert(commissionNative, nativeCurrency, NOK);
+        BigDecimal taxNok = converter.convert(taxNative, nativeCurrency, NOK);
+        BigDecimal amountNok = converter.convert(transaction.getSignedTotalNative(), nativeCurrency, NOK);
+
+        return new TransactionStats(
+                share.getQuantity(),
+                transaction.getPricePerShare(),
+                commissionNok,
+                taxNok,
+                amountNok,
+                nativeCurrency.getCurrencyCode(),
+                commissionNative,
+                taxNative);
     }
 
     /**
@@ -90,79 +86,13 @@ public class TransactionStatsService {
         BigDecimal salesNok = BigDecimal.ZERO;
 
         for (Transaction transaction : transactions) {
-            TransactionStats stats = getStats(transaction, converter);
-            if (transaction instanceof Purchase) {
-                purchasesNok = purchasesNok.add(stats.amountNok());
-            } else {
-                salesNok = salesNok.add(stats.amountNok());
-            }
+            BigDecimal amount = getStats(transaction, converter).amountNok();
+            purchasesNok = purchasesNok.add(amount.min(BigDecimal.ZERO));
+            salesNok = salesNok.add(amount.max(BigDecimal.ZERO));
         }
 
         BigDecimal totalNok = purchasesNok.add(salesNok);
         return new TransactionSummary(purchasesNok, salesNok, totalNok);
-    }
-
-    /**
-     * Builds the stats record for a sale, reading the frozen gross,
-     * commission, tax and total directly off the sale.
-     *
-     * @param sale            the sale to read values from
-     * @param share           the underlying share, used for quantity
-     * @param nativeCurrency  the stock's native currency
-     * @param converter       the active currency converter
-     * @return populated stats record
-     */
-    private TransactionStats statsForSale(Sale sale, Share share,
-                                          Currency nativeCurrency,
-                                          CurrencyConverter converter) {
-        BigDecimal pricePerShare = sale.getGross()
-                .divide(share.getQuantity(), PRICE_SCALE, RoundingMode.HALF_UP);
-        BigDecimal commissionNok = converter.convert(sale.getCommission(), nativeCurrency, NOK);
-        BigDecimal taxNok = converter.convert(sale.getTax(), nativeCurrency, NOK);
-        BigDecimal amountNok = converter.convert(sale.getTotal(), nativeCurrency, NOK);
-
-        return new TransactionStats(
-                share.getQuantity(),
-                pricePerShare,
-                commissionNok,
-                taxNok,
-                amountNok,
-                nativeCurrency.getCurrencyCode(),
-                sale.getCommission(),
-                sale.getTax());
-    }
-
-    /**
-     * Builds the stats record for a purchase, reconstructing commission
-     * and total from a fresh {@link PurchaseCalculator} since the
-     * transaction's own calculator is transient and may be null after
-     * a saved game is loaded. Tax is always zero for purchases, and the
-     * NOK amount is negated to signal an outflow.
-     *
-     * @param share          the share that was purchased
-     * @param nativeCurrency the stock's native currency
-     * @param converter      the active currency converter
-     * @return populated stats record
-     */
-    private TransactionStats statsForPurchase(Share share,
-                                              Currency nativeCurrency,
-                                              CurrencyConverter converter) {
-        PurchaseCalculator calculator = new PurchaseCalculator(share);
-        BigDecimal commissionNative = calculator.calculateCommission();
-        BigDecimal totalNative = calculator.calculateTotal();
-
-        BigDecimal commissionNok = converter.convert(commissionNative, nativeCurrency, NOK);
-        BigDecimal amountNok = converter.convert(totalNative, nativeCurrency, NOK).negate();
-
-        return new TransactionStats(
-                share.getQuantity(),
-                share.getPurchasePrice(),
-                commissionNok,
-                BigDecimal.ZERO,
-                amountNok,
-                nativeCurrency.getCurrencyCode(),
-                commissionNative,
-                BigDecimal.ZERO);
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/util/MoneyFormatter.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/util/MoneyFormatter.java
@@ -46,6 +46,8 @@ public final class MoneyFormatter {
     }
 
     private static DecimalFormat buildFormat(Locale locale) {
-        return new DecimalFormat("#,##0.00", new DecimalFormatSymbols(locale));
+        DecimalFormatSymbols symbols = new DecimalFormatSymbols(locale);
+        symbols.setMinusSign('-');
+        return new DecimalFormat("#,##0.00", symbols);
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/notification/NotificationPanel.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/notification/NotificationPanel.java
@@ -3,6 +3,7 @@ package edu.ntnu.idatt2003.millions.view.component.notification;
 import edu.ntnu.idatt2003.millions.model.notification.Notification;
 import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
+import edu.ntnu.idatt2003.millions.view.component.StyledText;
 import javafx.geometry.Bounds;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
@@ -131,8 +132,7 @@ public class NotificationPanel {
         title.getStyleClass().addAll("notification-title", severityTitleClass(n.severity()));
         title.setWrapText(true);
 
-        Label body = new Label(formatBody(n));
-        body.getStyleClass().add("notification-body");
+        StyledText body = StyledText.widgetLabel(formatBody(n));
         body.setWrapText(true);
 
         Label week = new Label("Uke " + n.week());

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/notification/NotificationPanel.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/notification/NotificationPanel.java
@@ -135,7 +135,7 @@ public class NotificationPanel {
         StyledText body = StyledText.widgetLabel(formatBody(n));
         body.setWrapText(true);
 
-        Label week = new Label("Uke " + n.week());
+        Label week = new Label(MessageFormat.format(LanguageManager.get("transactions.weekValue"), n.week()));
         week.getStyleClass().add("notification-week");
 
         VBox content = new VBox(2, title, body, week);

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/card/ActiveLoansCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/loans/card/ActiveLoansCard.java
@@ -15,7 +15,6 @@ import edu.ntnu.idatt2003.millions.view.dashboard.loans.LoansSort;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.control.Button;
-import javafx.scene.control.Label;
 import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.HBox;
@@ -167,24 +166,18 @@ public class ActiveLoansCard extends Card {
         GridPane.setColumnSpan(divider, loansSort.getColumnDefs().size());
         totalGrid.add(divider, 0, 0);
 
-        Label totalLabel = new Label(LanguageManager.get("loans.active.total"));
-        totalLabel.getStyleClass().addAll("holdings-cell", "bold");
-        totalGrid.add(totalLabel, TOTAL_COL_LABEL, 1);
+        totalGrid.add(TableCells.boldData(LanguageManager.get("loans.active.total")), TOTAL_COL_LABEL, 1);
 
         BigDecimal totalWeeklyCost = loans.stream()
                 .map(Loan::weeklyInterest)
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
-        Label weeklyCostLabel = new Label(
+        totalGrid.add(TableCells.boldData(
                 MoneyFormatter.format(totalWeeklyCost)
-                        + " " + CurrencyFormatter.symbol("NOK"));
-        weeklyCostLabel.getStyleClass().addAll("holdings-cell", "bold");
-        totalGrid.add(weeklyCostLabel, TOTAL_COL_WEEKLY_COST, 1);
+                        + " " + CurrencyFormatter.symbol("NOK")), TOTAL_COL_WEEKLY_COST, 1);
 
-        Label remainingLabel = new Label(
+        totalGrid.add(TableCells.boldData(
                 MoneyFormatter.format(gameService.getPlayer().getTotalDebt())
-                        + " " + CurrencyFormatter.symbol("NOK"));
-        remainingLabel.getStyleClass().addAll("holdings-cell", "bold");
-        totalGrid.add(remainingLabel, TOTAL_COL_REMAINING, 1);
+                        + " " + CurrencyFormatter.symbol("NOK")), TOTAL_COL_REMAINING, 1);
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/card/TransactionsActivityCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/card/TransactionsActivityCard.java
@@ -108,8 +108,9 @@ public class TransactionsActivityCard extends Card {
         weekRangeLabel.setText(MessageFormat.format(
                 LanguageManager.get("transactions.summary.weekRange"), fromWeek, toWeek));
 
-        int purchaseCount = countTransactions(fromWeek, toWeek, true);
-        int saleCount = countTransactions(fromWeek, toWeek, false);
+        TransactionArchive archive = gameService.getPlayer().getTransactionArchive();
+        int purchaseCount = archive.countPurchasesInRange(fromWeek, toWeek);
+        int saleCount = archive.countSalesInRange(fromWeek, toWeek);
         int total = purchaseCount + saleCount;
 
         grid.getChildren().clear();
@@ -127,22 +128,6 @@ public class TransactionsActivityCard extends Card {
 
         grid.add(rowLabel(LanguageManager.get("transactions.summary.total"), true), 0, 3);
         grid.add(rowValue(total, true), 1, 3);
-    }
-
-    /**
-     * Counts purchases or sales in the archive over the inclusive range.
-     *
-     * @param countBuys {@code true} for purchases, {@code false} for sales
-     */
-    private int countTransactions(int fromWeek, int toWeek, boolean countBuys) {
-        TransactionArchive archive = gameService.getPlayer().getTransactionArchive();
-        int total = 0;
-        for (int week = fromWeek; week <= toWeek; week++) {
-            total += countBuys
-                    ? archive.getPurchases(week).size()
-                    : archive.getSales(week).size();
-        }
-        return total;
     }
 
     /** Left-column label; bold variant is used for the total row. */

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/card/TransactionsCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/card/TransactionsCard.java
@@ -112,9 +112,9 @@ public class TransactionsCard extends SortableTableCard<Transaction, Transaction
 
     /**
      * Returns transactions scoped to the active week range and type filter,
-     * sorted chronologically. Returns an empty list when the player is null.
+     * sorted newest-first. Returns an empty list when the player is null.
      *
-     * @return mutable list of pre-filtered transactions, oldest first
+     * @return mutable list of pre-filtered transactions, newest first
      */
     @Override
     protected List<Transaction> fetchAll() {
@@ -126,7 +126,9 @@ public class TransactionsCard extends SortableTableCard<Transaction, Transaction
         int toWeek = weekRangeFilter.getToWeek();
         Class<? extends Transaction> selectedType = typeFilter.getSelectedValue();
 
-        return new ArrayList<>(collectRange(archive, fromWeek, toWeek).stream()
+        List<Transaction> range = archive.getTransactionsInRange(fromWeek, toWeek);
+        range.sort(Comparator.comparingInt(Transaction::getWeek).reversed());
+        return new ArrayList<>(range.stream()
                 .filter(t -> selectedType == null || selectedType.isInstance(t))
                 .toList());
     }
@@ -183,24 +185,6 @@ public class TransactionsCard extends SortableTableCard<Transaction, Transaction
     public void onGameUpdated() {
         weekRangeFilter.setMaxWeek(Math.max(gameService.getExchange().getWeek(), 1));
         refresh();
-    }
-
-    /**
-     * Gathers every transaction in the archive within the given week range
-     * (inclusive on both ends), sorted chronologically oldest first.
-     *
-     * @param archive  the archive to read transactions from
-     * @param fromWeek the first week to include (inclusive)
-     * @param toWeek   the last week to include (inclusive)
-     * @return a reverse-chronologically sorted mutable list of transactions in the range
-     */
-    private List<Transaction> collectRange(TransactionArchive archive, int fromWeek, int toWeek) {
-        List<Transaction> list = new ArrayList<>();
-        for (int week = fromWeek; week <= toWeek; week++) {
-            list.addAll(archive.getTransactions(week));
-        }
-        list.sort(Comparator.comparingInt(Transaction::getWeek).reversed());
-        return list;
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/card/TransactionsSummaryCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/transactions/card/TransactionsSummaryCard.java
@@ -20,7 +20,6 @@ import javafx.scene.layout.Region;
 
 import java.math.BigDecimal;
 import java.text.MessageFormat;
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -108,6 +107,12 @@ public class TransactionsSummaryCard extends Card {
      * updates the week-range label. The Total row uses the same
      * divider as {@code HoldingsCard} so the two cards read as a
      * visual family.
+     *
+     * <p>Transactions are fetched via
+     * {@link TransactionArchive#getTransactionsInRange} without additional
+     * sorting — ordering does not matter for the summary aggregation, so
+     * the newest-first sort that {@code TransactionsCard} applies is
+     * intentionally skipped here.</p>
      */
     private void refresh() {
         int fromWeek = weekRangeFilter.getFromWeek();
@@ -117,7 +122,7 @@ public class TransactionsSummaryCard extends Card {
                 LanguageManager.get("transactions.summary.weekRange"), fromWeek, toWeek));
 
         TransactionArchive archive = gameService.getPlayer().getTransactionArchive();
-        List<Transaction> transactions = collectRange(archive, fromWeek, toWeek);
+        List<Transaction> transactions = archive.getTransactionsInRange(fromWeek, toWeek);
         TransactionStatsService.TransactionSummary summary =
                 statsService.getSummary(transactions, gameService.getCurrencyConverter());
 
@@ -164,16 +169,4 @@ public class TransactionsSummaryCard extends Card {
         return label;
     }
 
-    /**
-     * Gathers transactions in the inclusive week range. Ordering does
-     * not matter for the summary, so this skips the sort
-     * {@code TransactionsCard} performs on the same data.
-     */
-    private List<Transaction> collectRange(TransactionArchive archive, int fromWeek, int toWeek) {
-        List<Transaction> list = new ArrayList<>();
-        for (int week = fromWeek; week <= toWeek; week++) {
-            list.addAll(archive.getTransactions(week));
-        }
-        return list;
-    }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/watchlist/WatchlistCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/watchlist/WatchlistCard.java
@@ -82,7 +82,7 @@ public class WatchlistCard extends SortableTableCard<WatchlistItem, WatchlistSor
                     return stock != null ? new WatchlistItem(stock, entry) : null;
                 })
                 .filter(Objects::nonNull)
-                .collect(Collectors.toCollection(ArrayList::new));
+                .toList();
     }
 
     @Override

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dialog/ForcedSaleDialog.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dialog/ForcedSaleDialog.java
@@ -1,7 +1,5 @@
 package edu.ntnu.idatt2003.millions.view.dialog;
 
-import edu.ntnu.idatt2003.millions.model.calculator.SalesCalculator;
-import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
 import edu.ntnu.idatt2003.millions.model.stock.Share;
 import edu.ntnu.idatt2003.millions.util.ChangeFormatter;
 import edu.ntnu.idatt2003.millions.util.ColourChange;
@@ -43,11 +41,10 @@ public class ForcedSaleDialog extends Modal {
     private final BigDecimal maturityDue;
     private final BigDecimal totalObligations;
     private final BigDecimal availableCash;
-    private final CurrencyConverter converter;
     private final int currentWeek;
     private final Consumer<List<Share>> onConfirm;
 
-    private final Map<Share, BigDecimal> netNokByShare = new LinkedHashMap<>();
+    private final Map<Share, BigDecimal> netNokByShare;
     private final List<Share> selectedShares = new ArrayList<>();
 
     private Label selectedTotalLabel;
@@ -58,7 +55,7 @@ public class ForcedSaleDialog extends Modal {
                             BigDecimal interestDue,
                             BigDecimal maturityDue,
                             BigDecimal availableCash,
-                            CurrencyConverter converter,
+                            Map<Share, BigDecimal> netNokByShare,
                             int currentWeek,
                             Consumer<List<Share>> onConfirm) {
         this.shares = shares;
@@ -66,13 +63,9 @@ public class ForcedSaleDialog extends Modal {
         this.maturityDue = maturityDue;
         this.totalObligations = interestDue.add(maturityDue);
         this.availableCash = availableCash;
-        this.converter = converter;
+        this.netNokByShare = netNokByShare;
         this.currentWeek = currentWeek;
         this.onConfirm = onConfirm;
-
-        for (Share share : shares) {
-            netNokByShare.put(share, SalesCalculator.calculateNetNok(share, converter));
-        }
     }
 
     /**

--- a/src/main/resources/css/notifications.css
+++ b/src/main/resources/css/notifications.css
@@ -156,11 +156,6 @@
     -fx-font-weight: normal;
 }
 
-.notification-body {
-    -fx-font-size: 12px;
-    -fx-text-fill: -text-secondary;
-}
-
 .notification-week {
     -fx-font-size: 11px;
     -fx-text-fill: -text-muted;

--- a/src/test/java/edu/ntnu/idatt2003/millions/controller/StartControllerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/controller/StartControllerTest.java
@@ -327,7 +327,7 @@ class StartControllerTest {
                     new ArrayList<>(List.of(stock)),
                     new FixedRateCurrencyConverter());
             Player player = new Player("Dara", new BigDecimal("10000.00"));
-            new JsonGameFileHandler().saveGame(player, exchange, saveFile.toFile());
+            new JsonGameFileHandler().saveGame(player, exchange, false, saveFile.toFile());
             // Act
             controller.validateAndSetSaveFile(saveFile.toFile());
             // Assert

--- a/src/test/java/edu/ntnu/idatt2003/millions/file/game/JsonGameFileHandlerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/file/game/JsonGameFileHandlerTest.java
@@ -72,7 +72,7 @@ class JsonGameFileHandlerTest {
             // Arrange
             Path file = tempDir.resolve("save.json");
             // Act
-            handler.saveGame(player, exchange, file.toFile());
+            handler.saveGame(player, exchange, false, file.toFile());
             // Assert
             assertTrue(file.toFile().exists());
         }
@@ -83,7 +83,7 @@ class JsonGameFileHandlerTest {
             // Arrange
             Path file = tempDir.resolve("save.json");
             // Act
-            handler.saveGame(player, exchange, file.toFile());
+            handler.saveGame(player, exchange, false, file.toFile());
             String content = Files.readString(file);
             // Assert
             assertTrue(content.contains("\"player\""));
@@ -100,7 +100,7 @@ class JsonGameFileHandlerTest {
             player.getPortfolio().addShare(share);
             // Act & Assert
             assertDoesNotThrow(() ->
-                    handler.saveGame(player, exchange, file.toFile()));
+                    handler.saveGame(player, exchange, false, file.toFile()));
         }
 
         @Test
@@ -111,7 +111,7 @@ class JsonGameFileHandlerTest {
             exchange.buy("EQNR", new BigDecimal("5"), player);
             // Act & Assert
             assertDoesNotThrow(() ->
-                    handler.saveGame(player, exchange, file.toFile()));
+                    handler.saveGame(player, exchange, false, file.toFile()));
         }
 
         @Test
@@ -119,7 +119,7 @@ class JsonGameFileHandlerTest {
         void throwsExceptionWhenFileIsNull() {
             // Act & Assert
             assertThrows(NullPointerException.class, () ->
-                    handler.saveGame(player, exchange, null));
+                    handler.saveGame(player, exchange, false, null));
         }
 
         @Test
@@ -129,7 +129,7 @@ class JsonGameFileHandlerTest {
             Path file = tempDir.resolve("save.json");
             // Act & Assert
             assertThrows(NullPointerException.class, () ->
-                    handler.saveGame(null, exchange, file.toFile()));
+                    handler.saveGame(null, exchange, false, file.toFile()));
         }
 
         @Test
@@ -139,7 +139,7 @@ class JsonGameFileHandlerTest {
             Path file = tempDir.resolve("save.json");
             // Act & Assert
             assertThrows(NullPointerException.class, () ->
-                    handler.saveGame(player, null, file.toFile()));
+                    handler.saveGame(player, null, false, file.toFile()));
         }
 
         @Test
@@ -149,7 +149,7 @@ class JsonGameFileHandlerTest {
             Path file = tempDir.resolve("nonexistent/save.json");
             // Act & Assert
             assertThrows(UncheckedIOException.class, () ->
-                    handler.saveGame(player, exchange, file.toFile()));
+                    handler.saveGame(player, exchange, false, file.toFile()));
         }
     }
 
@@ -162,7 +162,7 @@ class JsonGameFileHandlerTest {
         void returnsCorrectPlayerNameAfterLoad() throws GameSaveCorruptException {
             // Arrange
             Path file = tempDir.resolve("save.json");
-            handler.saveGame(player, exchange, file.toFile());
+            handler.saveGame(player, exchange, false, file.toFile());
             // Act
             GameState state = handler.loadGame(file.toFile());
             // Assert
@@ -174,7 +174,7 @@ class JsonGameFileHandlerTest {
         void returnsCorrectPlayerMoneyAfterLoad() throws GameSaveCorruptException {
             // Arrange
             Path file = tempDir.resolve("save.json");
-            handler.saveGame(player, exchange, file.toFile());
+            handler.saveGame(player, exchange, false, file.toFile());
             // Act
             GameState state = handler.loadGame(file.toFile());
             // Assert
@@ -187,7 +187,7 @@ class JsonGameFileHandlerTest {
         void returnsCorrectExchangeNameAfterLoad() throws GameSaveCorruptException {
             // Arrange
             Path file = tempDir.resolve("save.json");
-            handler.saveGame(player, exchange, file.toFile());
+            handler.saveGame(player, exchange, false, file.toFile());
             // Act
             GameState state = handler.loadGame(file.toFile());
             // Assert
@@ -200,7 +200,7 @@ class JsonGameFileHandlerTest {
             // Arrange
             Path file = tempDir.resolve("save.json");
             exchange.advance();
-            handler.saveGame(player, exchange, file.toFile());
+            handler.saveGame(player, exchange, false, file.toFile());
             // Act
             GameState state = handler.loadGame(file.toFile());
             // Assert
@@ -213,7 +213,7 @@ class JsonGameFileHandlerTest {
             // Arrange
             Path file = tempDir.resolve("save.json");
             exchange.buy("EQNR", new BigDecimal("5"), player);
-            handler.saveGame(player, exchange, file.toFile());
+            handler.saveGame(player, exchange, false, file.toFile());
             // Act
             GameState state = handler.loadGame(file.toFile());
             // Assert
@@ -226,7 +226,7 @@ class JsonGameFileHandlerTest {
             // Arrange
             Path file = tempDir.resolve("save.json");
             exchange.buy("EQNR", new BigDecimal("5"), player);
-            handler.saveGame(player, exchange, file.toFile());
+            handler.saveGame(player, exchange, false, file.toFile());
             // Act
             GameState state = handler.loadGame(file.toFile());
             Share loadedShare = state.player().getPortfolio().getShares().getFirst();
@@ -241,7 +241,7 @@ class JsonGameFileHandlerTest {
             // Arrange
             Path file = tempDir.resolve("save.json");
             exchange.buy("EQNR", new BigDecimal("5"), player);
-            handler.saveGame(player, exchange, file.toFile());
+            handler.saveGame(player, exchange, false, file.toFile());
             // Act
             GameState state = handler.loadGame(file.toFile());
             // Assert
@@ -253,7 +253,7 @@ class JsonGameFileHandlerTest {
         void returnsEmptyPortfolioWhenNoSharesOwned() throws GameSaveCorruptException {
             // Arrange
             Path file = tempDir.resolve("save.json");
-            handler.saveGame(player, exchange, file.toFile());
+            handler.saveGame(player, exchange, false, file.toFile());
             // Act
             GameState state = handler.loadGame(file.toFile());
             // Assert
@@ -265,7 +265,7 @@ class JsonGameFileHandlerTest {
         void returnsEmptyTransactionArchiveWhenNoTransactionsMade() throws GameSaveCorruptException {
             // Arrange
             Path file = tempDir.resolve("save.json");
-            handler.saveGame(player, exchange, file.toFile());
+            handler.saveGame(player, exchange, false, file.toFile());
             // Act
             GameState state = handler.loadGame(file.toFile());
             // Assert
@@ -279,7 +279,7 @@ class JsonGameFileHandlerTest {
             Path file = tempDir.resolve("save.json");
             exchange.advance();
             exchange.advance();
-            handler.saveGame(player, exchange, file.toFile());
+            handler.saveGame(player, exchange, false, file.toFile());
             // Act
             GameState state = handler.loadGame(file.toFile());
             // Assert
@@ -295,7 +295,7 @@ class JsonGameFileHandlerTest {
             Share share1 = new Share(stock, new BigDecimal("5"), new BigDecimal("276.43"));
             Share share2 = new Share(stock, new BigDecimal("3"), new BigDecimal("300.00"));
             player.getPortfolio().setShares(List.of(share1, share2));
-            handler.saveGame(player, exchange, file.toFile());
+            handler.saveGame(player, exchange, false, file.toFile());
             // Act
             GameState state = handler.loadGame(file.toFile());
             // Assert
@@ -373,7 +373,7 @@ class JsonGameFileHandlerTest {
             Path file = tempDir.resolve("save.json");
             Loan loan = new Loan(LoanCatalog.getOffers().get(0), new BigDecimal("4000.00"), 1);
             player.takeLoan(loan, new FixedRateCurrencyConverter());
-            handler.saveGame(player, exchange, file.toFile());
+            handler.saveGame(player, exchange, false, file.toFile());
             // Act
             GameState state = handler.loadGame(file.toFile());
             // Assert
@@ -390,7 +390,7 @@ class JsonGameFileHandlerTest {
             Path file = tempDir.resolve("save.json");
             Loan loan = new Loan(LoanCatalog.getOffers().get(0), new BigDecimal("4000.00"), 1);
             player.takeLoan(loan, new FixedRateCurrencyConverter());
-            handler.saveGame(player, exchange, file.toFile());
+            handler.saveGame(player, exchange, false, file.toFile());
             // Act
             GameState state = handler.loadGame(file.toFile());
             // Assert
@@ -407,7 +407,7 @@ class JsonGameFileHandlerTest {
             Loan loan = new Loan(LoanCatalog.getOffers().get(0), new BigDecimal("4000.00"), 1);
             player.takeLoan(loan, new FixedRateCurrencyConverter());
             player.recordTotalDebt();
-            handler.saveGame(player, exchange, file.toFile());
+            handler.saveGame(player, exchange, false, file.toFile());
             // Act
             GameState state = handler.loadGame(file.toFile());
             // Assert
@@ -422,7 +422,7 @@ class JsonGameFileHandlerTest {
             // Arrange
             Path file = tempDir.resolve("save.json");
             exchange.buy("EQNR", new BigDecimal("5"), player);
-            handler.saveGame(player, exchange, file.toFile());
+            handler.saveGame(player, exchange, false, file.toFile());
             // Act
             GameState state = handler.loadGame(file.toFile());
             // Assert
@@ -440,7 +440,7 @@ class JsonGameFileHandlerTest {
             exchange.buy("EQNR", new BigDecimal("5"), player);
             Share portfolioShare = player.getPortfolio().getShares().getFirst();
             new Sale(portfolioShare, 1).commit(player);
-            handler.saveGame(player, exchange, file.toFile());
+            handler.saveGame(player, exchange, false, file.toFile());
             // Act
             GameState state = handler.loadGame(file.toFile());
             // Assert
@@ -455,7 +455,7 @@ class JsonGameFileHandlerTest {
         void canAdvanceWeekAfterLoadingGameAndReinitialize() throws GameSaveCorruptException {
             // Arrange
             Path file = tempDir.resolve("save.json");
-            handler.saveGame(player, exchange, file.toFile());
+            handler.saveGame(player, exchange, false, file.toFile());
             GameState state = handler.loadGame(file.toFile());
             state.exchange().reinitialize(new FixedRateCurrencyConverter());
 
@@ -495,7 +495,7 @@ class JsonGameFileHandlerTest {
             ));
             File file = tempDir.resolve("notif-save.json").toFile();
 
-            handler.saveGame(player, exchange, file);
+            handler.saveGame(player, exchange, false, file);
             GameState loaded = handler.loadGame(file);
 
             assertEquals(1, loaded.player().getNotifications().size());
@@ -513,7 +513,7 @@ class JsonGameFileHandlerTest {
             player.setWasLowOnCash(true);
             File file = tempDir.resolve("flags-save.json").toFile();
 
-            handler.saveGame(player, exchange, file);
+            handler.saveGame(player, exchange, false, file);
             GameState loaded = handler.loadGame(file);
 
             assertTrue(loaded.player().wasAboveDebtThreshold());
@@ -530,7 +530,7 @@ class JsonGameFileHandlerTest {
                     List.of(), 1, false));
             File file = tempDir.resolve("next-id-save.json").toFile();
 
-            handler.saveGame(player, exchange, file);
+            handler.saveGame(player, exchange, false, file);
             GameState state = handler.loadGame(file);
 
             // Push a second notification on the loaded player — must get id=2, not id=1
@@ -549,7 +549,7 @@ class JsonGameFileHandlerTest {
             player.setPreviousStatus(PlayerStatusLevel.INVESTOR);
             File file = tempDir.resolve("status-save.json").toFile();
 
-            handler.saveGame(player, exchange, file);
+            handler.saveGame(player, exchange, false, file);
             GameState loaded = handler.loadGame(file);
 
             assertEquals(PlayerStatusLevel.INVESTOR, loaded.player().getPreviousStatus());

--- a/src/test/java/edu/ntnu/idatt2003/millions/file/stock/CsvStockFileHandlerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/file/stock/CsvStockFileHandlerTest.java
@@ -50,24 +50,24 @@ class CsvStockFileHandlerTest {
         @SuppressWarnings("java:S5976")
         @Test
         @DisplayName("Should return correct number of stocks when file is valid")
-        void returnsCorrectNumberOfStocks() throws Exception {
+        void returnsCorrectNumberOfStocks() throws InvalidStockDataException {
             // Arrange
-            Path file = tempDir.resolve("stocks.csv");
-            Files.writeString(file, "AAPL,Apple Inc.,276.43\nMSFT,Microsoft,404.68\n");
+            InputStream stream = new ByteArrayInputStream(
+                    "AAPL,Apple Inc.,276.43\nMSFT,Microsoft,404.68\n".getBytes(StandardCharsets.UTF_8));
             // Act
-            List<Stock> stocks = handler.readStocks(file);
+            List<Stock> stocks = handler.readStocks(stream);
             // Assert
             assertEquals(2, stocks.size());
         }
 
         @Test
         @DisplayName("Should parse stock fields correctly when file is valid")
-        void parsesStockFieldsCorrectly() throws Exception {
+        void parsesStockFieldsCorrectly() throws InvalidStockDataException {
             // Arrange
-            Path file = tempDir.resolve("stocks.csv");
-            Files.writeString(file, "AAPL,Apple Inc.,276.43\n");
+            InputStream stream = new ByteArrayInputStream(
+                    "AAPL,Apple Inc.,276.43\n".getBytes(StandardCharsets.UTF_8));
             // Act
-            List<Stock> stocks = handler.readStocks(file);
+            List<Stock> stocks = handler.readStocks(stream);
             // Assert
             assertEquals("AAPL", stocks.getFirst().getSymbol());
             assertEquals("Apple Inc.", stocks.getFirst().getCompany());
@@ -76,69 +76,68 @@ class CsvStockFileHandlerTest {
 
         @Test
         @DisplayName("Should skip comment lines when file contains comments")
-        void skipsCommentLines() throws Exception {
+        void skipsCommentLines() throws InvalidStockDataException {
             // Arrange
-            Path file = tempDir.resolve("stocks.csv");
-            Files.writeString(file, "# This is a comment\nAAPL,Apple Inc.,276.43\n");
+            InputStream stream = new ByteArrayInputStream(
+                    "# This is a comment\nAAPL,Apple Inc.,276.43\n".getBytes(StandardCharsets.UTF_8));
             // Act
-            List<Stock> stocks = handler.readStocks(file);
+            List<Stock> stocks = handler.readStocks(stream);
             // Assert
             assertEquals(1, stocks.size());
         }
 
         @Test
         @DisplayName("Should skip blank lines when file contains blank lines")
-        void skipsBlankLines() throws Exception {
+        void skipsBlankLines() throws InvalidStockDataException {
             // Arrange
-            Path file = tempDir.resolve("stocks.csv");
-            Files.writeString(file, "\nAAPL,Apple Inc.,276.43\n\n");
+            InputStream stream = new ByteArrayInputStream(
+                    "\nAAPL,Apple Inc.,276.43\n\n".getBytes(StandardCharsets.UTF_8));
             // Act
-            List<Stock> stocks = handler.readStocks(file);
+            List<Stock> stocks = handler.readStocks(stream);
             // Assert
             assertEquals(1, stocks.size());
         }
 
         @Test
         @DisplayName("Should throw InvalidStockDataException for wrong column count")
-        void throwsForWrongColumnCount() throws Exception {
+        void throwsForWrongColumnCount() {
             // Arrange
-            Path file = tempDir.resolve("stocks.csv");
-            Files.writeString(file, "AAPL,Apple Inc.,276.43\nINVALID_LINE\n");
+            InputStream stream = new ByteArrayInputStream(
+                    "AAPL,Apple Inc.,276.43\nINVALID_LINE\n".getBytes(StandardCharsets.UTF_8));
             // Act & Assert
-            assertThrows(InvalidStockDataException.class, () -> handler.readStocks(file));
+            assertThrows(InvalidStockDataException.class, () -> handler.readStocks(stream));
         }
 
         @Test
         @DisplayName("Should throw InvalidStockDataException for non-numeric price")
-        void throwsForNonNumericPrice() throws Exception {
+        void throwsForNonNumericPrice() {
             // Arrange
-            Path file = tempDir.resolve("stocks.csv");
-            Files.writeString(file, "AAPL,Apple Inc.,abc\n");
+            InputStream stream = new ByteArrayInputStream(
+                    "AAPL,Apple Inc.,abc\n".getBytes(StandardCharsets.UTF_8));
             // Act & Assert
-            assertThrows(InvalidStockDataException.class, () -> handler.readStocks(file));
+            assertThrows(InvalidStockDataException.class, () -> handler.readStocks(stream));
         }
 
         @Test
         @DisplayName("Should report the correct line number when a data line is malformed")
-        void reportsCorrectLineNumberOnMalformedLine() throws Exception {
+        void reportsCorrectLineNumberOnMalformedLine() {
             // Arrange — line 1 is a comment, line 2 is valid, line 3 is malformed
-            Path file = tempDir.resolve("stocks.csv");
-            Files.writeString(file, "# comment\nAAPL,Apple Inc.,276.43\nBAD\n");
+            InputStream stream = new ByteArrayInputStream(
+                    "# comment\nAAPL,Apple Inc.,276.43\nBAD\n".getBytes(StandardCharsets.UTF_8));
             // Act
             InvalidStockDataException ex = assertThrows(InvalidStockDataException.class,
-                    () -> handler.readStocks(file));
+                    () -> handler.readStocks(stream));
             // Assert — line 3 in the file is the bad one
             assertEquals(3, ex.getLineNumber());
         }
 
         @Test
         @DisplayName("Should throw EmptyStockFileException when file is empty")
-        void throwsEmptyStockFileExceptionWhenFileIsEmpty() throws Exception {
+        void throwsEmptyStockFileExceptionWhenFileIsEmpty() {
             // Arrange
-            Path file = tempDir.resolve("stocks.csv");
-            Files.writeString(file, "");
+            InputStream stream = new ByteArrayInputStream(new byte[0]);
             // Act & Assert
-            assertThrows(EmptyStockFileException.class, () -> handler.readStocks(file));
+            assertThrows(EmptyStockFileException.class, () -> handler.readStocks(stream));
         }
 
         @Test
@@ -163,12 +162,12 @@ class CsvStockFileHandlerTest {
 
         @Test
         @DisplayName("Should default stock currency to USD when no currency is supplied")
-        void defaultsCurrencyToUsd() throws Exception {
+        void defaultsCurrencyToUsd() throws InvalidStockDataException {
             // Arrange
-            Path file = tempDir.resolve("stocks.csv");
-            Files.writeString(file, "AAPL,Apple Inc.,276.43\n");
+            InputStream stream = new ByteArrayInputStream(
+                    "AAPL,Apple Inc.,276.43\n".getBytes(StandardCharsets.UTF_8));
             // Act
-            List<Stock> stocks = handler.readStocks(file);
+            List<Stock> stocks = handler.readStocks(stream);
             // Assert
             assertEquals(Currency.getInstance("USD"), stocks.getFirst().getCurrency());
         }
@@ -180,13 +179,13 @@ class CsvStockFileHandlerTest {
 
         @Test
         @DisplayName("Should tag every parsed stock with the supplied currency")
-        void tagsStocksWithSuppliedCurrency() throws Exception {
+        void tagsStocksWithSuppliedCurrency() throws InvalidStockDataException {
             // Arrange
-            Path file = tempDir.resolve("stocks.csv");
-            Files.writeString(file, "AAPL,Apple Inc.,276.43\nMSFT,Microsoft,404.68\n");
+            InputStream stream = new ByteArrayInputStream(
+                    "AAPL,Apple Inc.,276.43\nMSFT,Microsoft,404.68\n".getBytes(StandardCharsets.UTF_8));
             Currency eur = Currency.getInstance("EUR");
             // Act
-            List<Stock> stocks = handler.readStocks(file, eur);
+            List<Stock> stocks = handler.readStocks(stream, eur);
             // Assert
             assertEquals(2, stocks.size());
             assertTrue(stocks.stream().allMatch(stock -> eur.equals(stock.getCurrency())));
@@ -194,13 +193,12 @@ class CsvStockFileHandlerTest {
 
         @Test
         @DisplayName("Should throw EmptyStockFileException when file is empty")
-        void throwsEmptyStockFileExceptionWhenFileIsEmpty() throws Exception {
+        void throwsEmptyStockFileExceptionWhenFileIsEmpty() {
             // Arrange
-            Path file = tempDir.resolve("stocks.csv");
-            Files.writeString(file, "");
+            InputStream stream = new ByteArrayInputStream(new byte[0]);
             // Act & Assert
             assertThrows(EmptyStockFileException.class,
-                    () -> handler.readStocks(file, Currency.getInstance("NOK")));
+                    () -> handler.readStocks(stream, Currency.getInstance("NOK")));
         }
 
         @Test
@@ -215,13 +213,13 @@ class CsvStockFileHandlerTest {
 
         @Test
         @DisplayName("Should throw exception when currency is null")
-        void throwsExceptionWhenCurrencyIsNull() throws Exception {
+        void throwsExceptionWhenCurrencyIsNull() {
             // Arrange
-            Path file = tempDir.resolve("stocks.csv");
-            Files.writeString(file, "AAPL,Apple Inc.,276.43\n");
+            InputStream stream = new ByteArrayInputStream(
+                    "AAPL,Apple Inc.,276.43\n".getBytes(StandardCharsets.UTF_8));
             // Act & Assert
             assertThrows(NullPointerException.class, () ->
-                    handler.readStocks(file, null));
+                    handler.readStocks(stream, null));
         }
     }
 
@@ -320,88 +318,87 @@ class CsvStockFileHandlerTest {
 
         @Test
         @DisplayName("Should throw InvalidStockDataException when symbol is blank")
-        void throwsWhenSymbolIsBlank() throws Exception {
+        void throwsWhenSymbolIsBlank() {
             // Arrange
-            Path file = tempDir.resolve("stocks.csv");
-            Files.writeString(file, " ,Apple Inc.,276.43\n");
+            InputStream stream = new ByteArrayInputStream(
+                    " ,Apple Inc.,276.43\n".getBytes(StandardCharsets.UTF_8));
             // Act
             InvalidStockDataException ex = assertThrows(InvalidStockDataException.class,
-                    () -> handler.readStocks(file));
+                    () -> handler.readStocks(stream));
             // Assert
             assertTrue(ex.getMessage().contains("blank symbol"));
         }
 
         @Test
         @DisplayName("Should throw InvalidStockDataException when name is blank")
-        void throwsWhenNameIsBlank() throws Exception {
+        void throwsWhenNameIsBlank() {
             // Arrange
-            Path file = tempDir.resolve("stocks.csv");
-            Files.writeString(file, "AAPL, ,276.43\n");
+            InputStream stream = new ByteArrayInputStream(
+                    "AAPL, ,276.43\n".getBytes(StandardCharsets.UTF_8));
             // Act
             InvalidStockDataException ex = assertThrows(InvalidStockDataException.class,
-                    () -> handler.readStocks(file));
+                    () -> handler.readStocks(stream));
             // Assert
             assertTrue(ex.getMessage().contains("blank name"));
         }
 
         @Test
         @DisplayName("Should throw InvalidStockDataException when price is zero")
-        void throwsWhenPriceIsZero() throws Exception {
+        void throwsWhenPriceIsZero() {
             // Arrange
-            Path file = tempDir.resolve("stocks.csv");
-            Files.writeString(file, "AAPL,Apple Inc.,0\n");
+            InputStream stream = new ByteArrayInputStream(
+                    "AAPL,Apple Inc.,0\n".getBytes(StandardCharsets.UTF_8));
             // Act
             InvalidStockDataException ex = assertThrows(InvalidStockDataException.class,
-                    () -> handler.readStocks(file));
+                    () -> handler.readStocks(stream));
             // Assert
             assertTrue(ex.getMessage().contains("non-positive price"));
         }
 
         @Test
         @DisplayName("Should throw InvalidStockDataException when price is negative")
-        void throwsWhenPriceIsNegative() throws Exception {
+        void throwsWhenPriceIsNegative() {
             // Arrange
-            Path file = tempDir.resolve("stocks.csv");
-            Files.writeString(file, "AAPL,Apple Inc.,-1.00\n");
+            InputStream stream = new ByteArrayInputStream(
+                    "AAPL,Apple Inc.,-1.00\n".getBytes(StandardCharsets.UTF_8));
             // Act
             InvalidStockDataException ex = assertThrows(InvalidStockDataException.class,
-                    () -> handler.readStocks(file));
+                    () -> handler.readStocks(stream));
             // Assert
             assertTrue(ex.getMessage().contains("non-positive price"));
         }
 
         @Test
         @DisplayName("Should report correct line number when symbol is blank")
-        void reportsCorrectLineNumberForBlankSymbol() throws Exception {
+        void reportsCorrectLineNumberForBlankSymbol() {
             // Arrange — line 1 is valid, line 2 has a blank symbol
-            Path file = tempDir.resolve("stocks.csv");
-            Files.writeString(file, "AAPL,Apple Inc.,276.43\n ,Microsoft,404.68\n");
+            InputStream stream = new ByteArrayInputStream(
+                    "AAPL,Apple Inc.,276.43\n ,Microsoft,404.68\n".getBytes(StandardCharsets.UTF_8));
             // Act
             InvalidStockDataException ex = assertThrows(InvalidStockDataException.class,
-                    () -> handler.readStocks(file));
+                    () -> handler.readStocks(stream));
             // Assert
             assertEquals(2, ex.getLineNumber());
         }
 
         @Test
         @DisplayName("Should throw EmptyStockFileException when file contains only comments")
-        void throwsEmptyStockFileExceptionForOnlyComments() throws Exception {
+        void throwsEmptyStockFileExceptionForOnlyComments() {
             // Arrange
-            Path file = tempDir.resolve("stocks.csv");
-            Files.writeString(file, "# comment one\n# comment two\n");
+            InputStream stream = new ByteArrayInputStream(
+                    "# comment one\n# comment two\n".getBytes(StandardCharsets.UTF_8));
             // Act & Assert
-            assertThrows(EmptyStockFileException.class, () -> handler.readStocks(file));
+            assertThrows(EmptyStockFileException.class, () -> handler.readStocks(stream));
         }
 
         @Test
         @DisplayName("EmptyStockFileException should be an instance of InvalidStockDataException")
-        void emptyStockFileExceptionIsSubtypeOfInvalidStockDataException() throws Exception {
+        void emptyStockFileExceptionIsSubtypeOfInvalidStockDataException() {
             // Arrange
-            Path file = tempDir.resolve("stocks.csv");
-            Files.writeString(file, "");
+            InputStream stream = new ByteArrayInputStream(new byte[0]);
             // Act
             Exception ex = assertThrows(EmptyStockFileException.class,
-                    () -> handler.readStocks(file));
+                    () -> handler.readStocks(stream));
             // Assert
             assertInstanceOf(InvalidStockDataException.class, ex);
         }

--- a/src/test/java/edu/ntnu/idatt2003/millions/service/GameServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/service/GameServiceTest.java
@@ -74,7 +74,7 @@ class GameServiceTest {
         Player player = new Player("Dara", STARTING_MONEY);
 
         Path file = tempDir.resolve("save.json");
-        new JsonGameFileHandler().saveGame(player, exchange, file.toFile());
+        new JsonGameFileHandler().saveGame(player, exchange, false, file.toFile());
 
         lbService = new LeaderboardService(
                 new JsonLeaderboardFileHandler(),
@@ -694,7 +694,7 @@ class GameServiceTest {
                             "NYSE", new ArrayList<>(List.of(stock)),
                             new FixedRateCurrencyConverter());
             Player player = new Player("Dara", STARTING_MONEY);
-            new JsonGameFileHandler().saveGame(player, exchange, file.toFile());
+            new JsonGameFileHandler().saveGame(player, exchange, false, file.toFile());
             gameService.loadGame(file.toFile());
             assertFalse(gameService.isGameOver());
         }

--- a/src/test/java/edu/ntnu/idatt2003/millions/service/LeaderboardServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/service/LeaderboardServiceTest.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.lang.reflect.Field;
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -326,7 +328,7 @@ class LeaderboardServiceTest {
 
         @Override
         public void writeAll(List<LeaderboardEntry> entries, File file) {
-            if (failOnWrite) throw new RuntimeException("simulated write failure");
+            if (failOnWrite) throw new UncheckedIOException(new IOException("simulated write failure"));
             this.entries = new ArrayList<>(entries);
         }
     }

--- a/src/test/java/edu/ntnu/idatt2003/millions/util/MoneyFormatterTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/util/MoneyFormatterTest.java
@@ -63,6 +63,23 @@ class MoneyFormatterTest {
         }
 
         @Test
+        @DisplayName("negative value uses ASCII hyphen-minus not Unicode minus sign")
+        void negativeValueUsesAsciiMinus() {
+            // Spec: MoneyFormatter normalises the minus character to ASCII U+002D
+            // for all locales. Without setMinusSign('-'), the nb-NO locale returns
+            // U+2212 (MINUS SIGN) on some platforms (e.g. Windows), making output
+            // inconsistent with ChangeFormatter and the rest of the display layer.
+            // Arrange
+            BigDecimal amount = new BigDecimal("-500.00");
+            // Act
+            String result = MoneyFormatter.format(amount);
+            // Assert: first character must be U+002D HYPHEN-MINUS, not U+2212 MINUS SIGN
+            assertEquals('-', result.charAt(0),
+                    "Expected ASCII hyphen-minus U+002D but got U+" +
+                    Integer.toHexString(result.charAt(0)).toUpperCase() + ": " + result);
+        }
+
+        @Test
         @DisplayName("formats large value with grouping")
         void largeValueHasGrouping() {
             String result = MoneyFormatter.format(new BigDecimal("1000000.00"));


### PR DESCRIPTION
 ## Summary
 
Architecture and test-quality pass over the codebase ahead of the
final delivery. Every change here is a deliberate, reviewed
decision - the goal was to strengthen separation of concerns,
remove genuine coupling, and bring the test suite onto a single
documented convention, while explicitly NOT making risky
mechanical changes near the deadline. Where a change was
considered and deliberately not made, that decision is recorded
(in the report) rather than left implicit.
 
9 commits, grouped below by intent.
 
## What changed and why
 
**SoC: dispatch by type, not by `instanceof`** 
Replaced `instanceof Sale/Purchase` branching with polymorphic
dispatch. Type-specific behaviour now lives on the type;
arithmetic stays in the calculators. Lower coupling, open for
extension.
 
**SoC: two domain calculations moved out of the view layer**
A read-consistency audit found two views performing domain
calculation inline (range aggregation in TransactionsActivityCard;
a SalesCalculator call in ForcedSaleDialog). Both were moved
behind the correct layer: range accumulation extracted to
TransactionArchive; ForcedSaleController now prepares the
net-NOK map and the dialog just renders it. The audit also
confirmed the read/mutate boundary is applied uniformly across
all views — that uniformity is the concrete evidence of low
coupling, not just a claim.
 
**Robustness: narrow service-layer catches, log instead of
System.err**
Broad `catch (RuntimeException)` blocks were hiding root causes
and the error-reporting path itself was not robust. Catches are
now narrowed to the exceptions that can actually occur, and
failures go through a logger.
 
**i18n / styling consistency**
ActiveLoansCard now uses the StyledText access point instead of
raw label styling; the notification week label is routed through
LanguageManager so it actually switches language. Component-
specific styling that genuinely differs is documented as such
rather than disguised as a shared role.
 
**Tests: aligned to current saveGame signature; MoneyFormatter
locale fix**
The saveGame signature had changed; stale test call sites were
updated (production was already correct — these were stale tests,
not a production bug). The same work surfaced a latent
cross-platform defect: MoneyFormatter emitted the locale's
Unicode minus while the rest of the app uses ASCII `-`. Centralised
formatting made the fix a one-liner. This is discussed in the
report as a case for platform/locale-deterministic tests and for
step-wise human review of AI-assisted changes.
 
**Docs: test conventions** 
A `test_conventions.md` parallel to the existing SoC and CSS
convention docs. It is normative for new tests (single naming
form, `@Nested` grouping, spec-derived expected values, negative
tests mandatory, lifecycle annotations only where they earn their
place, parsing tested without disk). Pre-existing deviations are
named and deliberately left rather than mechanically rewritten —
a stated, conscious choice.
 
**Tests: CSV parsing tested off disk**
The CSV stock parser's parsing tests now feed in-memory streams
instead of temp files, satisfying the rubric's "test parsing,
not file access". Zero production change — the stream API already
existed on the interface (a Strategy-pattern payoff). The two
genuinely filesystem-level tests (missing file, path-null
contract) are deliberately kept on the Path API because that I/O
behaviour is exactly what they test. Round-trip persistence tests
are intentionally left as integration tests; the JSON handlers
are tracked as a follow-up issue.
 
## Deliberate non-changes (recorded, not oversights)
 
- GameService breadth left as-is - it is orchestration by design;
  splitting it near the deadline is risk without reward.
- Underscore-named tests and banner-grouped tests in a few legacy
  classes left as-is; new code uses the single documented form. (will 
refactor if time)
- JSON-handler round-trip tests stay on disk by design; the
  parse-seam extraction for their *parsing* tests is a tracked
  follow-up, not part of this PR.