### PR TITLE
chore: add JaCoCo coverage reporting (measurement only)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,24 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.12.0</version>
             </plugin>
+
+            <!-- JaCoCo Coverage Plugin (measurement only - no thresholds) -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.14</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals><goal>prepare-agent</goal></goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals><goal>report</goal></goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
 ## Summary
 
Adds JaCoCo as a coverage *measurement* tool so test coverage can
be inspected and reasoned about (the rubric asks "er
testdekningen fornuftig?"). One commit, one file changed
(`pom.xml`). Deliberately no coverage threshold and no `check`
goal - JaCoCo is an instrument here, not a gate. Nothing can fail
the build on low coverage.
 
## What changed
 
A single `jacoco-maven-plugin` block added to
`<build><plugins>`, following the existing flat-pinned-version
convention already used by the other plugins in this pom:
 
- `prepare-agent` - instruments the code so Surefire records
  what the tests exercise.
- `report` bound to the `test` phase - writes the HTML/CSV
  report automatically on every `mvn test`.
Version **0.8.14** was chosen deliberately: the project compiles
to Java 25 (class file major version 69), and 0.8.14 is the first
JaCoCo release with official Java 25 support. 0.8.13 has only
experimental support and 0.8.12 and earlier fail outright with
"Unsupported class file major version 69". The version is not
arbitrary - it is the minimum that works on this JDK.
 
No `check` goal, no `<rule>`/`<limit>`. No change to Surefire,
the Java version, or any other plugin.
 

## How to read the report
 
After `mvn test`, open `target/site/jacoco/index.html`. Branch
coverage on the business-logic packages (model.calculator,
model.transaction, model.player, model.exchange, service,
file.*) is what matters - not the overall percentage, and not the
view/JavaFX layer or trivial getters/records, which are
expected-low by design and are deliberately not dedicated-tested
per docs/test_conventions.md.
 
## Not in scope (deliberate)
 
This PR only adds the instrument. It does NOT add or change any
test, and it does NOT chase the percentage. The coverage numbers
it surfaces (notably several stateless service classes with low
coverage) are a separate, tracked piece of work to be addressed
with judgement in the test phase - measuring first, then deciding
which gaps are real business-critical holes versus
expected-low-by-design. Adding the measurement and acting on it
are kept as two separate concerns.