### PR TITLE
refcator: chopped tabnames in startview

### DIFF
--- a/src/main/resources/css/tabs.css
+++ b/src/main/resources/css/tabs.css
@@ -60,6 +60,8 @@
     -fx-background-color: -surface;
     -fx-background-radius: 12;
     -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.08), 16, 0, 0, 2);
+    -fx-tab-min-height: 60;
+    -fx-tab-max-height: 60;
 }
 
 .start-tab-pane > .tab-header-area > .tab-header-background {
@@ -70,6 +72,7 @@
 
 .start-tab-pane > .tab-header-area {
     -fx-background-color: transparent;
+    -fx-padding: 0;
     -fx-pref-height: 60;
     -fx-min-height: 60;
 }


### PR DESCRIPTION
Modena sets `-fx-tab-max-height: 1.8333em` (≈22 px) on every `.tab-pane`.
The TabPaneSkin reads this property directly and resizes tab headers to 22 px
in layout, ignoring the tab node's own CSS `min-height`/`max-height`. With the
start-tab-pane's 22 px font and 2 px bottom border, the content area was only
20 px - not enough to fit the glyphs, so the tab's own clip rect cut the tops
and descenders of every label.

Fix: override `-fx-tab-min-height` and `-fx-tab-max-height` on `.start-tab-pane`
to match the established 60 px header height. Also add `-fx-padding: 0` to
`.start-tab-pane > .tab-header-area` to neutralise Modena's 5 px top inset,
which would otherwise push the 60 px tabs 5 px below the header area boundary
and clip the selected-tab underline.

Only `tabs.css` changed.
