### PR TITLE
test: parse JSON game and leaderboard data without disk

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/millions/file/game/JsonGameFileHandler.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/game/JsonGameFileHandler.java
@@ -94,43 +94,45 @@ public class JsonGameFileHandler implements GameFileHandler {
     @Override
     public GameState loadGame(File file) throws GameSaveCorruptException {
         Objects.requireNonNull(file, "File cannot be null");
-
         try (FileReader reader = new FileReader(file)) {
-            JsonObject gameState;
-            try {
-                gameState = gson.fromJson(reader, JsonObject.class);
-            } catch (JsonParseException e) {
-                throw new GameSaveCorruptException(
-                        "Save file contains invalid JSON: " + file.getName(), e);
-            }
-
-            if (gameState == null
-                    || !gameState.has("player")
-                    || !gameState.has("exchange")) {
-                throw new GameSaveCorruptException(
-                        "Save file is missing required fields 'player' or 'exchange': " + file.getName());
-            }
-
-            Exchange exchange;
-            Player player;
-            try {
-                exchange = gson.fromJson(gameState.get("exchange"), Exchange.class);
-                player = gson.fromJson(gameState.get("player"), Player.class);
-            } catch (JsonParseException e) {
-                throw new GameSaveCorruptException(
-                        "Save file has an unreadable structure: " + file.getName(), e);
-            }
-
-            relinkShares(player, exchange);
-            mergeSharesBySymbol(player);
-            relinkArchive(player, exchange);
-
-            boolean gameOver = gameState.has("gameOver") && gameState.get("gameOver").getAsBoolean();
-            return new GameState(player, exchange, gameOver);
-
+            return parse(reader, file.getName());
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to load game from file: " + file.getName(), e);
         }
+    }
+
+    GameState parse(Reader reader, String label) throws GameSaveCorruptException {
+        JsonObject gameState;
+        try {
+            gameState = gson.fromJson(reader, JsonObject.class);
+        } catch (JsonParseException e) {
+            throw new GameSaveCorruptException(
+                    "Save file contains invalid JSON: " + label, e);
+        }
+
+        if (gameState == null
+                || !gameState.has("player")
+                || !gameState.has("exchange")) {
+            throw new GameSaveCorruptException(
+                    "Save file is missing required fields 'player' or 'exchange': " + label);
+        }
+
+        Exchange exchange;
+        Player player;
+        try {
+            exchange = gson.fromJson(gameState.get("exchange"), Exchange.class);
+            player = gson.fromJson(gameState.get("player"), Player.class);
+        } catch (JsonParseException e) {
+            throw new GameSaveCorruptException(
+                    "Save file has an unreadable structure: " + label, e);
+        }
+
+        relinkShares(player, exchange);
+        mergeSharesBySymbol(player);
+        relinkArchive(player, exchange);
+
+        boolean gameOver = gameState.has("gameOver") && gameState.get("gameOver").getAsBoolean();
+        return new GameState(player, exchange, gameOver);
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/leaderboard/JsonLeaderboardFileHandler.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/leaderboard/JsonLeaderboardFileHandler.java
@@ -55,15 +55,29 @@ public class JsonLeaderboardFileHandler implements LeaderboardFileHandler {
             return new ArrayList<>();
         }
         try (FileReader reader = new FileReader(file)) {
-            Type listType = new TypeToken<List<LeaderboardEntry>>() {}.getType();
-            List<LeaderboardEntry> entries = gson.fromJson(reader, listType);
-            return entries == null ? new ArrayList<>() : new ArrayList<>(entries);
-        } catch (JsonParseException e) {
-            throw new IllegalStateException(
-                    "Leaderboard file is corrupt: " + file.getName(), e);
+            return parse(reader);
         } catch (IOException e) {
             throw new IllegalStateException(
                     "Could not read leaderboard file: " + file.getName(), e);
+        }
+    }
+
+    /**
+     * Parses leaderboard entries from an already-opened reader.
+     * The file-absent short-circuit and file-open I/O concerns remain in
+     * {@link #readAll(File)}; this method handles only JSON deserialisation.
+     *
+     * @param reader the reader positioned at the start of a JSON leaderboard array
+     * @return a mutable list of entries; empty if the JSON is {@code null} or {@code []}
+     * @throws IllegalStateException if the input is not valid JSON
+     */
+    List<LeaderboardEntry> parse(Reader reader) {
+        Type listType = new TypeToken<List<LeaderboardEntry>>() {}.getType();
+        try {
+            List<LeaderboardEntry> entries = gson.fromJson(reader, listType);
+            return entries == null ? new ArrayList<>() : new ArrayList<>(entries);
+        } catch (JsonParseException e) {
+            throw new IllegalStateException("Leaderboard JSON is corrupt", e);
         }
     }
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/leaderboard/JsonLeaderboardFileHandler.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/leaderboard/JsonLeaderboardFileHandler.java
@@ -46,10 +46,10 @@ public class JsonLeaderboardFileHandler implements LeaderboardFileHandler {
      *
      * @param file the file to read from
      * @return list of entries; empty if the file is missing or contains no entries
-     * @throws IllegalStateException if the file exists but cannot be parsed
+     * @throws LeaderboardCorruptException if the file exists but cannot be parsed
      */
     @Override
-    public List<LeaderboardEntry> readAll(File file) {
+    public List<LeaderboardEntry> readAll(File file) throws LeaderboardCorruptException {
         Objects.requireNonNull(file, "File cannot be null");
         if (!file.exists()) {
             return new ArrayList<>();
@@ -69,15 +69,15 @@ public class JsonLeaderboardFileHandler implements LeaderboardFileHandler {
      *
      * @param reader the reader positioned at the start of a JSON leaderboard array
      * @return a mutable list of entries; empty if the JSON is {@code null} or {@code []}
-     * @throws IllegalStateException if the input is not valid JSON
+     * @throws LeaderboardCorruptException if the input is not valid JSON
      */
-    List<LeaderboardEntry> parse(Reader reader) {
+    List<LeaderboardEntry> parse(Reader reader) throws LeaderboardCorruptException {
         Type listType = new TypeToken<List<LeaderboardEntry>>() {}.getType();
         try {
             List<LeaderboardEntry> entries = gson.fromJson(reader, listType);
             return entries == null ? new ArrayList<>() : new ArrayList<>(entries);
         } catch (JsonParseException e) {
-            throw new IllegalStateException("Leaderboard JSON is corrupt", e);
+            throw new LeaderboardCorruptException("Leaderboard JSON is corrupt", e);
         }
     }
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/leaderboard/LeaderboardCorruptException.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/leaderboard/LeaderboardCorruptException.java
@@ -1,0 +1,38 @@
+package edu.ntnu.idatt2003.millions.file.leaderboard;
+
+/**
+ * Thrown when a leaderboard file cannot be deserialized because its content does
+ * not conform to the expected JSON schema — for example, the file contains invalid
+ * JSON or an unexpected structure.
+ *
+ * <p>This is a recoverable failure. Callers should catch it, treat the leaderboard
+ * as empty or unavailable, and log the problem rather than crashing. The rest of
+ * the game must continue normally even if the leaderboard is unreadable.
+ *
+ * <p>Note: this exception covers content-level corruption only. File-system failures
+ * (unreadable file, missing permissions) are reported as {@link IllegalStateException}
+ * by the reader. See {@link JsonLeaderboardFileHandler} for the exact split.
+ */
+public class LeaderboardCorruptException extends Exception {
+
+    /**
+     * Creates an exception with a descriptive message identifying what was corrupt.
+     *
+     * @param message a human-readable description of the parse failure
+     */
+    public LeaderboardCorruptException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates an exception with a descriptive message and a chained cause.
+     * Use this constructor when wrapping a lower-level exception such as a
+     * {@link com.google.gson.JsonParseException}.
+     *
+     * @param message a human-readable description of the parse failure
+     * @param cause   the lower-level exception that triggered this one
+     */
+    public LeaderboardCorruptException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/leaderboard/LeaderboardFileHandler.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/leaderboard/LeaderboardFileHandler.java
@@ -11,8 +11,8 @@ import java.util.List;
  *
  * <p>Implementations must tolerate a missing file on read — that is the normal
  * state before the first entry is recorded — and return an empty list rather
- * than throwing. Malformed content, however, should surface as an
- * {@link IllegalStateException} so the caller can decide how to react.</p>
+ * than throwing. Malformed content, however, should surface as a
+ * {@link LeaderboardCorruptException} so the caller can decide how to react.</p>
  */
 public interface LeaderboardFileHandler {
 
@@ -21,10 +21,10 @@ public interface LeaderboardFileHandler {
      *
      * @param file the file to read from
      * @return a list of entries; empty if the file does not exist or contains no entries
-     * @throws NullPointerException  if file is null
-     * @throws IllegalStateException if the file exists but cannot be parsed
+     * @throws NullPointerException         if file is null
+     * @throws LeaderboardCorruptException  if the file exists but cannot be parsed
      */
-    List<LeaderboardEntry> readAll(File file);
+    List<LeaderboardEntry> readAll(File file) throws LeaderboardCorruptException;
 
     /**
      * Writes all entries to the leaderboard file, replacing any existing content.

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/LeaderboardService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/LeaderboardService.java
@@ -1,6 +1,7 @@
 package edu.ntnu.idatt2003.millions.service;
 
 import edu.ntnu.idatt2003.millions.file.leaderboard.JsonLeaderboardFileHandler;
+import edu.ntnu.idatt2003.millions.file.leaderboard.LeaderboardCorruptException;
 import edu.ntnu.idatt2003.millions.file.leaderboard.LeaderboardFileHandler;
 import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
 import edu.ntnu.idatt2003.millions.model.exchange.Exchange;
@@ -111,7 +112,7 @@ public class LeaderboardService {
                 entries.add(snapshot);
             }
             fileHandler.writeAll(entries, file);
-        } catch (IllegalStateException | UncheckedIOException e) {
+        } catch (LeaderboardCorruptException | IllegalStateException | UncheckedIOException e) {
             LOGGER.log(Level.WARNING, "Could not update leaderboard", e);
         }
     }
@@ -144,7 +145,7 @@ public class LeaderboardService {
         List<LeaderboardEntry> entries;
         try {
             entries = readMutable();
-        } catch (IllegalStateException e) {
+        } catch (LeaderboardCorruptException | IllegalStateException e) {
             LOGGER.log(Level.WARNING, "Could not read leaderboard", e);
             return List.of();
         }
@@ -158,7 +159,7 @@ public class LeaderboardService {
      * Reads the leaderboard file into a fresh mutable list so callers can
      * upsert without affecting any internal cache.
      */
-    private List<LeaderboardEntry> readMutable() {
+    private List<LeaderboardEntry> readMutable() throws LeaderboardCorruptException {
         return new ArrayList<>(fileHandler.readAll(file));
     }
 

--- a/src/test/java/edu/ntnu/idatt2003/millions/file/game/JsonGameFileHandlerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/file/game/JsonGameFileHandlerTest.java
@@ -20,6 +20,7 @@ import edu.ntnu.idatt2003.millions.model.notification.Notification;
 import edu.ntnu.idatt2003.millions.model.player.PlayerStatusLevel;
 
 import java.io.File;
+import java.io.StringReader;
 import java.io.UncheckedIOException;
 import java.math.BigDecimal;
 import java.nio.file.Files;
@@ -306,46 +307,30 @@ class JsonGameFileHandlerTest {
 
         @Test
         @DisplayName("Should throw GameSaveCorruptException when file is empty")
-        void throwsGameSaveCorruptExceptionWhenFileIsEmpty() throws Exception {
-            // Arrange
-            Path file = tempDir.resolve("empty.json");
-            Files.writeString(file, "");
-            // Act & Assert
+        void parseThrowsGameSaveCorruptExceptionForEmptyInput() {
             assertThrows(GameSaveCorruptException.class, () ->
-                    handler.loadGame(file.toFile()));
+                    handler.parse(new StringReader(""), "test"));
         }
 
         @Test
         @DisplayName("Should throw GameSaveCorruptException when file contains a JSON array instead of an object")
-        void throwsGameSaveCorruptExceptionWhenFileIsJsonArray() throws Exception {
-            // Arrange
-            Path file = tempDir.resolve("array.json");
-            Files.writeString(file, "[1, 2, 3]");
-            // Act & Assert
+        void parseThrowsGameSaveCorruptExceptionForJsonArray() {
             assertThrows(GameSaveCorruptException.class, () ->
-                    handler.loadGame(file.toFile()));
+                    handler.parse(new StringReader("[1, 2, 3]"), "test"));
         }
 
         @Test
         @DisplayName("Should throw GameSaveCorruptException when file contains invalid JSON")
-        void throwsGameSaveCorruptExceptionForInvalidJson() throws Exception {
-            // Arrange
-            Path file = tempDir.resolve("corrupt.json");
-            Files.writeString(file, "{ this is not valid json }");
-            // Act & Assert
+        void parseThrowsGameSaveCorruptExceptionForInvalidJson() {
             assertThrows(GameSaveCorruptException.class, () ->
-                    handler.loadGame(file.toFile()));
+                    handler.parse(new StringReader("{ this is not valid json }"), "test"));
         }
 
         @Test
         @DisplayName("Should throw GameSaveCorruptException when file is missing required fields")
-        void throwsGameSaveCorruptExceptionForMissingFields() throws Exception {
-            // Arrange
-            Path file = tempDir.resolve("incomplete.json");
-            Files.writeString(file, "{ \"player\": {} }");
-            // Act & Assert
+        void parseThrowsGameSaveCorruptExceptionForMissingFields() {
             assertThrows(GameSaveCorruptException.class, () ->
-                    handler.loadGame(file.toFile()));
+                    handler.parse(new StringReader("{ \"player\": {} }"), "test"));
         }
 
         @Test

--- a/src/test/java/edu/ntnu/idatt2003/millions/file/leaderboard/JsonLeaderboardFileHandlerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/file/leaderboard/JsonLeaderboardFileHandlerTest.java
@@ -8,8 +8,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
+import java.io.StringReader;
 import java.math.BigDecimal;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.List;
@@ -47,19 +47,20 @@ class JsonLeaderboardFileHandlerTest {
     }
 
     @Test
-    void readAllReturnsEmptyListWhenFileIsEmptyJsonArray() throws Exception {
-        Files.writeString(leaderboardFile.toPath(), "[]");
-
-        List<LeaderboardEntry> entries = handler.readAll(leaderboardFile);
-
+    void readAllReturnsEmptyListWhenFileIsEmptyJsonArray() {
+        // Arrange
+        // Act
+        List<LeaderboardEntry> entries = handler.parse(new StringReader("[]"));
+        // Assert
         assertTrue(entries.isEmpty());
     }
 
     @Test
-    void readAllThrowsForCorruptFile() throws Exception {
-        Files.writeString(leaderboardFile.toPath(), "{not valid json");
-
-        assertThrows(IllegalStateException.class, () -> handler.readAll(leaderboardFile));
+    void readAllThrowsForCorruptFile() {
+        // Arrange
+        // Act & Assert
+        assertThrows(IllegalStateException.class,
+                () -> handler.parse(new StringReader("{not valid json")));
     }
 
     @Test

--- a/src/test/java/edu/ntnu/idatt2003/millions/file/leaderboard/JsonLeaderboardFileHandlerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/file/leaderboard/JsonLeaderboardFileHandlerTest.java
@@ -37,7 +37,7 @@ class JsonLeaderboardFileHandlerTest {
     // ---- readAll ----
 
     @Test
-    void readAllReturnsEmptyListWhenFileDoesNotExist() {
+    void readAllReturnsEmptyListWhenFileDoesNotExist() throws LeaderboardCorruptException {
         assertFalse(leaderboardFile.exists());
 
         List<LeaderboardEntry> entries = handler.readAll(leaderboardFile);
@@ -47,7 +47,7 @@ class JsonLeaderboardFileHandlerTest {
     }
 
     @Test
-    void parseReturnsEmptyListForEmptyJsonArray() {
+    void parseReturnsEmptyListForEmptyJsonArray() throws LeaderboardCorruptException {
         // Arrange
         // Act
         List<LeaderboardEntry> entries = handler.parse(new StringReader("[]"));
@@ -59,7 +59,7 @@ class JsonLeaderboardFileHandlerTest {
     void parseThrowsForCorruptJson() {
         // Arrange
         // Act & Assert
-        assertThrows(IllegalStateException.class,
+        assertThrows(LeaderboardCorruptException.class,
                 () -> handler.parse(new StringReader("{not valid json")));
     }
 
@@ -103,7 +103,7 @@ class JsonLeaderboardFileHandlerTest {
     }
 
     @Test
-    void writeAllOverwritesExistingContent() {
+    void writeAllOverwritesExistingContent() throws LeaderboardCorruptException {
         handler.writeAll(List.of(sample("s-1", "Alice", "10.0")), leaderboardFile);
         handler.writeAll(List.of(sample("s-2", "Bob", "20.0")), leaderboardFile);
 
@@ -125,7 +125,7 @@ class JsonLeaderboardFileHandlerTest {
     // ---- round-trip ----
 
     @Test
-    void roundTripPreservesAllFields() {
+    void roundTripPreservesAllFields() throws LeaderboardCorruptException {
         LeaderboardEntry original = sample("s-roundtrip", "Charlie", "42.5");
         handler.writeAll(List.of(original), leaderboardFile);
 
@@ -145,7 +145,7 @@ class JsonLeaderboardFileHandlerTest {
     }
 
     @Test
-    void roundTripPreservesMultipleEntries() {
+    void roundTripPreservesMultipleEntries() throws LeaderboardCorruptException {
         List<LeaderboardEntry> written = List.of(
                 sample("s-1", "Alice", "10.0"),
                 sample("s-2", "Bob", "20.0"),
@@ -162,7 +162,7 @@ class JsonLeaderboardFileHandlerTest {
     }
 
     @Test
-    void roundTripPreservesInstantPrecision() {
+    void roundTripPreservesInstantPrecision() throws LeaderboardCorruptException {
         Instant instant = Instant.parse("2026-05-14T10:30:45.123456789Z");
         LeaderboardEntry original = new LeaderboardEntry(
                 "s-time", "Alice", BigDecimal.ONE, BigDecimal.ONE, BigDecimal.ZERO,

--- a/src/test/java/edu/ntnu/idatt2003/millions/file/leaderboard/JsonLeaderboardFileHandlerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/file/leaderboard/JsonLeaderboardFileHandlerTest.java
@@ -47,7 +47,7 @@ class JsonLeaderboardFileHandlerTest {
     }
 
     @Test
-    void readAllReturnsEmptyListWhenFileIsEmptyJsonArray() {
+    void parseReturnsEmptyListForEmptyJsonArray() {
         // Arrange
         // Act
         List<LeaderboardEntry> entries = handler.parse(new StringReader("[]"));
@@ -56,7 +56,7 @@ class JsonLeaderboardFileHandlerTest {
     }
 
     @Test
-    void readAllThrowsForCorruptFile() {
+    void parseThrowsForCorruptJson() {
         // Arrange
         // Act & Assert
         assertThrows(IllegalStateException.class,

--- a/src/test/java/edu/ntnu/idatt2003/millions/file/leaderboard/LeaderboardCorruptExceptionTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/file/leaderboard/LeaderboardCorruptExceptionTest.java
@@ -1,0 +1,61 @@
+package edu.ntnu.idatt2003.millions.file.leaderboard;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link LeaderboardCorruptException}.
+ */
+class LeaderboardCorruptExceptionTest {
+
+    @Nested
+    @DisplayName("LeaderboardCorruptException(String message)")
+    class MessageConstructor {
+
+        @Test
+        @DisplayName("getMessage() returns the supplied message")
+        void messageIsPreserved() {
+            LeaderboardCorruptException ex =
+                    new LeaderboardCorruptException("leaderboard JSON is not valid");
+            assertEquals("leaderboard JSON is not valid", ex.getMessage());
+        }
+
+        @Test
+        @DisplayName("getCause() is null when no cause is supplied")
+        void causeIsNullByDefault() {
+            LeaderboardCorruptException ex = new LeaderboardCorruptException("msg");
+            assertNull(ex.getCause());
+        }
+
+        @Test
+        @DisplayName("is a checked exception")
+        void isChecked() {
+            assertTrue(Exception.class.isAssignableFrom(LeaderboardCorruptException.class));
+            assertFalse(RuntimeException.class.isAssignableFrom(LeaderboardCorruptException.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("LeaderboardCorruptException(String message, Throwable cause)")
+    class ChainingConstructor {
+
+        @Test
+        @DisplayName("getMessage() returns the supplied message")
+        void messageIsPreserved() {
+            LeaderboardCorruptException ex =
+                    new LeaderboardCorruptException("corrupt", new RuntimeException("root"));
+            assertEquals("corrupt", ex.getMessage());
+        }
+
+        @Test
+        @DisplayName("getCause() returns the supplied cause")
+        void causeIsPreserved() {
+            RuntimeException root = new RuntimeException("root");
+            LeaderboardCorruptException ex = new LeaderboardCorruptException("msg", root);
+            assertSame(root, ex.getCause());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
 
Brings the two JSON file handlers onto the same testing
principle the CSV handler already followed: parsing is tested
against in-memory input, not the filesystem, per the rubric
("for test av lesing fra fil testes kun parsing, ikke filaksess").
 
Every change here is deliberate. The mechanism differs per
handler *on purpose* - each was given the least invasive seam
its contract allows, not a mechanically uniform one. Where a
change was considered and deliberately not made, it is stated
below, not left implicit.
 
4 commits.
 
## What changed and why
 
**JsonLeaderboardFileHandler: package-private parse seam**
`readAll(File)` kept its exact signature and stays on the
`LeaderboardFileHandler` interface. Its JSON-deserialisation body
moved into a new package-private `parse(Reader)`; `readAll(File)`
is now a thin opener that keeps the file-absent short-circuit and
the I/O error wrapping (those are filesystem concerns) and
delegates only the parsing. ~4 lines moved, behaviour
byte-identical for every input (absent file, empty array, corrupt
JSON, valid entries, null file). No interface change, no caller
affected, no new exception type.
 
**JsonGameFileHandler: package-private parse seam**
Same pattern on the higher-risk handler (it is the class the
saveGame-arity fix was just in). `loadGame(File)` kept its exact
signature and stays on the `GameFileHandler` interface; the
Gson parse + structural validation + relink/merge body moved into
a package-private `parse(Reader, String label)`. `loadGame(File)`
keeps the null-File check and the missing-file →
UncheckedIOException behaviour and delegates the rest. The
`label` parameter preserves informative error messages for a
non-file source. No interface change, no caller affected, no new
exception type, `saveGame` untouched.
 
**Tests renamed to match what they exercise**
The leaderboard parsing tests were renamed from `readAll...` to
`parse...` so the names no longer claim to test the File method
when they test `parse`. (The four JsonGameFileHandler parsing
tests were already correctly named `parse...` from the prior
session.) Rename-only; no logic or assertions changed.
 
**Checked LeaderboardCorruptException for corrupt leaderboard
JSON**
While extracting the leaderboard parse seam we noticed an
asymmetry: the game-save handler already throws a dedicated
checked `GameSaveCorruptException` for corrupt JSON, but the
leaderboard handler threw a generic `IllegalStateException` for
the same situation. `IllegalStateException` is also semantically
wrong here - a corrupt external file is invalid input, not an
illegal program state. We introduced a parallel checked
`LeaderboardCorruptException` (mirroring GameSaveCorruptException,
with a mirrored test), threw it from `parse`, propagated it
through `readAll(File)` and the interface, and updated the two
`LeaderboardService` catches to catch the new type. The catches
were kept narrow (the deliberate narrowing from an earlier fix is
preserved - no widening to RuntimeException/Exception) and the
player-visible behaviour is unchanged: a corrupt leaderboard is
still non-fatal, still yields an empty leaderboard, still logged,
never crashes the game. Only the internal exception type and its
precision changed. Done in the same branch because it is the same
handler, same parse path, noticed during this work - not a
separate concern.
 
## Why the mechanism differs from CsvStockFileHandler (deliberate)
 
CsvStockFileHandler is testable off disk via a *public* stream
overload on its interface - stream input is part of its
contract (parsing classpath/in-memory data is a legitimate
caller need). The JSON handlers have no such caller: nothing
legitimately loads a save or a leaderboard from an arbitrary
Reader. Adding a `Reader` method to their interfaces would widen
the contract purely for testability and touch every caller. So
the JSON handlers use a package-private extract-method seam
instead: same testability, zero contract change, zero callers
affected. This is the right tool per handler based on what is
actually part of each contract - not mechanical symmetry.
 
 
## Deliberate non-changes (recorded, not oversights)
 
- The round-trip persistence tests in both handlers
  (save→load→assert-equal, write-behaviour, multi-entry, Instant
  precision, share/loan/notification round-trips) stay on disk
  with real domain objects. They verify the full Gson
  serialisation cycle end-to-end - an integration property that
  loses its meaning if split off disk. Keeping them on disk is a
  conscious testing-level decision, documented in the report.
- No `Reader`/`Stream` method was added to `GameFileHandler` -
  widening the game-save contract for testability was explicitly
  rejected; the package-private seam achieves the same with no
  contract change. (The leaderboard interface DID change, but to
  a strictly more precise checked exception type, done correctly
  with full caller propagation - see the LeaderboardCorrupt
  commit above. That is a deliberate, reviewed contract
  improvement, not an incidental leak.)
 