### PR TITLE
test: service classes

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/millions/model/player/Portfolio.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/player/Portfolio.java
@@ -79,12 +79,11 @@ public class Portfolio {
     }
 
     /**
-     * Gets all shares of a specific stock by symbol. The method will return
-     * an empty list if the symbol is null.
+     * Gets all shares of a specific stock by symbol.
+     * Returns an empty list if {@code symbol} is null or no shares match.
      *
-     * @param symbol the stock symbol to filter by
-     * @return a list of shares matching the symbol
-     * @throws NullPointerException if the symbol is null
+     * @param symbol the stock symbol to filter by; null returns an empty list
+     * @return a list of shares whose stock symbol equals {@code symbol}, never null
      */
     public List<Share> getShares(String symbol) {
         if (symbol == null) return List.of();

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/TransactionPreviewService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/TransactionPreviewService.java
@@ -68,6 +68,10 @@ public class TransactionPreviewService {
     public TransactionPreview previewSale(
             Share share, BigDecimal quantity, Player player, CurrencyConverter converter) {
 
+        if (quantity.compareTo(share.getQuantity()) > 0) {
+            throw new IllegalArgumentException(
+                    "Cannot preview selling " + quantity + " shares — position only holds " + share.getQuantity());
+        }
         Share partial = quantity.compareTo(share.getQuantity()) == 0
                 ? share
                 : new Share(share.getStock(), quantity, share.getPurchasePrice());

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/GameService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/GameService.java
@@ -542,7 +542,7 @@ public class GameService {
      */
     public void addToWatchlist(String symbol) {
         Objects.requireNonNull(symbol, "Symbol cannot be null");
-        if (player == null || exchange.getStock(symbol) == null) return;
+        if (player == null || !exchange.hasStock(symbol)) return;
         player.addToWatchlist(new WatchlistEntry(symbol, exchange.getWeek(), ""));
         notifyObservers();
     }

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/transaction/TransactionPreviewServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/transaction/TransactionPreviewServiceTest.java
@@ -1,0 +1,385 @@
+package edu.ntnu.idatt2003.millions.model.transaction;
+
+import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
+import edu.ntnu.idatt2003.millions.model.currency.FixedRateCurrencyConverter;
+import edu.ntnu.idatt2003.millions.model.player.Player;
+import edu.ntnu.idatt2003.millions.model.stock.Share;
+import edu.ntnu.idatt2003.millions.model.stock.Stock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Currency;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link TransactionPreviewService}.
+ * Covers {@link TransactionPreviewService#previewPurchase} and
+ * {@link TransactionPreviewService#previewSale} including the partial-position branch,
+ * currency conversion, and the loss path where tax must be zero.
+ * All tests follow the AAA pattern.
+ */
+class TransactionPreviewServiceTest {
+
+    private static final Currency NOK = Currency.getInstance("NOK");
+    private static final Currency USD = Currency.getInstance("USD");
+
+    private TransactionPreviewService service;
+    private CurrencyConverter converter;
+    private Player player;
+
+    @BeforeEach
+    void setUp() {
+        service = new TransactionPreviewService();
+        converter = new FixedRateCurrencyConverter();
+        player = new Player("Test", new BigDecimal("10000"));
+    }
+
+    private static void assertBigDecimalEquals(BigDecimal expected, BigDecimal actual) {
+        assertEquals(0, expected.compareTo(actual),
+                "Expected " + expected + " but was " + actual);
+    }
+
+    private static Stock nokStock(String price) {
+        return new Stock("TST", "Test Co.", List.of(new BigDecimal(price)), NOK);
+    }
+
+    private static Stock usdStock(String price) {
+        return new Stock("TST", "Test Co.", List.of(new BigDecimal(price)), USD);
+    }
+
+    private static Share share(Stock stock, String qty, String purchasePrice) {
+        return new Share(stock, new BigDecimal(qty), new BigDecimal(purchasePrice));
+    }
+
+    @Nested
+    @DisplayName("previewPurchase()")
+    class PreviewPurchase {
+
+        @Test
+        @DisplayName("Should compute gross as salesPrice times quantity")
+        void computesGrossAsSalesPriceTimesQuantity() {
+            // Arrange - spec: gross = salesPrice × quantity = 100×10 = 1000
+            Stock stock = nokStock("100");
+
+            // Act
+            TransactionPreview preview =
+                    service.previewPurchase(stock, new BigDecimal("10"), player, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("1000"), preview.gross());
+        }
+
+        @Test
+        @DisplayName("Should compute commission as 0.5% of gross for a purchase")
+        void computesHalfPercentCommission() {
+            // Arrange - gross=1000; commission=1000×0.005=5
+            Stock stock = nokStock("100");
+
+            // Act
+            TransactionPreview preview =
+                    service.previewPurchase(stock, new BigDecimal("10"), player, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("5"), preview.commission());
+        }
+
+        @Test
+        @DisplayName("Should return zero tax for a purchase")
+        void returnsZeroTaxForPurchase() {
+            // Arrange - spec: no tax on purchases
+            Stock stock = nokStock("100");
+
+            // Act
+            TransactionPreview preview =
+                    service.previewPurchase(stock, new BigDecimal("10"), player, converter);
+
+            // Assert
+            assertBigDecimalEquals(BigDecimal.ZERO, preview.tax());
+        }
+
+        @Test
+        @DisplayName("Should compute total as gross plus commission")
+        void computesTotalAsGrossPlusCommission() {
+            // Arrange - total = 1000 + 5 = 1005
+            Stock stock = nokStock("100");
+
+            // Act
+            TransactionPreview preview =
+                    service.previewPurchase(stock, new BigDecimal("10"), player, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("1005"), preview.total());
+        }
+
+        @Test
+        @DisplayName("Should compute balanceAfter by subtracting totalInNok from player balance")
+        void subtractsNokTotalFromBalance() {
+            // Arrange - balance=10000, totalInNok=1005 → balanceAfter=8995
+            Stock stock = nokStock("100");
+
+            // Act
+            TransactionPreview preview =
+                    service.previewPurchase(stock, new BigDecimal("10"), player, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("8995"), preview.balanceAfter());
+        }
+
+        @Test
+        @DisplayName("Should return null profit, profitPercent, and profitInNok for a purchase")
+        void returnsNullProfitFieldsForPurchase() {
+            // Arrange - spec: profit fields only apply to sales
+            Stock stock = nokStock("100");
+
+            // Act
+            TransactionPreview preview =
+                    service.previewPurchase(stock, new BigDecimal("10"), player, converter);
+
+            // Assert
+            assertNull(preview.profit());
+            assertNull(preview.profitPercent());
+            assertNull(preview.profitInNok());
+        }
+
+        @Test
+        @DisplayName("Should convert total to NOK and adjust balance when stock is priced in USD")
+        void convertsTotalToNokForUsdStock() {
+            // Arrange - price=100 USD, qty=5: total=502.5 USD
+            // totalInNok = 502.5 × 9.21 = 4628.025 NOK
+            // balanceAfter = 10000 − 4628.025 = 5371.975 NOK
+            Stock stock = usdStock("100");
+
+            // Act
+            TransactionPreview preview =
+                    service.previewPurchase(stock, new BigDecimal("5"), player, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("4628.025"), preview.totalInNok());
+            assertBigDecimalEquals(new BigDecimal("5371.975"), preview.balanceAfter());
+        }
+
+        @Test
+        @DisplayName("Should throw NullPointerException when stock is null")
+        void throwsWhenStockIsNull() {
+            // Act & Assert
+            assertThrows(NullPointerException.class,
+                    () -> service.previewPurchase(null, BigDecimal.ONE, player, converter));
+        }
+
+        @Test
+        @DisplayName("Should throw NullPointerException when quantity is null")
+        void throwsWhenQuantityIsNull() {
+            // Act & Assert
+            assertThrows(NullPointerException.class,
+                    () -> service.previewPurchase(nokStock("100"), null, player, converter));
+        }
+
+        @Test
+        @DisplayName("Should throw IllegalArgumentException when quantity is negative")
+        void throwsWhenQuantityIsNegative() {
+            // Arrange - Share constructor rejects negative quantity
+            Stock stock = nokStock("100");
+
+            // Act & Assert
+            assertThrows(IllegalArgumentException.class,
+                    () -> service.previewPurchase(stock, new BigDecimal("-1"), player, converter));
+        }
+
+        @Test
+        @DisplayName("Should throw NullPointerException when player is null")
+        void throwsWhenPlayerIsNull() {
+            // Act & Assert
+            assertThrows(NullPointerException.class,
+                    () -> service.previewPurchase(nokStock("100"), BigDecimal.ONE, null, converter));
+        }
+    }
+
+    @Nested
+    @DisplayName("previewSale()")
+    class PreviewSale {
+
+        @Test
+        @DisplayName("Should compute tax as 30% of gain for a profitable full-position sale")
+        void computesThirtyPercentTaxOnGainForProfitableSale() {
+            // Arrange - spec: tax = 30% of (gross − commission − purchaseCost)
+            // salePrice=200, qty=10, purchasePrice=100
+            // purchaseCost=1005; gross=2000; commission=20; gain=975; tax=292.5
+            Stock stock = nokStock("200");
+            Share sh = share(stock, "10", "100");
+
+            // Act
+            TransactionPreview preview =
+                    service.previewSale(sh, new BigDecimal("10"), player, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("292.5"), preview.tax());
+        }
+
+        @Test
+        @DisplayName("Should compute net total as gross minus commission minus tax for full position sale")
+        void computesNetTotalForFullPositionSale() {
+            // Arrange - total = 2000 − 20 − 292.5 = 1687.5
+            Stock stock = nokStock("200");
+            Share sh = share(stock, "10", "100");
+
+            // Act
+            TransactionPreview preview =
+                    service.previewSale(sh, new BigDecimal("10"), player, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("1687.5"), preview.total());
+        }
+
+        @Test
+        @DisplayName("Should compute profit as total minus original purchase cost")
+        void computesProfitAsTotalMinusPurchaseCost() {
+            // Arrange - profit = total − purchaseCost = 1687.5 − 1005 = 682.5
+            Stock stock = nokStock("200");
+            Share sh = share(stock, "10", "100");
+
+            // Act
+            TransactionPreview preview =
+                    service.previewSale(sh, new BigDecimal("10"), player, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("682.5"), preview.profit());
+        }
+
+        @Test
+        @DisplayName("Should compute profitPercent as profit over purchaseCost times 100")
+        void computesProfitPercent() {
+            // Arrange - profitPercent = 682.5×100/1005 = 67.9% (1dp HALF_UP)
+            Stock stock = nokStock("200");
+            Share sh = share(stock, "10", "100");
+
+            // Act
+            TransactionPreview preview =
+                    service.previewSale(sh, new BigDecimal("10"), player, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("67.9"), preview.profitPercent());
+        }
+
+        @Test
+        @DisplayName("Should add totalInNok to player balance for a NOK sale")
+        void addsNokTotalToPlayerBalance() {
+            // Arrange - balanceAfter = 10000 + 1687.5 = 11687.5
+            Stock stock = nokStock("200");
+            Share sh = share(stock, "10", "100");
+
+            // Act
+            TransactionPreview preview =
+                    service.previewSale(sh, new BigDecimal("10"), player, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("11687.5"), preview.balanceAfter());
+        }
+
+        @Test
+        @DisplayName("Should return null profitInNok when stock is already NOK")
+        void returnsNullProfitInNokForNokStock() {
+            // Arrange - spec: profitInNok is null when stock currency equals NOK
+            Stock stock = nokStock("200");
+            Share sh = share(stock, "10", "100");
+
+            // Act
+            TransactionPreview preview =
+                    service.previewSale(sh, new BigDecimal("10"), player, converter);
+
+            // Assert
+            assertNull(preview.profitInNok());
+        }
+
+        @Test
+        @DisplayName("Should use the partial quantity when selling less than the full position")
+        void usesPartialQuantityForPartialSale() {
+            // Arrange - selling 5 of 10: partial purchaseCost=502.5, gross=1000,
+            // commission=10, gain=487.5, tax=146.25, total=843.75
+            Stock stock = nokStock("200");
+            Share sh = share(stock, "10", "100");
+
+            // Act
+            TransactionPreview preview =
+                    service.previewSale(sh, new BigDecimal("5"), player, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("843.75"), preview.total());
+            assertBigDecimalEquals(new BigDecimal("10843.75"), preview.balanceAfter());
+        }
+
+        @Test
+        @DisplayName("Should return zero tax when a sale results in a loss")
+        void returnsZeroTaxForLossingSale() {
+            // Arrange - salePrice=50, qty=10, purchasePrice=100
+            // purchaseCost=1005; gross=500; commission=5; gain=−510 → tax=0
+            Stock stock = nokStock("50");
+            Share sh = share(stock, "10", "100");
+
+            // Act
+            TransactionPreview preview =
+                    service.previewSale(sh, new BigDecimal("10"), player, converter);
+
+            // Assert
+            assertBigDecimalEquals(BigDecimal.ZERO, preview.tax());
+        }
+
+        @Test
+        @DisplayName("Should return a negative profit when a sale results in a loss")
+        void returnsNegativeProfitForLossingSale() {
+            // Arrange - total=495; profit = 495 − 1005 = −510
+            Stock stock = nokStock("50");
+            Share sh = share(stock, "10", "100");
+
+            // Act
+            TransactionPreview preview =
+                    service.previewSale(sh, new BigDecimal("10"), player, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("-510"), preview.profit());
+        }
+
+        @Test
+        @DisplayName("Should convert totalInNok and compute profitInNok for a USD stock sale")
+        void convertsTotalAndProfitToNokForUsdStock() {
+            // Arrange - salePrice=200 USD, qty=10, purchasePrice=100 USD
+            // total=1687.5 USD → totalInNok=1687.5×9.21=15541.875 NOK
+            // profit=682.5 USD → profitInNok=682.5×9.21=6285.825 NOK
+            Stock stock = usdStock("200");
+            Share sh = share(stock, "10", "100");
+
+            // Act
+            TransactionPreview preview =
+                    service.previewSale(sh, new BigDecimal("10"), player, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("15541.875"), preview.totalInNok());
+            assertBigDecimalEquals(new BigDecimal("6285.825"), preview.profitInNok());
+            assertBigDecimalEquals(new BigDecimal("25541.875"), preview.balanceAfter());
+        }
+
+        @Test
+        @DisplayName("Should throw NullPointerException when share is null")
+        void throwsWhenShareIsNull() {
+            // Act & Assert
+            assertThrows(NullPointerException.class,
+                    () -> service.previewSale(null, BigDecimal.ONE, player, converter));
+        }
+
+        @Test
+        @DisplayName("Should throw NullPointerException when player is null")
+        void throwsWhenPlayerIsNull() {
+            // Arrange
+            Stock stock = nokStock("100");
+            Share sh = share(stock, "10", "100");
+
+            // Act & Assert
+            assertThrows(NullPointerException.class,
+                    () -> service.previewSale(sh, new BigDecimal("10"), null, converter));
+        }
+    }
+}

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/transaction/TransactionPreviewServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/transaction/TransactionPreviewServiceTest.java
@@ -363,6 +363,18 @@ class TransactionPreviewServiceTest {
         }
 
         @Test
+        @DisplayName("Should throw IllegalArgumentException when quantity exceeds the owned position")
+        void throwsWhenQuantityExceedsOwnedPosition() {
+            // Arrange — share holds qty=10; attempting to preview selling 11 is impossible
+            Stock stock = nokStock("100");
+            Share sh = share(stock, "10", "100");
+
+            // Act & Assert
+            assertThrows(IllegalArgumentException.class,
+                    () -> service.previewSale(sh, new BigDecimal("11"), player, converter));
+        }
+
+        @Test
         @DisplayName("Should throw NullPointerException when share is null")
         void throwsWhenShareIsNull() {
             // Act & Assert

--- a/src/test/java/edu/ntnu/idatt2003/millions/service/GameServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/service/GameServiceTest.java
@@ -698,6 +698,14 @@ class GameServiceTest {
             gameService.loadGame(file.toFile());
             assertFalse(gameService.isGameOver());
         }
+
+        @Test
+        @DisplayName("executeForcedSale() throws IllegalStateException when game is over")
+        void executeForcedSale_throwsWhenGameOver() {
+            gameService.declareGameOver();
+            assertThrows(IllegalStateException.class, () ->
+                    gameService.executeForcedSale(List.of(), 1));
+        }
     }
 
     @Nested
@@ -790,6 +798,156 @@ class GameServiceTest {
         void getCurrentSavePath_isResetOnNewGameCreated() {
             gameService.createNewGame("Ola", new BigDecimal("5000"));
             assertTrue(gameService.getCurrentSaveFile().isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("takeLoan()")
+    class TakeLoan {
+
+        @Test
+        @DisplayName("Should throw NullPointerException when offer is null")
+        void throwsWhenOfferIsNull() {
+            assertThrows(NullPointerException.class, () ->
+                    gameService.takeLoan(null, new BigDecimal("100")));
+        }
+
+        @Test
+        @DisplayName("Should throw NullPointerException when amount is null")
+        void throwsWhenAmountIsNull() {
+            LoanOffer offer = new LoanOffer("t", new BigDecimal("0.01"), 10,
+                    new BigDecimal("9000.00"), LoanRiskLevel.LOW);
+            assertThrows(NullPointerException.class, () ->
+                    gameService.takeLoan(offer, null));
+        }
+    }
+
+    @Nested
+    @DisplayName("repayLoan()")
+    class RepayLoan {
+
+        @Test
+        @DisplayName("Should throw NullPointerException when loan is null")
+        void throwsWhenLoanIsNull() {
+            assertThrows(NullPointerException.class, () ->
+                    gameService.repayLoan(null));
+        }
+    }
+
+    @Nested
+    @DisplayName("addToWatchlist()")
+    class AddToWatchlist {
+
+        @Test
+        @DisplayName("Should add a known stock to the player's watchlist")
+        void addsKnownStockToWatchlist() {
+            gameService.addToWatchlist("EQNR");
+            assertTrue(gameService.getPlayer().isOnWatchlist("EQNR"));
+        }
+
+        @Test
+        @DisplayName("Should be a no-op when the symbol does not exist on the exchange")
+        void isNoOpForUnknownSymbol() {
+            gameService.addToWatchlist("UNKNOWN");
+            assertFalse(gameService.getPlayer().isOnWatchlist("UNKNOWN"));
+        }
+
+        @Test
+        @DisplayName("Should throw NullPointerException when symbol is null")
+        void throwsWhenSymbolIsNull() {
+            assertThrows(NullPointerException.class, () ->
+                    gameService.addToWatchlist(null));
+        }
+    }
+
+    @Nested
+    @DisplayName("removeFromWatchlist()")
+    class RemoveFromWatchlist {
+
+        @Test
+        @DisplayName("Should remove a watchlisted stock from the player's watchlist")
+        void removesWatchlistedStock() {
+            gameService.addToWatchlist("EQNR");
+            assertTrue(gameService.getPlayer().isOnWatchlist("EQNR"));
+            gameService.removeFromWatchlist("EQNR");
+            assertFalse(gameService.getPlayer().isOnWatchlist("EQNR"));
+        }
+
+        @Test
+        @DisplayName("Should throw NullPointerException when symbol is null")
+        void throwsWhenSymbolIsNull() {
+            assertThrows(NullPointerException.class, () ->
+                    gameService.removeFromWatchlist(null));
+        }
+    }
+
+    @Nested
+    @DisplayName("updateWatchlistNote()")
+    class UpdateWatchlistNote {
+
+        @Test
+        @DisplayName("Should update the note for a watchlisted stock")
+        void updatesNoteForWatchlistedStock() {
+            gameService.addToWatchlist("EQNR");
+            gameService.updateWatchlistNote("EQNR", "my note");
+            String note = gameService.getPlayer().getWatchlist().stream()
+                    .filter(e -> e.symbol().equals("EQNR"))
+                    .findFirst()
+                    .orElseThrow()
+                    .note();
+            assertEquals("my note", note);
+        }
+
+        @Test
+        @DisplayName("Should throw NullPointerException when symbol is null")
+        void throwsWhenSymbolIsNull() {
+            assertThrows(NullPointerException.class, () ->
+                    gameService.updateWatchlistNote(null, "note"));
+        }
+    }
+
+    @Nested
+    @DisplayName("clearAllNotifications()")
+    class ClearAllNotifications {
+
+        @Test
+        @DisplayName("Should clear all notifications and notify observers")
+        void clearsNotificationsAndNotifiesObservers() throws ExcessiveDebtException {
+            // Arrange — take a loan expiring in 3 weeks, advance week to push a notification
+            LoanOffer offer = new LoanOffer("std", new BigDecimal("0.001"), 3,
+                    new BigDecimal("50000"), LoanRiskLevel.LOW);
+            gameService.takeLoan(offer, new BigDecimal("1000"));
+            gameService.advanceWeek();
+            assertFalse(gameService.getPlayer().getNotifications().isEmpty(),
+                    "precondition: notifications must be non-empty after week advance with maturing loan");
+            CountingObserver observer = new CountingObserver();
+            gameService.addObserver(observer);
+            // Act
+            gameService.clearAllNotifications();
+            // Assert
+            assertTrue(gameService.getPlayer().getNotifications().isEmpty());
+            assertEquals(1, observer.updateCount);
+        }
+    }
+
+    @Nested
+    @DisplayName("recordLeaderboardEntry()")
+    class RecordLeaderboardEntry {
+
+        @Test
+        @DisplayName("Should record an ACTIVE entry for the current player")
+        void recordsActiveEntryForCurrentPlayer() {
+            gameService.recordLeaderboardEntry();
+            assertEquals(1, lbService.getAllEntries().size());
+            assertEquals(Outcome.ACTIVE, lbService.getAllEntries().get(0).outcome());
+        }
+
+        @Test
+        @DisplayName("Should be a no-op when no game is active")
+        void isNoOpWhenNoGameIsActive() {
+            GameService fresh = new GameService(lbService);
+            fresh.recordLeaderboardEntry();
+            assertTrue(lbService.getAllEntries().isEmpty());
         }
     }
 

--- a/src/test/java/edu/ntnu/idatt2003/millions/service/GameServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/service/GameServiceTest.java
@@ -702,7 +702,9 @@ class GameServiceTest {
         @Test
         @DisplayName("executeForcedSale() throws IllegalStateException when game is over")
         void executeForcedSale_throwsWhenGameOver() {
+            // Arrange
             gameService.declareGameOver();
+            // Act & Assert
             assertThrows(IllegalStateException.class, () ->
                     gameService.executeForcedSale(List.of(), 1));
         }
@@ -808,6 +810,7 @@ class GameServiceTest {
         @Test
         @DisplayName("Should throw NullPointerException when offer is null")
         void throwsWhenOfferIsNull() {
+            // Act & Assert
             assertThrows(NullPointerException.class, () ->
                     gameService.takeLoan(null, new BigDecimal("100")));
         }
@@ -815,8 +818,10 @@ class GameServiceTest {
         @Test
         @DisplayName("Should throw NullPointerException when amount is null")
         void throwsWhenAmountIsNull() {
+            // Arrange
             LoanOffer offer = new LoanOffer("t", new BigDecimal("0.01"), 10,
                     new BigDecimal("9000.00"), LoanRiskLevel.LOW);
+            // Act & Assert
             assertThrows(NullPointerException.class, () ->
                     gameService.takeLoan(offer, null));
         }
@@ -829,6 +834,7 @@ class GameServiceTest {
         @Test
         @DisplayName("Should throw NullPointerException when loan is null")
         void throwsWhenLoanIsNull() {
+            // Act & Assert
             assertThrows(NullPointerException.class, () ->
                     gameService.repayLoan(null));
         }
@@ -841,6 +847,7 @@ class GameServiceTest {
         @Test
         @DisplayName("Should add a known stock to the player's watchlist")
         void addsKnownStockToWatchlist() {
+            // Act & Assert
             gameService.addToWatchlist("EQNR");
             assertTrue(gameService.getPlayer().isOnWatchlist("EQNR"));
         }
@@ -848,6 +855,7 @@ class GameServiceTest {
         @Test
         @DisplayName("Should be a no-op when the symbol does not exist on the exchange")
         void isNoOpForUnknownSymbol() {
+            // Act & Assert
             gameService.addToWatchlist("UNKNOWN");
             assertFalse(gameService.getPlayer().isOnWatchlist("UNKNOWN"));
         }
@@ -855,6 +863,7 @@ class GameServiceTest {
         @Test
         @DisplayName("Should throw NullPointerException when symbol is null")
         void throwsWhenSymbolIsNull() {
+            // Act & Assert
             assertThrows(NullPointerException.class, () ->
                     gameService.addToWatchlist(null));
         }
@@ -867,15 +876,19 @@ class GameServiceTest {
         @Test
         @DisplayName("Should remove a watchlisted stock from the player's watchlist")
         void removesWatchlistedStock() {
+            // Arrange
             gameService.addToWatchlist("EQNR");
             assertTrue(gameService.getPlayer().isOnWatchlist("EQNR"));
+            // Act
             gameService.removeFromWatchlist("EQNR");
+            // Assert
             assertFalse(gameService.getPlayer().isOnWatchlist("EQNR"));
         }
 
         @Test
         @DisplayName("Should throw NullPointerException when symbol is null")
         void throwsWhenSymbolIsNull() {
+            // Act & Assert
             assertThrows(NullPointerException.class, () ->
                     gameService.removeFromWatchlist(null));
         }
@@ -888,8 +901,11 @@ class GameServiceTest {
         @Test
         @DisplayName("Should update the note for a watchlisted stock")
         void updatesNoteForWatchlistedStock() {
+            // Arrange
             gameService.addToWatchlist("EQNR");
+            // Act
             gameService.updateWatchlistNote("EQNR", "my note");
+            // Assert
             String note = gameService.getPlayer().getWatchlist().stream()
                     .filter(e -> e.symbol().equals("EQNR"))
                     .findFirst()
@@ -901,6 +917,7 @@ class GameServiceTest {
         @Test
         @DisplayName("Should throw NullPointerException when symbol is null")
         void throwsWhenSymbolIsNull() {
+            // Act & Assert
             assertThrows(NullPointerException.class, () ->
                     gameService.updateWatchlistNote(null, "note"));
         }
@@ -937,6 +954,7 @@ class GameServiceTest {
         @Test
         @DisplayName("Should record an ACTIVE entry for the current player")
         void recordsActiveEntryForCurrentPlayer() {
+            // Act & Assert
             gameService.recordLeaderboardEntry();
             assertEquals(1, lbService.getAllEntries().size());
             assertEquals(Outcome.ACTIVE, lbService.getAllEntries().get(0).outcome());
@@ -945,8 +963,11 @@ class GameServiceTest {
         @Test
         @DisplayName("Should be a no-op when no game is active")
         void isNoOpWhenNoGameIsActive() {
+            // Arrange
             GameService fresh = new GameService(lbService);
+            // Act
             fresh.recordLeaderboardEntry();
+            // Assert
             assertTrue(lbService.getAllEntries().isEmpty());
         }
     }

--- a/src/test/java/edu/ntnu/idatt2003/millions/service/LoanPreviewServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/service/LoanPreviewServiceTest.java
@@ -82,19 +82,6 @@ class LoanPreviewServiceTest {
         }
 
         @Test
-        @DisplayName("Should reflect the exact principal in the preview")
-        void reflectsPrincipalInPreview() {
-            // Arrange
-            LoanOffer o = offer("0.015", 4);
-
-            // Act
-            LoanPreview preview = service.preview(o, new BigDecimal("500"));
-
-            // Assert
-            assertBigDecimalEquals(new BigDecimal("500"), preview.principal());
-        }
-
-        @Test
         @DisplayName("Should compute correct values for a different rate and term")
         void computesCorrectValuesForRateZeroPointZeroOneFive() {
             // Arrange - rate=1.5%, term=4, principal=500

--- a/src/test/java/edu/ntnu/idatt2003/millions/service/LoanPreviewServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/service/LoanPreviewServiceTest.java
@@ -1,0 +1,171 @@
+package edu.ntnu.idatt2003.millions.service;
+
+import edu.ntnu.idatt2003.millions.model.loan.LoanOffer;
+import edu.ntnu.idatt2003.millions.model.loan.LoanPreview;
+import edu.ntnu.idatt2003.millions.model.loan.LoanRiskLevel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link LoanPreviewService}.
+ * Covers {@link LoanPreviewService#preview} including weekly interest computation,
+ * total-interest accumulation, repayment sum, HALF_UP rounding, and all documented
+ * rejection rules (null arguments, non-positive principal).
+ * All tests follow the AAA pattern.
+ */
+class LoanPreviewServiceTest {
+
+    private LoanPreviewService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new LoanPreviewService();
+    }
+
+    private static void assertBigDecimalEquals(BigDecimal expected, BigDecimal actual) {
+        assertEquals(0, expected.compareTo(actual),
+                "Expected " + expected + " but was " + actual);
+    }
+
+    private static LoanOffer offer(String weeklyRate, int termWeeks) {
+        return new LoanOffer("test", new BigDecimal(weeklyRate),
+                termWeeks, new BigDecimal("1000000"), LoanRiskLevel.LOW);
+    }
+
+    @Nested
+    @DisplayName("preview()")
+    class Preview {
+
+        @Test
+        @DisplayName("Should compute weeklyInterestAmount as principal times weeklyRate")
+        void computesWeeklyInterestAmount() {
+            // Arrange - rate=1%, principal=1000; weeklyInterest=1000×0.01=10.00
+            LoanOffer o = offer("0.01", 10);
+
+            // Act
+            LoanPreview preview = service.preview(o, new BigDecimal("1000"));
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("10.00"), preview.weeklyInterestAmount());
+        }
+
+        @Test
+        @DisplayName("Should compute totalInterest as weeklyInterestAmount times termWeeks")
+        void computesTotalInterest() {
+            // Arrange - weeklyInterest=10.00, term=10; totalInterest=10.00×10=100.00
+            LoanOffer o = offer("0.01", 10);
+
+            // Act
+            LoanPreview preview = service.preview(o, new BigDecimal("1000"));
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("100.00"), preview.totalInterest());
+        }
+
+        @Test
+        @DisplayName("Should compute totalRepayment as principal plus totalInterest")
+        void computesTotalRepayment() {
+            // Arrange - principal=1000, totalInterest=100.00; totalRepayment=1100.00
+            LoanOffer o = offer("0.01", 10);
+
+            // Act
+            LoanPreview preview = service.preview(o, new BigDecimal("1000"));
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("1100.00"), preview.totalRepayment());
+        }
+
+        @Test
+        @DisplayName("Should reflect the exact principal in the preview")
+        void reflectsPrincipalInPreview() {
+            // Arrange
+            LoanOffer o = offer("0.015", 4);
+
+            // Act
+            LoanPreview preview = service.preview(o, new BigDecimal("500"));
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("500"), preview.principal());
+        }
+
+        @Test
+        @DisplayName("Should compute correct values for a different rate and term")
+        void computesCorrectValuesForRateZeroPointZeroOneFive() {
+            // Arrange - rate=1.5%, term=4, principal=500
+            // weeklyInterest=500×0.015=7.50; totalInterest=7.50×4=30.00; totalRepayment=530.00
+            LoanOffer o = offer("0.015", 4);
+
+            // Act
+            LoanPreview preview = service.preview(o, new BigDecimal("500"));
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("7.50"), preview.weeklyInterestAmount());
+            assertBigDecimalEquals(new BigDecimal("30.00"), preview.totalInterest());
+            assertBigDecimalEquals(new BigDecimal("530.00"), preview.totalRepayment());
+        }
+
+        @Test
+        @DisplayName("Should round weekly interest amount to 2 decimal places using HALF_UP")
+        void roundsWeeklyInterestToTwoDecimalsHalfUp() {
+            // Arrange - rate=0.001, principal=333
+            // rawWeekly = 333×0.001 = 0.333 → HALF_UP scale 2 = 0.33
+            // totalInterest = 0.33×10=3.30; totalRepayment=333+3.30=336.30
+            LoanOffer o = offer("0.001", 10);
+
+            // Act
+            LoanPreview preview = service.preview(o, new BigDecimal("333"));
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("0.33"), preview.weeklyInterestAmount());
+            assertBigDecimalEquals(new BigDecimal("3.30"), preview.totalInterest());
+            assertBigDecimalEquals(new BigDecimal("336.30"), preview.totalRepayment());
+        }
+
+        @Test
+        @DisplayName("Should throw NullPointerException when offer is null")
+        void throwsWhenOfferIsNull() {
+            // Act & Assert
+            assertThrows(NullPointerException.class,
+                    () -> service.preview(null, new BigDecimal("1000")));
+        }
+
+        @Test
+        @DisplayName("Should throw NullPointerException when principal is null")
+        void throwsWhenPrincipalIsNull() {
+            // Arrange
+            LoanOffer o = offer("0.01", 10);
+
+            // Act & Assert
+            assertThrows(NullPointerException.class,
+                    () -> service.preview(o, null));
+        }
+
+        @Test
+        @DisplayName("Should throw IllegalArgumentException when principal is zero")
+        void throwsWhenPrincipalIsZero() {
+            // Arrange - spec: principal must be positive
+            LoanOffer o = offer("0.01", 10);
+
+            // Act & Assert
+            assertThrows(IllegalArgumentException.class,
+                    () -> service.preview(o, BigDecimal.ZERO));
+        }
+
+        @Test
+        @DisplayName("Should throw IllegalArgumentException when principal is negative")
+        void throwsWhenPrincipalIsNegative() {
+            // Arrange
+            LoanOffer o = offer("0.01", 10);
+
+            // Act & Assert
+            assertThrows(IllegalArgumentException.class,
+                    () -> service.preview(o, new BigDecimal("-500")));
+        }
+    }
+}

--- a/src/test/java/edu/ntnu/idatt2003/millions/service/PlayerStatsServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/service/PlayerStatsServiceTest.java
@@ -3,6 +3,7 @@ package edu.ntnu.idatt2003.millions.service;
 import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
 import edu.ntnu.idatt2003.millions.model.currency.FixedRateCurrencyConverter;
 import edu.ntnu.idatt2003.millions.model.player.Player;
+import edu.ntnu.idatt2003.millions.model.player.PlayerStatusLevel;
 import edu.ntnu.idatt2003.millions.model.stock.Share;
 import edu.ntnu.idatt2003.millions.model.stock.Stock;
 import edu.ntnu.idatt2003.millions.model.transaction.Purchase;
@@ -17,7 +18,10 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Unit tests for {@link PlayerStatsService#getProgressToNextStatus}.
+ * Unit tests for {@link PlayerStatsService}.
+ * Covers all seven public methods — net worth, change since start, percent change since start,
+ * weekly change, weekly percent change, status, and progress to next status.
+ * All tests follow the AAA pattern.
  */
 class PlayerStatsServiceTest {
 
@@ -28,6 +32,11 @@ class PlayerStatsServiceTest {
     void setUp() {
         service = new PlayerStatsService();
         converter = new FixedRateCurrencyConverter();
+    }
+
+    private static void assertBigDecimalEquals(BigDecimal expected, BigDecimal actual) {
+        assertEquals(0, expected.compareTo(actual),
+                "Expected " + expected + " but was " + actual);
     }
 
     private static Player playerWith(String startingMoney) {
@@ -149,6 +158,139 @@ class PlayerStatsServiceTest {
             double progress = service.getProgressToNextStatus(p, converter);
             // Assert — growth sub-score must be clamped to 0, not go negative
             assertEquals(0.0, progress);
+        }
+    }
+
+    @Nested
+    @DisplayName("getNetWorth()")
+    class GetNetWorth {
+
+        @Test
+        @DisplayName("Returns money balance when portfolio is empty")
+        void returnsMoneyBalanceWithEmptyPortfolio() {
+            Player p = playerWith("1000");
+            assertBigDecimalEquals(new BigDecimal("1000"), service.getNetWorth(p, converter));
+        }
+    }
+
+    @Nested
+    @DisplayName("getNetWorthChangeSinceStart()")
+    class GetNetWorthChangeSinceStart {
+
+        @Test
+        @DisplayName("Returns zero for a player whose balance is unchanged")
+        void returnsZeroForUnchangedBalance() {
+            Player p = playerWith("1000");
+            assertBigDecimalEquals(BigDecimal.ZERO, service.getNetWorthChangeSinceStart(p, converter));
+        }
+
+        @Test
+        @DisplayName("Returns positive value when player gained money")
+        void returnsPositiveValueWhenPlayerGainedMoney() {
+            // Arrange — start=1000, add 200 → change=200
+            Player p = playerWith("1000");
+            p.addMoney(new BigDecimal("200"));
+            assertBigDecimalEquals(new BigDecimal("200"), service.getNetWorthChangeSinceStart(p, converter));
+        }
+
+        @Test
+        @DisplayName("Returns negative value when player lost money")
+        void returnsNegativeValueWhenPlayerLostMoney() {
+            // Arrange — start=1000, withdraw 300 → change=−300
+            Player p = playerWith("1000");
+            p.withdrawMoney(new BigDecimal("300"));
+            assertBigDecimalEquals(new BigDecimal("-300"), service.getNetWorthChangeSinceStart(p, converter));
+        }
+    }
+
+    @Nested
+    @DisplayName("getNetWorthChangePercentSinceStart()")
+    class GetNetWorthChangePercentSinceStart {
+
+        @Test
+        @DisplayName("Returns zero percent for a player whose balance is unchanged")
+        void returnsZeroPercentForUnchangedBalance() {
+            Player p = playerWith("1000");
+            assertBigDecimalEquals(BigDecimal.ZERO,
+                    service.getNetWorthChangePercentSinceStart(p, converter));
+        }
+
+        @Test
+        @DisplayName("Returns 10.0% when player gained 100 on a 1000 start")
+        void returnsTenPercentOnTenPercentGain() {
+            // Arrange — start=1000, add 100 → 100/1000×100 = 10.0%
+            Player p = playerWith("1000");
+            p.addMoney(new BigDecimal("100"));
+            assertBigDecimalEquals(new BigDecimal("10.0"),
+                    service.getNetWorthChangePercentSinceStart(p, converter));
+        }
+    }
+
+    @Nested
+    @DisplayName("getWeeklyNetWorthChange()")
+    class GetWeeklyNetWorthChange {
+
+        @Test
+        @DisplayName("Returns null when no week has been advanced yet")
+        void returnsNullBeforeAnyWeekAdvance() {
+            Player p = playerWith("1000");
+            assertNull(service.getWeeklyNetWorthChange(p, converter));
+        }
+
+        @Test
+        @DisplayName("Returns difference between current and previous net worth after week advance")
+        void returnsDifferenceAfterWeekAdvance() {
+            // Arrange — snapshot previous=1000, add 100 → change=100
+            Player p = playerWith("1000");
+            p.setPreviousNetWorth(p.getNetWorth(converter));
+            p.addMoney(new BigDecimal("100"));
+            assertBigDecimalEquals(new BigDecimal("100"),
+                    service.getWeeklyNetWorthChange(p, converter));
+        }
+    }
+
+    @Nested
+    @DisplayName("getWeeklyNetWorthChangePercent()")
+    class GetWeeklyNetWorthChangePercent {
+
+        @Test
+        @DisplayName("Returns null when no week has been advanced yet")
+        void returnsNullBeforeAnyWeekAdvance() {
+            Player p = playerWith("1000");
+            assertNull(service.getWeeklyNetWorthChangePercent(p, converter));
+        }
+
+        @Test
+        @DisplayName("Returns 10.0% when player gained 100 on a 1000 previous net worth")
+        void returnsPercentageChangeAfterWeekAdvance() {
+            // Arrange — previous=1000, add 100 → 100/1000×100 = 10.0%
+            Player p = playerWith("1000");
+            p.setPreviousNetWorth(p.getNetWorth(converter));
+            p.addMoney(new BigDecimal("100"));
+            assertBigDecimalEquals(new BigDecimal("10.0"),
+                    service.getWeeklyNetWorthChangePercent(p, converter));
+        }
+    }
+
+    @Nested
+    @DisplayName("getStatus()")
+    class GetStatus {
+
+        @Test
+        @DisplayName("Returns NOVICE for a fresh player with no growth")
+        void returnsNoviceForFreshPlayer() {
+            Player p = playerWith("1000");
+            assertEquals(PlayerStatusLevel.NOVICE, service.getStatus(p, converter));
+        }
+
+        @Test
+        @DisplayName("Returns SPECULATOR for a player with 20 weeks and 100% growth")
+        void returnsSpeculatorForTopTierPlayer() {
+            // Arrange — 20 weeks + 100% growth (1000 on 1000 start) → SPECULATOR
+            Player p = playerWith("1000");
+            addWeeks(p, 20);
+            p.addMoney(new BigDecimal("1000"));
+            assertEquals(PlayerStatusLevel.SPECULATOR, service.getStatus(p, converter));
         }
     }
 }

--- a/src/test/java/edu/ntnu/idatt2003/millions/service/PlayerStatsServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/service/PlayerStatsServiceTest.java
@@ -168,7 +168,9 @@ class PlayerStatsServiceTest {
         @Test
         @DisplayName("Returns money balance when portfolio is empty")
         void returnsMoneyBalanceWithEmptyPortfolio() {
+            // Arrange
             Player p = playerWith("1000");
+            // Act & Assert
             assertBigDecimalEquals(new BigDecimal("1000"), service.getNetWorth(p, converter));
         }
     }
@@ -180,7 +182,9 @@ class PlayerStatsServiceTest {
         @Test
         @DisplayName("Returns zero for a player whose balance is unchanged")
         void returnsZeroForUnchangedBalance() {
+            // Arrange
             Player p = playerWith("1000");
+            // Act & Assert
             assertBigDecimalEquals(BigDecimal.ZERO, service.getNetWorthChangeSinceStart(p, converter));
         }
 
@@ -210,7 +214,9 @@ class PlayerStatsServiceTest {
         @Test
         @DisplayName("Returns zero percent for a player whose balance is unchanged")
         void returnsZeroPercentForUnchangedBalance() {
+            // Arrange
             Player p = playerWith("1000");
+            // Act & Assert
             assertBigDecimalEquals(BigDecimal.ZERO,
                     service.getNetWorthChangePercentSinceStart(p, converter));
         }
@@ -233,7 +239,9 @@ class PlayerStatsServiceTest {
         @Test
         @DisplayName("Returns null when no week has been advanced yet")
         void returnsNullBeforeAnyWeekAdvance() {
+            // Arrange
             Player p = playerWith("1000");
+            // Act & Assert
             assertNull(service.getWeeklyNetWorthChange(p, converter));
         }
 
@@ -256,7 +264,9 @@ class PlayerStatsServiceTest {
         @Test
         @DisplayName("Returns null when no week has been advanced yet")
         void returnsNullBeforeAnyWeekAdvance() {
+            // Arrange
             Player p = playerWith("1000");
+            // Act & Assert
             assertNull(service.getWeeklyNetWorthChangePercent(p, converter));
         }
 
@@ -279,7 +289,9 @@ class PlayerStatsServiceTest {
         @Test
         @DisplayName("Returns NOVICE for a fresh player with no growth")
         void returnsNoviceForFreshPlayer() {
+            // Arrange
             Player p = playerWith("1000");
+            // Act & Assert
             assertEquals(PlayerStatusLevel.NOVICE, service.getStatus(p, converter));
         }
 
@@ -290,6 +302,7 @@ class PlayerStatsServiceTest {
             Player p = playerWith("1000");
             addWeeks(p, 20);
             p.addMoney(new BigDecimal("1000"));
+            // Act & Assert
             assertEquals(PlayerStatusLevel.SPECULATOR, service.getStatus(p, converter));
         }
     }

--- a/src/test/java/edu/ntnu/idatt2003/millions/service/PortfolioServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/service/PortfolioServiceTest.java
@@ -1,0 +1,436 @@
+package edu.ntnu.idatt2003.millions.service;
+
+import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
+import edu.ntnu.idatt2003.millions.model.currency.FixedRateCurrencyConverter;
+import edu.ntnu.idatt2003.millions.model.player.Player;
+import edu.ntnu.idatt2003.millions.model.stock.Share;
+import edu.ntnu.idatt2003.millions.model.stock.Stock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Currency;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link PortfolioService}.
+ * Verifies per-share queries ({@code getShareValueInNok}, {@code getShareReturnInNok},
+ * {@code getLiquidationValueInNok}) and aggregate portfolio queries including
+ * {@code getInvestedAmount}, {@code getWeeklyReturnInNok}, {@code getWeeklyReturnPercent},
+ * and {@code getPositionCount}.  All tests follow the AAA pattern.
+ */
+class PortfolioServiceTest {
+
+    private static final Currency NOK = Currency.getInstance("NOK");
+    private static final Currency USD = Currency.getInstance("USD");
+
+    private PortfolioService service;
+    private CurrencyConverter converter;
+
+    @BeforeEach
+    void setUp() {
+        service = new PortfolioService();
+        converter = new FixedRateCurrencyConverter();
+    }
+
+    private static void assertBigDecimalEquals(BigDecimal expected, BigDecimal actual) {
+        assertEquals(0, expected.compareTo(actual),
+                "Expected " + expected + " but was " + actual);
+    }
+
+    /**
+     * Creates a NOK stock whose sales price is the last element of {@code prices}
+     * and whose weekly price change is {@code prices[last] − prices[last-1]}.
+     */
+    private static Stock nokStock(String symbol, String... prices) {
+        List<BigDecimal> priceList = java.util.Arrays.stream(prices)
+                .map(BigDecimal::new)
+                .toList();
+        return new Stock(symbol, symbol + " Co.", priceList, NOK);
+    }
+
+    private static Stock usdStock(String symbol, String... prices) {
+        List<BigDecimal> priceList = java.util.Arrays.stream(prices)
+                .map(BigDecimal::new)
+                .toList();
+        return new Stock(symbol, symbol + " Co.", priceList, USD);
+    }
+
+    private static Share share(Stock stock, String qty, String purchasePrice) {
+        return new Share(stock, new BigDecimal(qty), new BigDecimal(purchasePrice));
+    }
+
+    private static Player player(String balance) {
+        return new Player("Test", new BigDecimal(balance));
+    }
+
+    @Nested
+    @DisplayName("getShareValueInNok()")
+    class GetShareValueInNok {
+
+        @Test
+        @DisplayName("Should return salesPrice times quantity in NOK")
+        void returnsSalesPriceTimesQuantityInNok() {
+            // Arrange - price=120, qty=10: currentValue=1200 NOK
+            Stock stock = nokStock("TST", "80", "100", "120");
+            Share sh = share(stock, "10", "80");
+
+            // Act
+            BigDecimal value = service.getShareValueInNok(sh, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("1200"), value);
+        }
+
+        @Test
+        @DisplayName("Should convert USD position value to NOK")
+        void convertsUsdPositionValueToNok() {
+            // Arrange - price=100 USD, qty=5: currentValue=500 USD → 500×9.21=4605 NOK
+            Stock stock = usdStock("TST", "100");
+            Share sh = share(stock, "5", "100");
+
+            // Act
+            BigDecimal value = service.getShareValueInNok(sh, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("4605"), value);
+        }
+    }
+
+    @Nested
+    @DisplayName("getShareReturnInNok()")
+    class GetShareReturnInNok {
+
+        @Test
+        @DisplayName("Should return currentValue minus cost in NOK for a position with gains")
+        void returnsCurrentValueMinusCostForGain() {
+            // Arrange - price=120, qty=10, purchasePrice=80
+            // returnNative = (120−80)×10 = 400 NOK
+            Stock stock = nokStock("TST", "80", "120");
+            Share sh = share(stock, "10", "80");
+
+            // Act
+            BigDecimal ret = service.getShareReturnInNok(sh, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("400"), ret);
+        }
+
+        @Test
+        @DisplayName("Should return a negative value in NOK when the position is at a loss")
+        void returnsNegativeForLossPosition() {
+            // Arrange - price=80, qty=10, purchasePrice=100
+            // returnNative = (80−100)×10 = −200 NOK
+            Stock stock = nokStock("TST", "100", "80");
+            Share sh = share(stock, "10", "100");
+
+            // Act
+            BigDecimal ret = service.getShareReturnInNok(sh, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("-200"), ret);
+        }
+    }
+
+    @Nested
+    @DisplayName("getLiquidationValueInNok()")
+    class GetLiquidationValueInNok {
+
+        @Test
+        @DisplayName("Should return net payout after commission and tax in NOK")
+        void returnsNetPayoutAfterFeesInNok() {
+            // Arrange - stock: price=120, qty=10, purchasePrice=80
+            // purchaseCost = 80×10 + 80×10×0.005 = 800+4 = 804
+            // gross=1200; commission=12; gain=1200−12−804=384; tax=384×0.3=115.2
+            // liquidation = 1200−12−115.2 = 1072.8 NOK
+            Stock stock = nokStock("TST", "80", "120");
+            Share sh = share(stock, "10", "80");
+
+            // Act
+            BigDecimal lv = service.getLiquidationValueInNok(sh, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("1072.8"), lv);
+        }
+    }
+
+    @Nested
+    @DisplayName("getValue()")
+    class GetValue {
+
+        @Test
+        @DisplayName("Should return total portfolio market value in NOK")
+        void returnsTotalPortfolioMarketValueInNok() {
+            // Arrange - one NOK share: price=120, qty=10 → currentValue=1200 NOK
+            Stock stock = nokStock("TST", "80", "120");
+            Share sh = share(stock, "10", "80");
+            Player p = player("5000");
+            p.getPortfolio().addShare(sh);
+
+            // Act
+            BigDecimal value = service.getValue(p, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("1200"), value);
+        }
+
+        @Test
+        @DisplayName("Should return zero for an empty portfolio")
+        void returnsZeroForEmptyPortfolio() {
+            // Arrange
+            Player p = player("5000");
+
+            // Act
+            BigDecimal value = service.getValue(p, converter);
+
+            // Assert
+            assertBigDecimalEquals(BigDecimal.ZERO, value);
+        }
+    }
+
+    @Nested
+    @DisplayName("getTotalReturnInNok()")
+    class GetTotalReturnInNok {
+
+        @Test
+        @DisplayName("Should return the sum of unrealized returns across all positions in NOK")
+        void returnsSumOfUnrealizedReturnsInNok() {
+            // Arrange - price=120, qty=10, purchasePrice=80: returnNative=400 NOK
+            Stock stock = nokStock("TST", "80", "120");
+            Share sh = share(stock, "10", "80");
+            Player p = player("5000");
+            p.getPortfolio().addShare(sh);
+
+            // Act
+            BigDecimal ret = service.getTotalReturnInNok(p, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("400"), ret);
+        }
+    }
+
+    @Nested
+    @DisplayName("getTotalReturnPercent()")
+    class GetTotalReturnPercent {
+
+        @Test
+        @DisplayName("Should return totalReturnInNok over totalCost times 100")
+        void returnsTotalReturnOverCostTimes100() {
+            // Arrange - returnNative=400, costNok=800 → percent=400/800×100=50.00
+            Stock stock = nokStock("TST", "80", "120");
+            Share sh = share(stock, "10", "80");
+            Player p = player("5000");
+            p.getPortfolio().addShare(sh);
+
+            // Act
+            BigDecimal pct = service.getTotalReturnPercent(p, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("50.00"), pct);
+        }
+
+        @Test
+        @DisplayName("Should return zero for an empty portfolio")
+        void returnsZeroForEmptyPortfolio() {
+            // Arrange
+            Player p = player("5000");
+
+            // Act
+            BigDecimal pct = service.getTotalReturnPercent(p, converter);
+
+            // Assert
+            assertBigDecimalEquals(BigDecimal.ZERO, pct);
+        }
+    }
+
+    @Nested
+    @DisplayName("getInvestedAmount()")
+    class GetInvestedAmount {
+
+        @Test
+        @DisplayName("Should return market value minus total unrealized return in NOK")
+        void returnsMarketValueMinusTotalReturn() {
+            // Arrange - marketValue=1200, totalReturn=400; investedAmount=1200−400=800
+            // This equals the position cost basis: 80×10=800
+            Stock stock = nokStock("TST", "80", "120");
+            Share sh = share(stock, "10", "80");
+            Player p = player("5000");
+            p.getPortfolio().addShare(sh);
+
+            // Act
+            BigDecimal invested = service.getInvestedAmount(p, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("800"), invested);
+        }
+
+        @Test
+        @DisplayName("Should return zero for an empty portfolio")
+        void returnsZeroForEmptyPortfolio() {
+            // Arrange
+            Player p = player("5000");
+
+            // Act
+            BigDecimal invested = service.getInvestedAmount(p, converter);
+
+            // Assert
+            assertBigDecimalEquals(BigDecimal.ZERO, invested);
+        }
+    }
+
+    @Nested
+    @DisplayName("getWeeklyReturnInNok()")
+    class GetWeeklyReturnInNok {
+
+        @Test
+        @DisplayName("Should return sum of latestPriceChange times quantity in NOK")
+        void returnsPriceChangeTimesQuantityInNok() {
+            // Arrange - prices=[80,100,120]: priceChange=120−100=20; weeklyReturn=20×10=200 NOK
+            Stock stock = nokStock("TST", "80", "100", "120");
+            Share sh = share(stock, "10", "80");
+            Player p = player("5000");
+            p.getPortfolio().addShare(sh);
+
+            // Act
+            BigDecimal weekly = service.getWeeklyReturnInNok(p, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("200"), weekly);
+        }
+
+        @Test
+        @DisplayName("Should return zero when stock has only one price point")
+        void returnsZeroForSinglePricePoint() {
+            // Arrange - only one price means no previous → priceChange=0
+            Stock stock = nokStock("TST", "100");
+            Share sh = share(stock, "10", "100");
+            Player p = player("5000");
+            p.getPortfolio().addShare(sh);
+
+            // Act
+            BigDecimal weekly = service.getWeeklyReturnInNok(p, converter);
+
+            // Assert
+            assertBigDecimalEquals(BigDecimal.ZERO, weekly);
+        }
+
+        @Test
+        @DisplayName("Should return a negative value when price fell this week")
+        void returnsNegativeWhenPriceFell() {
+            // Arrange - prices=[200,150]: priceChange=150−200=−50; weeklyReturn=−50×4=−200 NOK
+            Stock stock = nokStock("TST", "200", "150");
+            Share sh = share(stock, "4", "200");
+            Player p = player("5000");
+            p.getPortfolio().addShare(sh);
+
+            // Act
+            BigDecimal weekly = service.getWeeklyReturnInNok(p, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("-200"), weekly);
+        }
+
+        @Test
+        @DisplayName("Should sum weekly returns across multiple positions in NOK")
+        void sumsWeeklyReturnsAcrossMultiplePositions() {
+            // Arrange
+            // Stock A: priceChange=+20, qty=10 → +200 NOK
+            // Stock B: priceChange=−10, qty=5  → −50 NOK
+            // Total = +150 NOK
+            Stock stockA = nokStock("AAA", "80", "100", "120");
+            Stock stockB = nokStock("BBB", "200", "190");
+            Share shA = share(stockA, "10", "80");
+            Share shB = share(stockB, "5", "200");
+            Player p = player("5000");
+            p.getPortfolio().addShare(shA);
+            p.getPortfolio().addShare(shB);
+
+            // Act
+            BigDecimal weekly = service.getWeeklyReturnInNok(p, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("150"), weekly);
+        }
+    }
+
+    @Nested
+    @DisplayName("getWeeklyReturnPercent()")
+    class GetWeeklyReturnPercent {
+
+        @Test
+        @DisplayName("Should return weeklyReturnInNok over investedAmount times 100")
+        void returnsWeeklyReturnOverInvestedTimesOneHundred() {
+            // Arrange - prices=[80,100,120]: priceChange=20, weeklyReturn=200 NOK
+            // investedAmount = marketValue(1200)−totalReturn(400) = 800 NOK
+            // weeklyPercent = 200/800×100 = 25.0000
+            Stock stock = nokStock("TST", "80", "100", "120");
+            Share sh = share(stock, "10", "80");
+            Player p = player("5000");
+            p.getPortfolio().addShare(sh);
+
+            // Act
+            BigDecimal pct = service.getWeeklyReturnPercent(p, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("25"), pct);
+        }
+
+        @Test
+        @DisplayName("Should return zero when portfolio is empty")
+        void returnsZeroForEmptyPortfolio() {
+            // Arrange - investedAmount=0 → divide-by-zero guard triggers
+            Player p = player("5000");
+
+            // Act
+            BigDecimal pct = service.getWeeklyReturnPercent(p, converter);
+
+            // Assert
+            assertBigDecimalEquals(BigDecimal.ZERO, pct);
+        }
+    }
+
+    @Nested
+    @DisplayName("getPositionCount()")
+    class GetPositionCount {
+
+        @Test
+        @DisplayName("Should return zero for an empty portfolio")
+        void returnsZeroForEmptyPortfolio() {
+            // Arrange
+            Player p = player("5000");
+
+            // Act & Assert
+            assertEquals(0, service.getPositionCount(p));
+        }
+
+        @Test
+        @DisplayName("Should return one for a single stock position")
+        void returnsOneForSinglePosition() {
+            // Arrange
+            Stock stock = nokStock("TST", "100");
+            Player p = player("5000");
+            p.getPortfolio().addShare(share(stock, "10", "100"));
+
+            // Act & Assert
+            assertEquals(1, service.getPositionCount(p));
+        }
+
+        @Test
+        @DisplayName("Should count each distinct stock symbol as one position")
+        void countsDistinctSymbolsAsPositions() {
+            // Arrange - two different stocks → 2 positions
+            Stock s1 = nokStock("AAA", "100");
+            Stock s2 = nokStock("BBB", "200");
+            Player p = player("5000");
+            p.getPortfolio().addShare(share(s1, "5", "100"));
+            p.getPortfolio().addShare(share(s2, "5", "200"));
+
+            // Act & Assert
+            assertEquals(2, service.getPositionCount(p));
+        }
+    }
+}

--- a/src/test/java/edu/ntnu/idatt2003/millions/service/RealizedReturnsServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/service/RealizedReturnsServiceTest.java
@@ -1,0 +1,413 @@
+package edu.ntnu.idatt2003.millions.service;
+
+import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
+import edu.ntnu.idatt2003.millions.model.currency.FixedRateCurrencyConverter;
+import edu.ntnu.idatt2003.millions.model.player.Player;
+import edu.ntnu.idatt2003.millions.model.stock.Share;
+import edu.ntnu.idatt2003.millions.model.stock.Stock;
+import edu.ntnu.idatt2003.millions.model.transaction.Purchase;
+import edu.ntnu.idatt2003.millions.model.transaction.Sale;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Currency;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link RealizedReturnsService}.
+ * Covers all six public methods — gains, losses, net realized, total tax, total commission,
+ * and sales count — including empty-archive zeros, profitable/loss sale paths, multi-sale
+ * aggregation, and USD currency conversion via {@link FixedRateCurrencyConverter}.
+ * Sales are added directly to the player's {@code TransactionArchive} (bypassing
+ * {@link Sale#commit}) so tests control archive state without full game-flow setup.
+ * All tests follow the AAA pattern.
+ */
+class RealizedReturnsServiceTest {
+
+    private static final Currency NOK = Currency.getInstance("NOK");
+    private static final Currency USD = Currency.getInstance("USD");
+
+    private RealizedReturnsService service;
+    private CurrencyConverter converter;
+    private Player player;
+
+    @BeforeEach
+    void setUp() {
+        service = new RealizedReturnsService();
+        converter = new FixedRateCurrencyConverter();
+        player = new Player("Test", new BigDecimal("10000"));
+    }
+
+    private static void assertBigDecimalEquals(BigDecimal expected, BigDecimal actual) {
+        assertEquals(0, expected.compareTo(actual),
+                "Expected " + expected + " but was " + actual);
+    }
+
+    private static Stock nokStock(String price) {
+        return new Stock("TST", "Test Co.", List.of(new BigDecimal(price)), NOK);
+    }
+
+    private static Stock usdStock(String price) {
+        return new Stock("TST", "Test Co.", List.of(new BigDecimal(price)), USD);
+    }
+
+    private static Share share(Stock stock, String qty, String purchasePrice) {
+        return new Share(stock, new BigDecimal(qty), new BigDecimal(purchasePrice));
+    }
+
+    /**
+     * Creates a profitable NOK Sale: salePrice=200, qty=10, purchasePrice=100.
+     * profit = total − purchaseCost = 1687.5 − 1005 = 682.5 NOK
+     * commission = 2000×0.01 = 20 NOK; tax = 975×0.30 = 292.5 NOK
+     */
+    private static Sale profitableNokSale() {
+        Stock stock = nokStock("200");
+        return new Sale(share(stock, "10", "100"), 1);
+    }
+
+    /**
+     * Creates a loss NOK Sale: salePrice=50, qty=10, purchasePrice=100.
+     * profit = 495 − 1005 = −510 NOK; commission = 500×0.01 = 5 NOK; tax = 0
+     */
+    private static Sale lossNokSale() {
+        Stock stock = nokStock("50");
+        return new Sale(share(stock, "10", "100"), 1);
+    }
+
+    /**
+     * Creates a profitable USD Sale: salePrice=200, qty=10, purchasePrice=100.
+     * profit = 682.5 USD → 682.5×9.21 = 6285.825 NOK
+     * commission = 20 USD → 20×9.21 = 184.2 NOK
+     * tax = 292.5 USD → 292.5×9.21 = 2693.925 NOK
+     */
+    private static Sale profitableUsdSale() {
+        Stock stock = usdStock("200");
+        return new Sale(share(stock, "10", "100"), 1);
+    }
+
+    @Nested
+    @DisplayName("getGainsInNok()")
+    class GetGainsInNok {
+
+        @Test
+        @DisplayName("Should return zero when the archive is empty")
+        void returnsZeroForEmptyArchive() {
+            // Act
+            BigDecimal gains = service.getGainsInNok(player, converter);
+
+            // Assert
+            assertBigDecimalEquals(BigDecimal.ZERO, gains);
+        }
+
+        @Test
+        @DisplayName("Should return the profit of a single profitable sale in NOK")
+        void returnsProfitOfSingleProfitableSale() {
+            // Arrange — profitable NOK sale: profit=682.5 NOK
+            player.getTransactionArchive().add(profitableNokSale());
+
+            // Act
+            BigDecimal gains = service.getGainsInNok(player, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("682.5"), gains);
+        }
+
+        @Test
+        @DisplayName("Should return zero when all sales are losses")
+        void returnsZeroWhenAllSalesAreLosses() {
+            // Arrange — loss sale: profit=−510, excluded from gains
+            player.getTransactionArchive().add(lossNokSale());
+
+            // Act
+            BigDecimal gains = service.getGainsInNok(player, converter);
+
+            // Assert
+            assertBigDecimalEquals(BigDecimal.ZERO, gains);
+        }
+
+        @Test
+        @DisplayName("Should sum gains across multiple profitable sales in NOK")
+        void sumsGainsAcrossMultipleProfitableSales() {
+            // Arrange — two profitable NOK sales: 682.5 + 682.5 = 1365 NOK
+            player.getTransactionArchive().add(profitableNokSale());
+            player.getTransactionArchive().add(new Sale(share(nokStock("200"), "10", "100"), 2));
+
+            // Act
+            BigDecimal gains = service.getGainsInNok(player, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("1365"), gains);
+        }
+
+        @Test
+        @DisplayName("Should convert USD profit to NOK for a profitable USD sale")
+        void convertsUsdProfitToNok() {
+            // Arrange — profitable USD sale: profit=682.5 USD → 682.5×9.21=6285.825 NOK
+            player.getTransactionArchive().add(profitableUsdSale());
+
+            // Act
+            BigDecimal gains = service.getGainsInNok(player, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("6285.825"), gains);
+        }
+    }
+
+    @Nested
+    @DisplayName("getLossesInNok()")
+    class GetLossesInNok {
+
+        @Test
+        @DisplayName("Should return zero when the archive is empty")
+        void returnsZeroForEmptyArchive() {
+            // Act
+            BigDecimal losses = service.getLossesInNok(player, converter);
+
+            // Assert
+            assertBigDecimalEquals(BigDecimal.ZERO, losses);
+        }
+
+        @Test
+        @DisplayName("Should return the absolute loss of a single losing sale as a positive value in NOK")
+        void returnsAbsoluteLossAsPositiveValue() {
+            // Arrange — loss NOK sale: profit=−510; absolute loss=510 NOK
+            player.getTransactionArchive().add(lossNokSale());
+
+            // Act
+            BigDecimal losses = service.getLossesInNok(player, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("510"), losses);
+        }
+
+        @Test
+        @DisplayName("Should return zero when all sales are profitable")
+        void returnsZeroWhenAllSalesAreProfitable() {
+            // Arrange — profitable sale: profit=682.5, excluded from losses
+            player.getTransactionArchive().add(profitableNokSale());
+
+            // Act
+            BigDecimal losses = service.getLossesInNok(player, converter);
+
+            // Assert
+            assertBigDecimalEquals(BigDecimal.ZERO, losses);
+        }
+    }
+
+    @Nested
+    @DisplayName("getNetRealizedInNok()")
+    class GetNetRealizedInNok {
+
+        @Test
+        @DisplayName("Should return zero when the archive is empty")
+        void returnsZeroForEmptyArchive() {
+            // Act
+            BigDecimal net = service.getNetRealizedInNok(player, converter);
+
+            // Assert
+            assertBigDecimalEquals(BigDecimal.ZERO, net);
+        }
+
+        @Test
+        @DisplayName("Should return gains minus losses when archive has both")
+        void returnsGainsMinusLosses() {
+            // Arrange — profitable sale: gains=682.5; loss sale: losses=510
+            // net = 682.5 − 510 = 172.5 NOK
+            player.getTransactionArchive().add(profitableNokSale());
+            player.getTransactionArchive().add(lossNokSale());
+
+            // Act
+            BigDecimal net = service.getNetRealizedInNok(player, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("172.5"), net);
+        }
+
+        @Test
+        @DisplayName("Should return a negative net when losses exceed gains")
+        void returnsNegativeNetWhenLossesExceedGains() {
+            // Arrange — two loss sales: losses=1020; no gains; net=0−1020=−1020 NOK
+            player.getTransactionArchive().add(lossNokSale());
+            player.getTransactionArchive().add(new Sale(share(nokStock("50"), "10", "100"), 2));
+
+            // Act
+            BigDecimal net = service.getNetRealizedInNok(player, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("-1020"), net);
+        }
+    }
+
+    @Nested
+    @DisplayName("getTotalTaxPaidInNok()")
+    class GetTotalTaxPaidInNok {
+
+        @Test
+        @DisplayName("Should return zero when the archive is empty")
+        void returnsZeroForEmptyArchive() {
+            // Act
+            BigDecimal tax = service.getTotalTaxPaidInNok(player, converter);
+
+            // Assert
+            assertBigDecimalEquals(BigDecimal.ZERO, tax);
+        }
+
+        @Test
+        @DisplayName("Should return 30% of gain as tax for a single profitable sale in NOK")
+        void returnsTaxOfSingleProfitableSale() {
+            // Arrange — profitable NOK sale: gain=975, tax=975×0.30=292.5 NOK
+            player.getTransactionArchive().add(profitableNokSale());
+
+            // Act
+            BigDecimal tax = service.getTotalTaxPaidInNok(player, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("292.5"), tax);
+        }
+
+        @Test
+        @DisplayName("Should return zero tax for a loss sale")
+        void returnsZeroTaxForLossSale() {
+            // Arrange — loss sale: tax=0 (no tax on losses)
+            player.getTransactionArchive().add(lossNokSale());
+
+            // Act
+            BigDecimal tax = service.getTotalTaxPaidInNok(player, converter);
+
+            // Assert
+            assertBigDecimalEquals(BigDecimal.ZERO, tax);
+        }
+
+        @Test
+        @DisplayName("Should sum tax across profitable and loss sales, including only profitable tax")
+        void sumsTaxAcrossMixedSales() {
+            // Arrange — profitable: tax=292.5; loss: tax=0; total=292.5 NOK
+            player.getTransactionArchive().add(profitableNokSale());
+            player.getTransactionArchive().add(lossNokSale());
+
+            // Act
+            BigDecimal tax = service.getTotalTaxPaidInNok(player, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("292.5"), tax);
+        }
+
+        @Test
+        @DisplayName("Should convert USD tax to NOK for a USD sale")
+        void convertsUsdTaxToNok() {
+            // Arrange — profitable USD sale: tax=292.5 USD → 292.5×9.21=2693.925 NOK
+            player.getTransactionArchive().add(profitableUsdSale());
+
+            // Act
+            BigDecimal tax = service.getTotalTaxPaidInNok(player, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("2693.925"), tax);
+        }
+    }
+
+    @Nested
+    @DisplayName("getTotalSaleCommissionInNok()")
+    class GetTotalSaleCommissionInNok {
+
+        @Test
+        @DisplayName("Should return zero when the archive is empty")
+        void returnsZeroForEmptyArchive() {
+            // Act
+            BigDecimal commission = service.getTotalSaleCommissionInNok(player, converter);
+
+            // Assert
+            assertBigDecimalEquals(BigDecimal.ZERO, commission);
+        }
+
+        @Test
+        @DisplayName("Should return 1% of gross as commission for a single sale in NOK")
+        void returnsOnePercentGrossAsCommission() {
+            // Arrange — profitable NOK sale: gross=2000, commission=2000×0.01=20 NOK
+            player.getTransactionArchive().add(profitableNokSale());
+
+            // Act
+            BigDecimal commission = service.getTotalSaleCommissionInNok(player, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("20"), commission);
+        }
+
+        @Test
+        @DisplayName("Should sum commission across both profitable and loss sales")
+        void sumsCommissionAcrossMixedSales() {
+            // Arrange — profitable: commission=20; loss: commission=5; total=25 NOK
+            player.getTransactionArchive().add(profitableNokSale());
+            player.getTransactionArchive().add(lossNokSale());
+
+            // Act
+            BigDecimal commission = service.getTotalSaleCommissionInNok(player, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("25"), commission);
+        }
+
+        @Test
+        @DisplayName("Should convert USD commission to NOK for a USD sale")
+        void convertsUsdCommissionToNok() {
+            // Arrange — profitable USD sale: commission=20 USD → 20×9.21=184.2 NOK
+            player.getTransactionArchive().add(profitableUsdSale());
+
+            // Act
+            BigDecimal commission = service.getTotalSaleCommissionInNok(player, converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("184.2"), commission);
+        }
+    }
+
+    @Nested
+    @DisplayName("getSalesCount()")
+    class GetSalesCount {
+
+        @Test
+        @DisplayName("Should return zero when the archive is empty")
+        void returnsZeroForEmptyArchive() {
+            // Act & Assert
+            assertEquals(0, service.getSalesCount(player));
+        }
+
+        @Test
+        @DisplayName("Should return one for a single sale in the archive")
+        void returnsOneForSingleSale() {
+            // Arrange
+            player.getTransactionArchive().add(profitableNokSale());
+
+            // Act & Assert
+            assertEquals(1, service.getSalesCount(player));
+        }
+
+        @Test
+        @DisplayName("Should count multiple sales correctly")
+        void countsMultipleSalesCorrectly() {
+            // Arrange — one profitable and one loss sale
+            player.getTransactionArchive().add(profitableNokSale());
+            player.getTransactionArchive().add(lossNokSale());
+
+            // Act & Assert
+            assertEquals(2, service.getSalesCount(player));
+        }
+
+        @Test
+        @DisplayName("Should not count purchases towards the sales count")
+        void doesNotCountPurchases() {
+            // Arrange — one sale and one purchase; only the sale should count
+            player.getTransactionArchive().add(profitableNokSale());
+            player.getTransactionArchive().add(
+                    new Purchase(share(nokStock("100"), "5", "100"), 1));
+
+            // Act & Assert
+            assertEquals(1, service.getSalesCount(player));
+        }
+    }
+}

--- a/src/test/java/edu/ntnu/idatt2003/millions/service/TransactionStatsServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/service/TransactionStatsServiceTest.java
@@ -1,0 +1,445 @@
+package edu.ntnu.idatt2003.millions.service;
+
+import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
+import edu.ntnu.idatt2003.millions.model.currency.FixedRateCurrencyConverter;
+import edu.ntnu.idatt2003.millions.model.stock.Share;
+import edu.ntnu.idatt2003.millions.model.stock.Stock;
+import edu.ntnu.idatt2003.millions.model.transaction.Purchase;
+import edu.ntnu.idatt2003.millions.model.transaction.Sale;
+import edu.ntnu.idatt2003.millions.model.transaction.Transaction;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Currency;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link TransactionStatsService}.
+ * Covers per-transaction display values via {@link TransactionStatsService#getStats} and
+ * aggregate summary values via {@link TransactionStatsService#getSummary}, including the
+ * polymorphic purchase-vs-sale dispatch that the instanceof→polymorphism refactor touched.
+ * All tests follow the AAA pattern.
+ */
+class TransactionStatsServiceTest {
+
+    private static final Currency NOK = Currency.getInstance("NOK");
+    private static final Currency USD = Currency.getInstance("USD");
+
+    private TransactionStatsService service;
+    private CurrencyConverter converter;
+
+    @BeforeEach
+    void setUp() {
+        service = new TransactionStatsService();
+        converter = new FixedRateCurrencyConverter();
+    }
+
+    private static void assertBigDecimalEquals(BigDecimal expected, BigDecimal actual) {
+        assertEquals(0, expected.compareTo(actual),
+                "Expected " + expected + " but was " + actual);
+    }
+
+    private static Stock nokStock(String price) {
+        return new Stock("TST", "Test Co.", List.of(new BigDecimal(price)), NOK);
+    }
+
+    private static Stock usdStock(String price) {
+        return new Stock("TST", "Test Co.", List.of(new BigDecimal(price)), USD);
+    }
+
+    private static Share share(Stock stock, String qty, String purchasePrice) {
+        return new Share(stock, new BigDecimal(qty), new BigDecimal(purchasePrice));
+    }
+
+    @Nested
+    @DisplayName("getStats()")
+    class GetStats {
+
+        @Nested
+        @DisplayName("purchase")
+        class PurchasePaths {
+
+            @Test
+            @DisplayName("Should return 0.5% of gross as commission for a purchase")
+            void returnsHalfPercentCommissionForPurchase() {
+                // Arrange - spec: purchase commission = 0.5% of gross
+                // price=100, qty=10: gross=1000; commission=1000×0.005=5
+                Stock stock = nokStock("100");
+                Share sh = share(stock, "10", "100");
+                Transaction purchase = new Purchase(sh, 1);
+
+                // Act
+                TransactionStatsService.TransactionStats stats = service.getStats(purchase, converter);
+
+                // Assert
+                assertBigDecimalEquals(new BigDecimal("5"), stats.commissionNative());
+            }
+
+            @Test
+            @DisplayName("Should return zero tax for a purchase")
+            void returnsZeroTaxForPurchase() {
+                // Arrange - spec: no tax is applied on purchases
+                Stock stock = nokStock("100");
+                Share sh = share(stock, "10", "100");
+                Transaction purchase = new Purchase(sh, 1);
+
+                // Act
+                TransactionStatsService.TransactionStats stats = service.getStats(purchase, converter);
+
+                // Assert
+                assertBigDecimalEquals(BigDecimal.ZERO, stats.taxNative());
+                assertBigDecimalEquals(BigDecimal.ZERO, stats.taxNok());
+            }
+
+            @Test
+            @DisplayName("Should return a negative amountNok for a purchase")
+            void returnsNegativeAmountNokForPurchase() {
+                // Arrange - spec: purchase is an outflow; gross=1000, commission=5, total=1005
+                // signedTotal = −1005 → amountNok = −1005 (NOK→NOK identity)
+                Stock stock = nokStock("100");
+                Share sh = share(stock, "10", "100");
+                Transaction purchase = new Purchase(sh, 1);
+
+                // Act
+                TransactionStatsService.TransactionStats stats = service.getStats(purchase, converter);
+
+                // Assert
+                assertBigDecimalEquals(new BigDecimal("-1005"), stats.amountNok());
+            }
+
+            @Test
+            @DisplayName("Should return purchasePrice as pricePerShare for a purchase")
+            void returnsPurchasePriceAsPerShareForPurchase() {
+                // Arrange
+                Stock stock = nokStock("120");
+                Share sh = share(stock, "5", "120");
+                Transaction purchase = new Purchase(sh, 1);
+
+                // Act
+                TransactionStatsService.TransactionStats stats = service.getStats(purchase, converter);
+
+                // Assert - spec: purchase price is the per-share price for buys
+                assertBigDecimalEquals(new BigDecimal("120"), stats.pricePerShare());
+            }
+
+            @Test
+            @DisplayName("Should expose the stock's native currency code for a purchase")
+            void returnsNativeCurrencyCodeForPurchase() {
+                // Arrange
+                Stock stock = nokStock("100");
+                Share sh = share(stock, "1", "100");
+                Transaction purchase = new Purchase(sh, 1);
+
+                // Act
+                TransactionStatsService.TransactionStats stats = service.getStats(purchase, converter);
+
+                // Assert
+                assertEquals("NOK", stats.nativeCurrencyCode());
+            }
+        }
+
+        @Nested
+        @DisplayName("profitable sale")
+        class ProfitableSalePaths {
+
+            @Test
+            @DisplayName("Should return 1% of gross as commission for a sale")
+            void returnsOnePercentCommissionForSale() {
+                // Arrange - spec: sale commission = 1% of gross
+                // salePrice=200, qty=10: gross=2000; commission=2000×0.01=20
+                Stock stock = nokStock("200");
+                Share sh = share(stock, "10", "100");
+                Transaction sale = new Sale(sh, 1);
+
+                // Act
+                TransactionStatsService.TransactionStats stats = service.getStats(sale, converter);
+
+                // Assert
+                assertBigDecimalEquals(new BigDecimal("20"), stats.commissionNative());
+            }
+
+            @Test
+            @DisplayName("Should return 30% of gain as tax for a profitable sale")
+            void returnsThirtyPercentTaxOnGainForProfitableSale() {
+                // Arrange - spec: tax = 30% of (gross − commission − purchaseCost)
+                // salePrice=200, qty=10, purchasePrice=100
+                // purchaseCost = 1000 + 1000×0.005 = 1005
+                // gross=2000, commission=20, gain=2000−20−1005=975
+                // tax = 975×0.30 = 292.5
+                Stock stock = nokStock("200");
+                Share sh = share(stock, "10", "100");
+                Transaction sale = new Sale(sh, 1);
+
+                // Act
+                TransactionStatsService.TransactionStats stats = service.getStats(sale, converter);
+
+                // Assert
+                assertBigDecimalEquals(new BigDecimal("292.5"), stats.taxNative());
+                assertBigDecimalEquals(new BigDecimal("292.5"), stats.taxNok());
+            }
+
+            @Test
+            @DisplayName("Should return a positive amountNok for a profitable sale")
+            void returnsPositiveAmountNokForProfitableSale() {
+                // Arrange - spec: sale is an inflow
+                // total = gross − commission − tax = 2000 − 20 − 292.5 = 1687.5
+                Stock stock = nokStock("200");
+                Share sh = share(stock, "10", "100");
+                Transaction sale = new Sale(sh, 1);
+
+                // Act
+                TransactionStatsService.TransactionStats stats = service.getStats(sale, converter);
+
+                // Assert
+                assertBigDecimalEquals(new BigDecimal("1687.5"), stats.amountNok());
+            }
+
+            @Test
+            @DisplayName("Should return gross divided by quantity as pricePerShare for a sale")
+            void returnsGrossDividedByQuantityAsPerShareForSale() {
+                // Arrange - gross=2000, qty=10 → pricePerShare=200
+                Stock stock = nokStock("200");
+                Share sh = share(stock, "10", "100");
+                Transaction sale = new Sale(sh, 1);
+
+                // Act
+                TransactionStatsService.TransactionStats stats = service.getStats(sale, converter);
+
+                // Assert
+                assertBigDecimalEquals(new BigDecimal("200"), stats.pricePerShare());
+            }
+        }
+
+        @Nested
+        @DisplayName("loss sale")
+        class LossSalePaths {
+
+            @Test
+            @DisplayName("Should return zero tax when sale results in a loss")
+            void returnsZeroTaxWhenSaleIsALoss() {
+                // Arrange - spec: no tax is levied when gain is zero or negative
+                // salePrice=50, qty=10, purchasePrice=100
+                // purchaseCost=1005; gross=500; commission=5; gain=500−5−1005=−510 → tax=0
+                Stock stock = nokStock("50");
+                Share sh = share(stock, "10", "100");
+                Transaction sale = new Sale(sh, 1);
+
+                // Act
+                TransactionStatsService.TransactionStats stats = service.getStats(sale, converter);
+
+                // Assert
+                assertBigDecimalEquals(BigDecimal.ZERO, stats.taxNative());
+                assertBigDecimalEquals(BigDecimal.ZERO, stats.taxNok());
+            }
+
+            @Test
+            @DisplayName("Should return a positive amountNok even when a sale is a loss")
+            void returnsPositiveAmountNokForLossSale() {
+                // Arrange - total = 500 − 5 − 0 = 495 NOK (inflow even at a loss)
+                Stock stock = nokStock("50");
+                Share sh = share(stock, "10", "100");
+                Transaction sale = new Sale(sh, 1);
+
+                // Act
+                TransactionStatsService.TransactionStats stats = service.getStats(sale, converter);
+
+                // Assert
+                assertBigDecimalEquals(new BigDecimal("495"), stats.amountNok());
+            }
+        }
+
+        @Nested
+        @DisplayName("currency conversion")
+        class CurrencyConversion {
+
+            @Test
+            @DisplayName("Should convert commission from USD to NOK for a purchase")
+            void convertsUsdPurchaseCommissionToNok() {
+                // Arrange - price=100 USD, qty=5, purchasePrice=100 USD
+                // commissionNative = 500×0.005 = 2.5 USD
+                // commissionNok = 2.5×9.21 = 23.025 NOK
+                Stock stock = usdStock("100");
+                Share sh = share(stock, "5", "100");
+                Transaction purchase = new Purchase(sh, 1);
+
+                // Act
+                TransactionStatsService.TransactionStats stats = service.getStats(purchase, converter);
+
+                // Assert
+                assertBigDecimalEquals(new BigDecimal("2.5"), stats.commissionNative());
+                assertBigDecimalEquals(new BigDecimal("23.025"), stats.commissionNok());
+            }
+
+            @Test
+            @DisplayName("Should convert amountNok from USD to NOK and expose USD currency code for a purchase")
+            void convertsUsdPurchaseAmountToNokAndExposesCurrencyCode() {
+                // Arrange - signedTotal = −502.5 USD; amountNok = −502.5×9.21 = −4628.025 NOK
+                Stock stock = usdStock("100");
+                Share sh = share(stock, "5", "100");
+                Transaction purchase = new Purchase(sh, 1);
+
+                // Act
+                TransactionStatsService.TransactionStats stats = service.getStats(purchase, converter);
+
+                // Assert
+                assertBigDecimalEquals(new BigDecimal("-4628.025"), stats.amountNok());
+                assertEquals("USD", stats.nativeCurrencyCode());
+            }
+        }
+
+        @Nested
+        @DisplayName("null inputs")
+        class NullInputs {
+
+            @Test
+            @DisplayName("Should throw NullPointerException when transaction is null")
+            void throwsWhenTransactionIsNull() {
+                // Act & Assert
+                assertThrows(NullPointerException.class,
+                        () -> service.getStats(null, converter));
+            }
+
+            @Test
+            @DisplayName("Should throw NullPointerException when converter is null")
+            void throwsWhenConverterIsNull() {
+                // Arrange
+                Stock stock = nokStock("100");
+                Transaction purchase = new Purchase(share(stock, "1", "100"), 1);
+
+                // Act & Assert
+                assertThrows(NullPointerException.class,
+                        () -> service.getStats(purchase, null));
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("getSummary()")
+    class GetSummary {
+
+        @Test
+        @DisplayName("Should return all zeros for an empty transaction list")
+        void returnsAllZerosForEmptyList() {
+            // Act
+            TransactionStatsService.TransactionSummary summary =
+                    service.getSummary(List.of(), converter);
+
+            // Assert
+            assertBigDecimalEquals(BigDecimal.ZERO, summary.purchasesNok());
+            assertBigDecimalEquals(BigDecimal.ZERO, summary.salesNok());
+            assertBigDecimalEquals(BigDecimal.ZERO, summary.totalNok());
+        }
+
+        @Test
+        @DisplayName("Should accumulate purchase amountNok into purchasesNok as a non-positive value")
+        void accumulatesPurchaseAsNonPositive() {
+            // Arrange - amountNok for purchase = −1005 (see getStats purchase tests)
+            Stock stock = nokStock("100");
+            Transaction purchase = new Purchase(share(stock, "10", "100"), 1);
+
+            // Act
+            TransactionStatsService.TransactionSummary summary =
+                    service.getSummary(List.of(purchase), converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("-1005"), summary.purchasesNok());
+            assertBigDecimalEquals(BigDecimal.ZERO, summary.salesNok());
+        }
+
+        @Test
+        @DisplayName("Should accumulate sale amountNok into salesNok as a non-negative value")
+        void accumulatesSaleAsNonNegative() {
+            // Arrange - amountNok for profitable sale = +1687.5
+            Stock stock = nokStock("200");
+            Transaction sale = new Sale(share(stock, "10", "100"), 1);
+
+            // Act
+            TransactionStatsService.TransactionSummary summary =
+                    service.getSummary(List.of(sale), converter);
+
+            // Assert
+            assertBigDecimalEquals(BigDecimal.ZERO, summary.purchasesNok());
+            assertBigDecimalEquals(new BigDecimal("1687.5"), summary.salesNok());
+        }
+
+        @Test
+        @DisplayName("Should compute totalNok as purchasesNok plus salesNok for mixed list")
+        void totalNokIsSumOfPurchasesAndSalesForMixedList() {
+            // Arrange - purchase: −1005; profitable sale: +1687.5; total: 682.5
+            Stock buyStock = nokStock("100");
+            Transaction purchase = new Purchase(share(buyStock, "10", "100"), 1);
+
+            Stock sellStock = nokStock("200");
+            Transaction sale = new Sale(share(sellStock, "10", "100"), 1);
+
+            // Act
+            TransactionStatsService.TransactionSummary summary =
+                    service.getSummary(List.of(purchase, sale), converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("-1005"), summary.purchasesNok());
+            assertBigDecimalEquals(new BigDecimal("1687.5"), summary.salesNok());
+            assertBigDecimalEquals(new BigDecimal("682.5"), summary.totalNok());
+        }
+
+        @Test
+        @DisplayName("Should sum multiple purchase amounts correctly")
+        void sumsMultiplePurchasesCorrectly() {
+            // Arrange - two purchases each −1005 → purchasesNok = −2010
+            Stock stock = nokStock("100");
+            Transaction p1 = new Purchase(share(stock, "10", "100"), 1);
+            Transaction p2 = new Purchase(share(stock, "10", "100"), 2);
+
+            // Act
+            TransactionStatsService.TransactionSummary summary =
+                    service.getSummary(List.of(p1, p2), converter);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("-2010"), summary.purchasesNok());
+            assertBigDecimalEquals(BigDecimal.ZERO, summary.salesNok());
+        }
+
+        @Test
+        @DisplayName("Should not count purchase amounts in salesNok")
+        void doesNotCountPurchasesInSalesNok() {
+            // Arrange
+            Stock stock = nokStock("100");
+            Transaction purchase = new Purchase(share(stock, "10", "100"), 1);
+
+            // Act
+            TransactionStatsService.TransactionSummary summary =
+                    service.getSummary(List.of(purchase), converter);
+
+            // Assert - purchase amounts must not leak into salesNok
+            assertBigDecimalEquals(BigDecimal.ZERO, summary.salesNok());
+        }
+
+        @Test
+        @DisplayName("Should not count sale amounts in purchasesNok")
+        void doesNotCountSalesInPurchasesNok() {
+            // Arrange
+            Stock stock = nokStock("200");
+            Transaction sale = new Sale(share(stock, "10", "100"), 1);
+
+            // Act
+            TransactionStatsService.TransactionSummary summary =
+                    service.getSummary(List.of(sale), converter);
+
+            // Assert - sale amounts must not leak into purchasesNok
+            assertBigDecimalEquals(BigDecimal.ZERO, summary.purchasesNok());
+        }
+
+        @Test
+        @DisplayName("Should throw NullPointerException when transaction list is null")
+        void throwsWhenTransactionListIsNull() {
+            // Act & Assert
+            assertThrows(NullPointerException.class,
+                    () -> service.getSummary(null, converter));
+        }
+    }
+}


### PR DESCRIPTION
## Why
 
JaCoCo showed the stateless service layer almost entirely
untested - several business-critical classes at 0% line and
branch coverage. These classes compute money (commission, tax,
realized/unrealized returns, net worth, loan interest), so an
undetected error there is a silent financial bug.
 
Rather than write tests to hit a percentage, the expected
values were derived independently from the assignment's domain
rules (0.5% purchase / 1% sale commission, 30% tax on gain,
gain = gross - commission - purchase cost, net worth = cash +
portfolio sale value) and hand-computed in each test. The point
was for the tests to be able to fail if the code is wrong, not
to mirror the implementation back at itself.
 
This worked as a contract audit: writing the tests surfaced
three real defects where documented or expected behaviour did
not match the actual code. Those are fixed here, each as its
own commit.
 
## The three defects found (the substantive part)
 
1. **`fix: reject oversell in transaction sale preview`** -
   `previewSale` silently built a Share with a quantity larger
   than the player owned and returned a preview for a trade
   that cannot execute (Share accepts any non-negative
   quantity, so nothing threw). Added validation rejecting
   quantity greater than the owned position. The regression
   test was written to fail against the unfixed code before the
   guard was added.
2. **`fix: correct getShares(String) javadoc to match null
   contract`** - the javadoc declared `@throws
   NullPointerException` for a null symbol, but the method
   returns an empty list. The behaviour is safe; the
   documentation was false. Corrected the javadoc to document
   the real contract (behaviour unchanged - making it throw
   could break callers).
3. **`fix: correct addToWatchlist unknown-symbol guard`** -
   `addToWatchlist` documented a no-op for unknown symbols, but
   the guard tested `exchange.getStock(symbol) == null` while
   `getStock` throws `IllegalArgumentException` for unknown
   symbols - so the documented no-op would instead throw.
   Changed the guard to `!exchange.hasStock(symbol)`. Surfaced
   by the new GameService watchlist tests.
These three are the same shape: documented/expected contract ≠
actual behaviour, none caught before because no test existed
for those paths at all. It is concrete evidence that the
coverage work was a real audit, not a number-chasing exercise.

## A known, deliberately-accepted test weakness
 
`PortfolioServiceTest.returnsMarketValueMinusTotalReturn`
asserts `getValue - getReturnNative`, which is a mathematical
identity (always equals purchasePrice × qty regardless of
current price). It cannot catch a symmetric sign error in both
operands. It is kept because the individual per-share value and
return tests independently catch single-operand errors before
they could combine. This is documented rather than hidden - the
limitation is understood and backstopped, not overlooked.
 
## Deliberately NOT done
 
- No mechanical renaming of existing tests. Two new tests
  (`executeForcedSale_throwsWhenGameOver`; the PlayerStats
  "Returns…" @DisplayName form) match their pre-existing
  class's style rather than the newer convention, because the
  conventions doc forbids mixing styles within a class more
  strongly than it requires the newer form. Aligning them would
  mean rewriting working legacy tests near the deadline - a
  deliberate non-change.
- No behavioural change to the currency cost-basis logic
  (purchase cost converted at current rate, not purchase-time
  rate). The assignment explicitly permits this simplification;
  it is documented in the report rather than rewritten near
  submission.
 