### PR TITLE
fix: watchlist column swap

### DIFF
--- a/leaderboard.json
+++ b/leaderboard.json
@@ -3,12 +3,12 @@
     "sessionId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
     "playerName": "Alva",
     "startingCapital": 10000.00,
-    "finalNetWorth": 12584.3503,
-    "returnPercent": 25.8,
-    "weeksPlayed": 48,
+    "finalNetWorth": 12573.4871,
+    "returnPercent": 25.7,
+    "weeksPlayed": 45,
     "status": "NOVICE",
     "outcome": "ACTIVE",
-    "lastUpdated": "2026-05-16T04:26:16.681206900Z"
+    "lastUpdated": "2026-05-16T20:56:59.744024300Z"
   },
   {
     "sessionId": "80651cf1-aef5-4e63-b1b9-96c109f64730",

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/watchlist/WatchlistRowRenderer.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/watchlist/WatchlistRowRenderer.java
@@ -104,8 +104,8 @@ class WatchlistRowRenderer extends RowRenderer {
         GridPane.setValignment(highLowLabel, VPos.TOP);
         GridPane.setValignment(sparkline, VPos.TOP);
         GridPane.setValignment(actions, VPos.TOP);
-        GridPane.setValignment(noteButton, VPos.TOP);
-        GridPane.setValignment(removeButton, VPos.TOP);
+        GridPane.setValignment(noteButton, VPos.CENTER);
+        GridPane.setValignment(removeButton, VPos.CENTER);
 
         Node[] cells = {tickerLabel, companyLabel, currencyLabel, priceAltLabel, priceNokLabel,
                 changeNokLabel, changePctLabel, highLowLabel, sparkline,

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/watchlist/WatchlistRowRenderer.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/watchlist/WatchlistRowRenderer.java
@@ -5,7 +5,6 @@ import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
 import edu.ntnu.idatt2003.millions.model.stock.Stock;
 import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.util.ChangeFormatter;
-import edu.ntnu.idatt2003.millions.util.CurrencyFormatter;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
 import edu.ntnu.idatt2003.millions.util.TableCells;
 import edu.ntnu.idatt2003.millions.view.component.RowRenderer;
@@ -79,13 +78,9 @@ class WatchlistRowRenderer extends RowRenderer {
         Label companyLabel = TableCells.data(stock.getCompany());
 
         BigDecimal priceNok = converter.convert(stock.getSalesPrice(), stock.getCurrency(), NOK);
-        Label priceNokLabel = TableCells.data(
-                ChangeFormatter.formatPlain(priceNok)
-                        + " " + CurrencyFormatter.symbol("NOK"));
-
-        Label priceAltLabel = TableCells.data(
-                ChangeFormatter.formatPlain(stock.getSalesPrice())
-                        + " " + CurrencyFormatter.symbol(stock.getCurrency()));
+        Label priceNokLabel = TableCells.data(ChangeFormatter.formatPlain(priceNok));
+        Label currencyLabel = TableCells.data(stock.getCurrency().getCurrencyCode());
+        Label priceAltLabel = TableCells.data(ChangeFormatter.formatPlain(stock.getSalesPrice()));
 
         BigDecimal changeNok = converter.convert(stock.getLatestPriceChange(), stock.getCurrency(), NOK);
         Label changeNokLabel = ChangeFormatter.styledAmount(changeNok, "holdings-cell");
@@ -104,6 +99,7 @@ class WatchlistRowRenderer extends RowRenderer {
         GridPane.setValignment(tickerLabel, VPos.TOP);
         GridPane.setValignment(companyLabel, VPos.TOP);
         GridPane.setValignment(priceNokLabel, VPos.TOP);
+        GridPane.setValignment(currencyLabel, VPos.TOP);
         GridPane.setValignment(priceAltLabel, VPos.TOP);
         GridPane.setValignment(changeNokLabel, VPos.TOP);
         GridPane.setValignment(changePctLabel, VPos.TOP);
@@ -114,7 +110,7 @@ class WatchlistRowRenderer extends RowRenderer {
         GridPane.setValignment(noteButton, VPos.TOP);
         GridPane.setValignment(removeButton, VPos.TOP);
 
-        Node[] cells = {tickerLabel, companyLabel, priceAltLabel, priceNokLabel,
+        Node[] cells = {tickerLabel, companyLabel, priceNokLabel, currencyLabel, priceAltLabel,
                 changeNokLabel, changePctLabel, highLowLabel, sparkline,
                 addedWeekLabel, actions, noteButton, removeButton};
         table.addRow(rowIndex, cells);

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/watchlist/WatchlistRowRenderer.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/watchlist/WatchlistRowRenderer.java
@@ -90,8 +90,6 @@ class WatchlistRowRenderer extends RowRenderer {
 
         SparklineChart sparkline = buildSparkline(stock, MAX_SPARKLINE_WEEKS);
 
-        Label addedWeekLabel = TableCells.data(String.valueOf(item.entry().addedAtWeek()));
-
         HBox actions = buildActionButtons(item);
         Button noteButton = buildNoteButton(item);
         Button removeButton = buildRemoveButton(stock.getSymbol());
@@ -105,14 +103,13 @@ class WatchlistRowRenderer extends RowRenderer {
         GridPane.setValignment(changePctLabel, VPos.TOP);
         GridPane.setValignment(highLowLabel, VPos.TOP);
         GridPane.setValignment(sparkline, VPos.TOP);
-        GridPane.setValignment(addedWeekLabel, VPos.TOP);
         GridPane.setValignment(actions, VPos.TOP);
         GridPane.setValignment(noteButton, VPos.TOP);
         GridPane.setValignment(removeButton, VPos.TOP);
 
-        Node[] cells = {tickerLabel, companyLabel, priceNokLabel, currencyLabel, priceAltLabel,
+        Node[] cells = {tickerLabel, companyLabel, currencyLabel, priceAltLabel, priceNokLabel,
                 changeNokLabel, changePctLabel, highLowLabel, sparkline,
-                addedWeekLabel, actions, noteButton, removeButton};
+                actions, noteButton, removeButton};
         table.addRow(rowIndex, cells);
     }
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/watchlist/WatchlistSort.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/watchlist/WatchlistSort.java
@@ -2,7 +2,6 @@ package edu.ntnu.idatt2003.millions.view.dashboard.watchlist;
 
 import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
 import edu.ntnu.idatt2003.millions.model.stock.Stock;
-import edu.ntnu.idatt2003.millions.model.watchlist.WatchlistEntry;
 import edu.ntnu.idatt2003.millions.view.component.table.SortProvider;
 import edu.ntnu.idatt2003.millions.view.component.table.TableColumnDef;
 import java.util.List;
@@ -15,9 +14,9 @@ import java.util.Objects;
 /**
  * Defines sortable columns and comparators for the watchlist table.
  *
- * <p>Operates on {@link WatchlistItem} so both {@link Stock} data and {@link WatchlistEntry} metadata
- * are available for sorting. Column labels are resolved via {@link LanguageManager}
- * on every call so language changes are picked up automatically.</p>
+ * <p>Operates on {@link WatchlistItem} so {@link Stock} data is available for sorting.
+ * Column labels are resolved via {@link LanguageManager} on every call so language
+ * changes are picked up automatically.</p>
  */
 class WatchlistSort extends SortProvider<WatchlistItem, WatchlistSort.SortColumn> {
 
@@ -28,7 +27,7 @@ class WatchlistSort extends SortProvider<WatchlistItem, WatchlistSort.SortColumn
      * Columns that support ascending/descending sort in the watchlist table.
      */
     enum SortColumn {
-        TICKER, COMPANY, PRICE_NOK, CURRENCY, PRICE_ALT, CHANGE_NOK, CHANGE_PCT, HIGH_LOW, ADDED_WEEK
+        TICKER, COMPANY, CURRENCY, PRICE_ALT, PRICE_NOK, CHANGE_NOK, CHANGE_PCT, HIGH_LOW
     }
 
     private final CurrencyConverter converter;
@@ -46,26 +45,22 @@ class WatchlistSort extends SortProvider<WatchlistItem, WatchlistSort.SortColumn
     /**
      * Returns the ordered column definitions for the watchlist table.
      *
-     * <p>The alternative-currency column header is formatted lazily with the
-     * currently active currency code from {@link CurrencyManager} so it updates
-     * automatically on every header refresh.</p>
-     *
      * @return a fresh list of {@link TableColumnDef} in display order
      */
     @Override
     public List<TableColumnDef<SortColumn>> getColumnDefs() {
         return List.of(
                 TableColumnDef.sortable(
-                        "col.ticker", SortColumn.TICKER, 10, HPos.LEFT),
+                        "col.ticker", SortColumn.TICKER, 8, HPos.LEFT),
                 TableColumnDef.sortable(
-                        "col.company", SortColumn.COMPANY, 18, HPos.LEFT),
+                        "col.company", SortColumn.COMPANY, 24, HPos.LEFT),
+                TableColumnDef.sortable("col.currency", SortColumn.CURRENCY, 7, HPos.LEFT),
+                TableColumnDef.sortable("col.priceNative", SortColumn.PRICE_ALT, 8, HPos.RIGHT),
                 TableColumnDef.sortable(
-                        "col.priceNok", SortColumn.PRICE_NOK, 14, HPos.RIGHT),
-                TableColumnDef.sortable("col.currency", SortColumn.CURRENCY, 6, HPos.LEFT),
-                TableColumnDef.sortable("col.priceNative", SortColumn.PRICE_ALT, 14, HPos.RIGHT),
+                        "col.priceNok", SortColumn.PRICE_NOK, 10, HPos.RIGHT),
                 TableColumnDef.sortable(
                         "col.changeNok", SortColumn.CHANGE_NOK,
-                        "tooltip.shared.changeNok", 10, HPos.RIGHT),
+                        "tooltip.shared.changeNok", 11, HPos.RIGHT),
                 TableColumnDef.sortable(
                         "col.changePct", SortColumn.CHANGE_PCT,
                         "tooltip.shared.weeklyChange", 10, HPos.RIGHT),
@@ -73,9 +68,7 @@ class WatchlistSort extends SortProvider<WatchlistItem, WatchlistSort.SortColumn
                         "col.highLow", SortColumn.HIGH_LOW,
                         "tooltip.shared.highLow", 10, HPos.RIGHT),
                 TableColumnDef.of("col.trend", "tooltip.shared.trend", 12, HPos.CENTER),
-                TableColumnDef.sortable(
-                        "col.addedWeek", SortColumn.ADDED_WEEK, 10, HPos.CENTER),
-                TableColumnDef.of("col.trade", 10, HPos.CENTER),
+                TableColumnDef.of("col.trade", 7, HPos.CENTER),
                 TableColumnDef.of("col.note", 7, HPos.CENTER),
                 TableColumnDef.spacer(3, HPos.CENTER)
         );
@@ -92,13 +85,12 @@ class WatchlistSort extends SortProvider<WatchlistItem, WatchlistSort.SortColumn
         return switch (column) {
             case TICKER -> Comparator.comparing(i -> i.stock().getSymbol());
             case COMPANY -> Comparator.comparing(i -> i.stock().getCompany());
-            case PRICE_NOK -> Comparator.comparing(i -> priceInNok(i.stock(), converter, NOK));
             case CURRENCY -> Comparator.comparing(i -> i.stock().getCurrency().getCurrencyCode());
             case PRICE_ALT -> Comparator.comparing(i -> i.stock().getSalesPrice());
+            case PRICE_NOK -> Comparator.comparing(i -> priceInNok(i.stock(), converter, NOK));
             case CHANGE_NOK -> Comparator.comparing(i -> changeInNok(i.stock(), converter, NOK));
             case CHANGE_PCT -> Comparator.comparing(i -> i.stock().getWeeklyChangePercent());
             case HIGH_LOW -> Comparator.comparing(i -> highLowRange(i.stock(), converter, NOK, HIGH_LOW_WEEKS));
-            case ADDED_WEEK -> Comparator.comparingInt(i -> i.entry().addedAtWeek());
         };
     }
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/watchlist/WatchlistSort.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/watchlist/WatchlistSort.java
@@ -28,7 +28,7 @@ class WatchlistSort extends SortProvider<WatchlistItem, WatchlistSort.SortColumn
      * Columns that support ascending/descending sort in the watchlist table.
      */
     enum SortColumn {
-        TICKER, COMPANY, PRICE_ALT, PRICE_NOK, CHANGE_NOK, CHANGE_PCT, HIGH_LOW, ADDED_WEEK
+        TICKER, COMPANY, PRICE_NOK, CURRENCY, PRICE_ALT, CHANGE_NOK, CHANGE_PCT, HIGH_LOW, ADDED_WEEK
     }
 
     private final CurrencyConverter converter;
@@ -58,10 +58,11 @@ class WatchlistSort extends SortProvider<WatchlistItem, WatchlistSort.SortColumn
                 TableColumnDef.sortable(
                         "col.ticker", SortColumn.TICKER, 10, HPos.LEFT),
                 TableColumnDef.sortable(
-                        "col.company", SortColumn.COMPANY, 20, HPos.LEFT),
+                        "col.company", SortColumn.COMPANY, 18, HPos.LEFT),
                 TableColumnDef.sortable(
-                        "col.priceNok", SortColumn.PRICE_NOK, 15, HPos.RIGHT),
-                TableColumnDef.sortable("col.priceNative", SortColumn.PRICE_ALT, 15, HPos.RIGHT),
+                        "col.priceNok", SortColumn.PRICE_NOK, 14, HPos.RIGHT),
+                TableColumnDef.sortable("col.currency", SortColumn.CURRENCY, 6, HPos.LEFT),
+                TableColumnDef.sortable("col.priceNative", SortColumn.PRICE_ALT, 14, HPos.RIGHT),
                 TableColumnDef.sortable(
                         "col.changeNok", SortColumn.CHANGE_NOK,
                         "tooltip.shared.changeNok", 10, HPos.RIGHT),
@@ -76,7 +77,7 @@ class WatchlistSort extends SortProvider<WatchlistItem, WatchlistSort.SortColumn
                         "col.addedWeek", SortColumn.ADDED_WEEK, 10, HPos.CENTER),
                 TableColumnDef.of("col.trade", 10, HPos.CENTER),
                 TableColumnDef.of("col.note", 7, HPos.CENTER),
-                TableColumnDef.spacer(5, HPos.CENTER)
+                TableColumnDef.spacer(3, HPos.CENTER)
         );
     }
 
@@ -92,6 +93,7 @@ class WatchlistSort extends SortProvider<WatchlistItem, WatchlistSort.SortColumn
             case TICKER -> Comparator.comparing(i -> i.stock().getSymbol());
             case COMPANY -> Comparator.comparing(i -> i.stock().getCompany());
             case PRICE_NOK -> Comparator.comparing(i -> priceInNok(i.stock(), converter, NOK));
+            case CURRENCY -> Comparator.comparing(i -> i.stock().getCurrency().getCurrencyCode());
             case PRICE_ALT -> Comparator.comparing(i -> i.stock().getSalesPrice());
             case CHANGE_NOK -> Comparator.comparing(i -> changeInNok(i.stock(), converter, NOK));
             case CHANGE_PCT -> Comparator.comparing(i -> i.stock().getWeeklyChangePercent());

--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -472,7 +472,6 @@ col.netWorth=Net Worth
 col.weeks=Weeks
 col.status=Status
 col.outcome=Outcome
-col.addedWeek=Week added
 col.note=Note
 
 # Shared table column tooltips

--- a/src/main/resources/i18n/messages_no.properties
+++ b/src/main/resources/i18n/messages_no.properties
@@ -463,7 +463,6 @@ col.netWorth=Nettoverdi
 col.weeks=Uker
 col.status=Status
 col.outcome=Tilstand
-col.addedWeek=Uke lagt til
 col.note=Notat
 
 # Shared table column tooltips


### PR DESCRIPTION
## Why
 
The Watchlist table had its native-price and NOK-price cells
placed under the wrong headers. The "Kurs NOK" header showed the
native (USD) price, and the native-price header showed the
NOK-converted value. Because each column's sort comparator was
correctly paired with its own header, sorting the "Kurs NOK"
column sorted by NOK price while the cell under it displayed the
native value - so header label, sorted order, and visible cell
each described a different quantity. This is a correctness bug,
not a cosmetic one.
 
Separately, the Watchlist table had drifted out of visual
consistency with the Marked table (which PR #248 cleaned up):
currency suffixes on the numbers, no Valuta column, a different
price/currency column order, and a wide low-value "Uke lagt til"
column.
 
## Commit 1 - `fix: correct Watchlist price column/cell alignment and align with Market`
 
The comparators and headers already agreed with each other at
each index; only the cell array order was wrong. Fix: swap the
two price cells in the WatchlistRowRenderer cell array so the
NOK price sits under the "Kurs NOK" header (matching its NOK
comparator) and the native price sits under the native header
(matching its native comparator). Comparators, column
definitions and WatchlistSort were intentionally left untouched
- the correct end state is reached by reordering exactly those
two array elements. Header/cell/comparator alignment was then
re-verified for every index from the actual code order.
 
## Commit 2 - `feat: align Watchlist with Marked (drop suffixes, add Valuta, remove Added-week)`
 
Brings the table into visual consistency with Marked, one
coherent change:
- removed the "Uke lagt til" / Added-week column - wide
  relative to its value, does not inform any in-game decision,
  and the space was needed for the new Valuta column
- dropped the "$"/"kr" suffix from the native and NOK price
  cells (same change PR #248 made to Marked)
- added a Valuta column showing each stock's currency code,
  reusing the shared `col.currency` key (added to both language
  bundles in PR #248)
- reordered the price/currency block to match Marked:
  company → Valuta → Kurs → Kurs NOK, so the currency is
  introduced before the price it applies to
- column widths rebalanced for the new layout
Every column add/remove/reorder was applied synchronously in
WatchlistSort.getColumnDefs() and the WatchlistRowRenderer cell
array, and the full header/cell/comparator alignment was
re-verified - deliberately, so this change could not reintroduce
the very misalignment commit 1 fixed.
 
## Commit 3 — `fix: vertically align Watchlist note and remove icons with row text`
 
The note (pencil) and remove (X) icons sat ~6 px higher than the
row text. Root cause: the holdings-cell CSS applies vertical
padding to text labels, placing their content 10 px from the row
top, while the two icon buttons had no such padding and, with
VPos.TOP, sat ~4 px from the top. Fix: VPos.CENTER on those two
buttons so their content aligns with the label text at any row
height - no hardcoded offset. One file, two lines; no CSS change
(the cause is layout valignment, not button styling).
 