### PR TITLE
Test/loan

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/millions/model/loan/Loan.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/loan/Loan.java
@@ -43,7 +43,12 @@ public record Loan(LoanOffer offer, BigDecimal principal, int takenAtWeek) {
         return principal.add(totalInterest());
     }
 
-    /** Number of weeks elapsed since the loan was taken. */
+    /**
+     * Number of weeks elapsed since the loan was taken.
+     *
+     * <p>Precondition: {@code currentWeek >= takenAtWeek}. Behaviour for earlier
+     * weeks is undefined (the result will be negative).
+     */
     public int weeksElapsed(int currentWeek) {
         return currentWeek - takenAtWeek;
     }
@@ -53,7 +58,12 @@ public record Loan(LoanOffer offer, BigDecimal principal, int takenAtWeek) {
         return Math.max(0, offer.termWeeks() - weeksElapsed(currentWeek));
     }
 
-    /** Interest already paid up to {@code currentWeek} (weeklyInterest × weeksElapsed). */
+    /**
+     * Interest already paid up to {@code currentWeek} (weeklyInterest × weeksElapsed).
+     *
+     * <p>Precondition: {@code currentWeek >= takenAtWeek}. Behaviour for earlier
+     * weeks is undefined (the result will be negative).
+     */
     public BigDecimal interestPaid(int currentWeek) {
         return weeklyInterest().multiply(BigDecimal.valueOf(weeksElapsed(currentWeek)));
     }
@@ -63,7 +73,16 @@ public record Loan(LoanOffer offer, BigDecimal principal, int takenAtWeek) {
         return weeklyInterest().multiply(BigDecimal.valueOf(weeksRemaining(currentWeek)));
     }
 
-    /** True when {@code currentWeek} is the week this loan's principal becomes due. */
+    /**
+     * Returns true when this loan's principal is due — that is, when
+     * {@code currentWeek >= takenAtWeek + termWeeks}.
+     *
+     * <p>Note that this returns true for the due week and any week thereafter;
+     * preventing duplicate settlement is the caller's responsibility. In
+     * practice, settled loans are removed from the active-loans list
+     * immediately, so this method is only ever evaluated for loans that have
+     * not yet been settled.
+     */
     public boolean isDueThisWeek(int currentWeek) {
         return weeksRemaining(currentWeek) == 0;
     }

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/loan/LoanTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/loan/LoanTest.java
@@ -11,48 +11,406 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit tests for the {@link Loan} record.
+ * Covers the compact constructor (all documented rejection rules) and every public
+ * method — weeklyInterest, totalInterest, totalRepayment, weeksElapsed, weeksRemaining,
+ * interestPaid, interestSaved, and isDueThisWeek.
+ * All expected values are derived by hand from domain rules; none are read from the
+ * implementation. All tests follow the AAA pattern.
  */
 class LoanTest {
 
-    private LoanOffer offer;
+    // rate=1%/week, term=4 weeks, maxPrincipal=10000.00, LOW risk
+    private static final LoanOffer STANDARD_OFFER = new LoanOffer(
+            "standard", new BigDecimal("0.01"), 4,
+            new BigDecimal("10000.00"), LoanRiskLevel.LOW);
 
-    @BeforeEach
-    void setUp() {
-        offer = new LoanOffer("test", new BigDecimal("0.01"), 4,
-                new BigDecimal("1000.00"), LoanRiskLevel.LOW);
+    private static void assertBigDecimalEquals(BigDecimal expected, BigDecimal actual) {
+        assertEquals(0, expected.compareTo(actual),
+                "Expected " + expected + " but was " + actual);
     }
+
+    // ─── Constructor ────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("Loan()")
+    class LoanConstructor {
+
+        @Test
+        @DisplayName("Should throw NullPointerException when offer is null")
+        void throwsNullPointerExceptionWhenOfferIsNull() {
+            // Act & Assert
+            NullPointerException ex = assertThrows(NullPointerException.class,
+                    () -> new Loan(null, new BigDecimal("100.00"), 1));
+            assertEquals("Offer cannot be null", ex.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should throw NullPointerException when principal is null")
+        void throwsNullPointerExceptionWhenPrincipalIsNull() {
+            // Act & Assert
+            NullPointerException ex = assertThrows(NullPointerException.class,
+                    () -> new Loan(STANDARD_OFFER, null, 1));
+            assertEquals("Principal cannot be null", ex.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should throw IllegalArgumentException when principal is zero")
+        void throwsIllegalArgumentExceptionWhenPrincipalIsZero() {
+            // Act & Assert
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    () -> new Loan(STANDARD_OFFER, BigDecimal.ZERO, 1));
+            assertEquals("Principal must be positive", ex.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should throw IllegalArgumentException when principal is negative")
+        void throwsIllegalArgumentExceptionWhenPrincipalIsNegative() {
+            // Act & Assert
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    () -> new Loan(STANDARD_OFFER, new BigDecimal("-500.00"), 1));
+            assertEquals("Principal must be positive", ex.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should throw IllegalArgumentException when principal exceeds the offer maximum")
+        void throwsIllegalArgumentExceptionWhenPrincipalExceedsMaximum() {
+            // Act & Assert — STANDARD_OFFER maxPrincipal=10000.00; 10000.01 is strictly greater
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    () -> new Loan(STANDARD_OFFER, new BigDecimal("10000.01"), 1));
+            assertTrue(ex.getMessage().contains("exceeds offer maximum"),
+                    "Message should name the excess: " + ex.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should throw IllegalArgumentException when takenAtWeek is negative")
+        void throwsIllegalArgumentExceptionWhenTakenAtWeekIsNegative() {
+            // Act & Assert
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    () -> new Loan(STANDARD_OFFER, new BigDecimal("100.00"), -1));
+            assertEquals("takenAtWeek must be non-negative", ex.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should accept a principal exactly equal to the offer maximum")
+        void acceptsPrincipalEqualToOfferMaximum() {
+            // Act & Assert — principal == maxPrincipal: compareTo returns 0, not > 0; must not throw
+            assertDoesNotThrow(
+                    () -> new Loan(STANDARD_OFFER, new BigDecimal("10000.00"), 1));
+        }
+
+        @Test
+        @DisplayName("Should accept takenAtWeek of zero")
+        void acceptsZeroAsTakenAtWeek() {
+            // Act & Assert — zero is the minimum valid value for takenAtWeek
+            assertDoesNotThrow(
+                    () -> new Loan(STANDARD_OFFER, new BigDecimal("500.00"), 0));
+        }
+
+        @Test
+        @DisplayName("Should store offer, principal, and takenAtWeek as supplied")
+        void storesFieldsAsSupplied() {
+            // Arrange
+            BigDecimal principal = new BigDecimal("750.00");
+            // Act
+            Loan loan = new Loan(STANDARD_OFFER, principal, 3);
+            // Assert
+            assertSame(STANDARD_OFFER, loan.offer());
+            assertBigDecimalEquals(principal, loan.principal());
+            assertEquals(3, loan.takenAtWeek());
+        }
+    }
+
+    // ─── weeklyInterest() ───────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("weeklyInterest()")
+    class WeeklyInterest {
+
+        @Test
+        @DisplayName("Should return principal times weeklyInterestRate rounded to 2 decimal places")
+        void returnsRateTimesPrincipal() {
+            // Arrange — principal=1000.00, rate=0.01; 1000.00 × 0.01 = 10.00
+            Loan loan = new Loan(STANDARD_OFFER, new BigDecimal("1000.00"), 1);
+            // Act & Assert
+            assertBigDecimalEquals(new BigDecimal("10.00"), loan.weeklyInterest());
+        }
+
+        @Test
+        @DisplayName("Should round to 2 decimal places using HALF_UP when the raw product is not exact")
+        void roundsToTwoDecimalsHalfUp() {
+            // Arrange — rate=0.001, principal=333; raw = 333 × 0.001 = 0.333 → HALF_UP 2dp → 0.33
+            // (third decimal digit is 3, which is < 5, so rounds down)
+            LoanOffer roundingOffer = new LoanOffer("r", new BigDecimal("0.001"), 10,
+                    new BigDecimal("10000.00"), LoanRiskLevel.LOW);
+            Loan loan = new Loan(roundingOffer, new BigDecimal("333"), 1);
+            // Act & Assert
+            assertBigDecimalEquals(new BigDecimal("0.33"), loan.weeklyInterest());
+        }
+    }
+
+    // ─── totalInterest() ────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("totalInterest()")
+    class TotalInterest {
+
+        @Test
+        @DisplayName("Should return weeklyInterest multiplied by the number of term weeks")
+        void returnsWeeklyInterestTimesTermWeeks() {
+            // Arrange — principal=1000.00, rate=0.01, term=4;
+            // weeklyInterest=10.00; totalInterest=10.00 × 4 = 40.00
+            Loan loan = new Loan(STANDARD_OFFER, new BigDecimal("1000.00"), 1);
+            // Act & Assert
+            assertBigDecimalEquals(new BigDecimal("40.00"), loan.totalInterest());
+        }
+
+        @Test
+        @DisplayName("Should use the rounded weekly amount, not the raw principal-times-rate product")
+        void usesRoundedWeeklyInterestNotRawProduct() {
+            // Arrange — rate=0.001, term=10, principal=333;
+            // rounded weekly=0.33; totalInterest=0.33 × 10 = 3.30
+            // (raw product 0.333 × 10 = 3.33 would be wrong — rounding applies first)
+            LoanOffer roundingOffer = new LoanOffer("r", new BigDecimal("0.001"), 10,
+                    new BigDecimal("10000.00"), LoanRiskLevel.LOW);
+            Loan loan = new Loan(roundingOffer, new BigDecimal("333"), 1);
+            // Act & Assert
+            assertBigDecimalEquals(new BigDecimal("3.30"), loan.totalInterest());
+        }
+    }
+
+    // ─── totalRepayment() ───────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("totalRepayment()")
+    class TotalRepayment {
+
+        @Test
+        @DisplayName("Should return principal plus totalInterest")
+        void returnsPrincipalPlusTotalInterest() {
+            // Arrange — principal=1000.00, totalInterest=40.00; totalRepayment=1000.00+40.00=1040.00
+            Loan loan = new Loan(STANDARD_OFFER, new BigDecimal("1000.00"), 1);
+            // Act & Assert
+            assertBigDecimalEquals(new BigDecimal("1040.00"), loan.totalRepayment());
+        }
+
+        @Test
+        @DisplayName("Should include the rounded total interest when weekly rounding is in effect")
+        void includesRoundedTotalInterest() {
+            // Arrange — rate=0.001, term=10, principal=333;
+            // rounded weekly=0.33; totalInterest=3.30; totalRepayment=333+3.30=336.30
+            LoanOffer roundingOffer = new LoanOffer("r", new BigDecimal("0.001"), 10,
+                    new BigDecimal("10000.00"), LoanRiskLevel.LOW);
+            Loan loan = new Loan(roundingOffer, new BigDecimal("333"), 1);
+            // Act & Assert
+            assertBigDecimalEquals(new BigDecimal("336.30"), loan.totalRepayment());
+        }
+    }
+
+    // ─── weeksElapsed() ─────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("weeksElapsed()")
+    class WeeksElapsed {
+
+        @Test
+        @DisplayName("Should return zero at the week the loan was taken")
+        void returnsZeroAtTheTakenWeek() {
+            // Arrange — takenAtWeek=3, currentWeek=3; elapsed = 3 - 3 = 0
+            Loan loan = new Loan(STANDARD_OFFER, new BigDecimal("1000.00"), 3);
+            // Act & Assert
+            assertEquals(0, loan.weeksElapsed(3));
+        }
+
+        @Test
+        @DisplayName("Should return one after one week has passed")
+        void returnsOneAfterOneWeek() {
+            // Arrange — takenAtWeek=1, currentWeek=2; elapsed = 2 - 1 = 1
+            Loan loan = new Loan(STANDARD_OFFER, new BigDecimal("1000.00"), 1);
+            // Act & Assert
+            assertEquals(1, loan.weeksElapsed(2));
+        }
+
+        @Test
+        @DisplayName("Should return the term length at the due week")
+        void returnsTermLengthAtDueWeek() {
+            // Arrange — takenAtWeek=1, term=4, currentWeek=5 (due week); elapsed = 5 - 1 = 4
+            Loan loan = new Loan(STANDARD_OFFER, new BigDecimal("1000.00"), 1);
+            // Act & Assert
+            assertEquals(4, loan.weeksElapsed(5));
+        }
+    }
+
+    // ─── weeksRemaining() ───────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("weeksRemaining()")
+    class WeeksRemaining {
+
+        private Loan loan;
+
+        @BeforeEach
+        void setUp() {
+            // principal=1000.00, rate=0.01, term=4, takenAtWeek=1; due week = 1+4 = 5
+            loan = new Loan(STANDARD_OFFER, new BigDecimal("1000.00"), 1);
+        }
+
+        @Test
+        @DisplayName("Should return the full term length at the week the loan was taken")
+        void returnsFullTermAtTakenWeek() {
+            // Act & Assert — currentWeek=1; elapsed=0; remaining = max(0, 4-0) = 4
+            assertEquals(4, loan.weeksRemaining(1));
+        }
+
+        @Test
+        @DisplayName("Should return one in the week immediately before the due week")
+        void returnsOneOneWeekBeforeDue() {
+            // Act & Assert — currentWeek=4; elapsed=3; remaining = max(0, 4-3) = 1
+            assertEquals(1, loan.weeksRemaining(4));
+        }
+
+        @Test
+        @DisplayName("Should return zero at the due week")
+        void returnsZeroAtDueWeek() {
+            // Act & Assert — currentWeek=5; elapsed=4; remaining = max(0, 4-4) = 0
+            assertEquals(0, loan.weeksRemaining(5));
+        }
+
+        @Test
+        @DisplayName("Should return zero one week past the due week — clamped, not negative")
+        void returnsZeroOneWeekPastDue() {
+            // Act & Assert — currentWeek=6; elapsed=5; max(0, 4-5) = max(0, -1) = 0
+            assertEquals(0, loan.weeksRemaining(6));
+        }
+
+        @Test
+        @DisplayName("Should return zero when well past the due week")
+        void returnsZeroWhenWellPastDue() {
+            // Act & Assert — currentWeek=20; elapsed=19; max(0, 4-19) = 0
+            assertEquals(0, loan.weeksRemaining(20));
+        }
+    }
+
+    // ─── interestPaid() ─────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("interestPaid()")
+    class InterestPaid {
+
+        private Loan loan;
+
+        @BeforeEach
+        void setUp() {
+            // principal=1000.00, rate=0.01 → weekly=10.00; term=4, takenAtWeek=1
+            loan = new Loan(STANDARD_OFFER, new BigDecimal("1000.00"), 1);
+        }
+
+        @Test
+        @DisplayName("Should return zero at the week the loan was taken")
+        void returnsZeroAtTakenWeek() {
+            // Act & Assert — elapsed=0; paid = 10.00 × 0 = 0
+            assertBigDecimalEquals(BigDecimal.ZERO, loan.interestPaid(1));
+        }
+
+        @Test
+        @DisplayName("Should return weekly interest times elapsed weeks after several weeks")
+        void returnsWeeklyTimesElapsedAfterSeveralWeeks() {
+            // Act & Assert — currentWeek=4; elapsed=3; paid = 10.00 × 3 = 30.00
+            assertBigDecimalEquals(new BigDecimal("30.00"), loan.interestPaid(4));
+        }
+
+        @Test
+        @DisplayName("Should return the full total interest at the due week")
+        void returnsFullTotalInterestAtDueWeek() {
+            // Act & Assert — currentWeek=5; elapsed=4; paid = 10.00 × 4 = 40.00 (= totalInterest)
+            assertBigDecimalEquals(new BigDecimal("40.00"), loan.interestPaid(5));
+        }
+    }
+
+    // ─── interestSaved() ────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("interestSaved()")
+    class InterestSaved {
+
+        private Loan loan;
+
+        @BeforeEach
+        void setUp() {
+            // principal=1000.00, rate=0.01 → weekly=10.00; term=4, takenAtWeek=1; due week=5
+            loan = new Loan(STANDARD_OFFER, new BigDecimal("1000.00"), 1);
+        }
+
+        @Test
+        @DisplayName("Should return the full total interest at the week the loan was taken")
+        void returnsFullInterestAtTakenWeek() {
+            // Act & Assert — currentWeek=1; remaining=4; saved = 10.00 × 4 = 40.00 (= totalInterest)
+            assertBigDecimalEquals(new BigDecimal("40.00"), loan.interestSaved(1));
+        }
+
+        @Test
+        @DisplayName("Should return one week's interest when repaid one week before the due week")
+        void returnsOneWeeklyInterestOneWeekBeforeDue() {
+            // Act & Assert — currentWeek=4; remaining=1; saved = 10.00 × 1 = 10.00
+            assertBigDecimalEquals(new BigDecimal("10.00"), loan.interestSaved(4));
+        }
+
+        @Test
+        @DisplayName("Should return zero at the due week — nothing left to save")
+        void returnsZeroAtDueWeek() {
+            // Act & Assert — currentWeek=5; remaining=0; saved = 10.00 × 0 = 0
+            assertBigDecimalEquals(BigDecimal.ZERO, loan.interestSaved(5));
+        }
+
+        @Test
+        @DisplayName("Should return zero after the due week has passed")
+        void returnsZeroAfterDueWeekHasPassed() {
+            // Act & Assert — currentWeek=6; remaining=0 (clamped); saved = 10.00 × 0 = 0
+            assertBigDecimalEquals(BigDecimal.ZERO, loan.interestSaved(6));
+        }
+    }
+
+    // ─── isDueThisWeek() ────────────────────────────────────────────────────────
 
     @Nested
     @DisplayName("isDueThisWeek()")
     class IsDueThisWeek {
 
-        @Test
-        @DisplayName("returns true when weeksRemaining equals zero at due week")
-        void isDueThisWeek_trueAtDueWeek() {
-            // Loan taken at week 1, term 4 → due at week 5
-            Loan loan = new Loan(offer, new BigDecimal("100.00"), 1);
-            assertTrue(loan.isDueThisWeek(5));
+        private Loan loan;
+
+        @BeforeEach
+        void setUp() {
+            // takenAtWeek=1, term=4; due week = 1 + 4 = 5
+            loan = new Loan(STANDARD_OFFER, new BigDecimal("1000.00"), 1);
         }
 
         @Test
-        @DisplayName("returns false one week before the due week")
-        void isDueThisWeek_falseOneWeekBefore() {
-            Loan loan = new Loan(offer, new BigDecimal("100.00"), 1);
-            assertFalse(loan.isDueThisWeek(4));
-        }
-
-        @Test
-        @DisplayName("returns false at the week the loan was taken")
-        void isDueThisWeek_falseAtTakenWeek() {
-            Loan loan = new Loan(offer, new BigDecimal("100.00"), 1);
+        @DisplayName("Should return false at the week the loan was taken")
+        void returnsFalseAtTakenWeek() {
+            // Act & Assert — currentWeek=1; remaining=4 ≠ 0
             assertFalse(loan.isDueThisWeek(1));
         }
 
         @Test
-        @DisplayName("returns false when week is before takenAtWeek")
-        void isDueThisWeek_falseBeforeTakenWeek() {
-            Loan loan = new Loan(offer, new BigDecimal("100.00"), 3);
-            assertFalse(loan.isDueThisWeek(2));
+        @DisplayName("Should return false one week before the due week")
+        void returnsFalseOneWeekBeforeDue() {
+            // Act & Assert — currentWeek=4; remaining=1 ≠ 0
+            assertFalse(loan.isDueThisWeek(4));
+        }
+
+        @Test
+        @DisplayName("Should return true at the exact due week")
+        void returnsTrueAtExactDueWeek() {
+            // Act & Assert — currentWeek=5 = takenAtWeek + term = 1 + 4; remaining=0
+            assertTrue(loan.isDueThisWeek(5));
+        }
+
+        @Test
+        @DisplayName("Should return true one week past the due week — at-or-past semantics")
+        void returnsTrueOneWeekPastDue() {
+            // Act & Assert — currentWeek=6; remaining=max(0, 4-5)=0 → true.
+            // Contract: isDueThisWeek returns true for currentWeek >= takenAtWeek + termWeeks.
+            // This prevents a skipped due week from silently leaving a loan unsettled.
+            assertTrue(loan.isDueThisWeek(6));
         }
     }
 }


### PR DESCRIPTION
## Why
 
After the service-layer testing work brought every service
class to 100% coverage, JaCoCo flagged three remaining model
classes with low coverage. `Loan` was the clearest gap -
58% lines, 63% branches, four of nine methods completely
unexercised - in a class that governs the loan feature's debt
lifecycle.
 
The same spec-first discipline as the service work was applied:
the expected contract for each method was stated from the
javadoc and domain rules BEFORE writing any test, then
confirmed before tests were committed. As with the three
previous rounds, this surfaced a documented-contract-vs-actual-
code mismatch - the fourth of the same pattern.
 
## The defect found
 
`Loan.isDueThisWeek(int)` documented "the week this loan's
principal becomes due" - wording that implies exactly one
week. The implementation delegates to `weeksRemaining(...) ==
0`, which clamps at zero, so the method actually returns true
for the due week AND every subsequent week.
 
The investigation step before writing tests asked: is this
benign or harmful? A grep of every call site showed the
implementation is correct for how it is used - settled loans
are evicted from `activeLoans` immediately after repayment, so
subsequent week advances never re-evaluate them. The "still
true past due" behaviour is also defensive: if a week were
ever skipped (e.g. save/load crossing a due week), the loan
would still be caught instead of silently missed.
 
So this is the same shape as Flaw 3 (`getShares` javadoc): the
behaviour is correct, the documentation lied. The fix is to
make the documentation true.
 
The same javadoc commit also clarified that `weeksElapsed` and
`interestPaid` have a precondition (`currentWeek >=
takenAtWeek`) - they return negative values for earlier
weeks, which is undefined behaviour that should not be
codified as "correct" in tests.
 
## Commits
 
1. **`fix: clarify Loan javadoc to match at-or-past-due
   semantics`** - javadoc-only on three methods
   (`isDueThisWeek`, `weeksElapsed`, `interestPaid`). No
   method bodies changed.
2. **`test: add spec-derived tests for Loan`** - 30 new tests
   against the confirmed contract. Coverage 58%/63% → 100%/
   100%.
## What the tests catch
 
Each financial-calculation test has a concrete realistic
regression it would detect. Three worth highlighting:
 
- `usesRoundedWeeklyInterestNotRawProduct` - pins the design
  decision that `totalInterest()` multiplies the *rounded*
  weekly figure by term, not raw `principal × rate × term`.
  With principal=333 and rate=0.001, the rounded path gives
  3.30 and the raw path gives 3.33; if a future change reversed
  the order, this test fails.
- `roundsToTwoDecimalsHalfUp` - fails if rounding mode is
  changed to CEILING (0.333 → 0.34 instead of 0.33).
- `returnsTrueOneWeekPastDue` (`isDueThisWeek`) - this is a
  seal test. The javadoc now documents the "at or past due"
  semantics, and the implementation depends on the structural
  invariant (settled loans removed from active list) for
  correctness. If a future developer "fixes" the method back
  to exact-week semantics - assuming the documentation was
  imprecise the other way - this test fails and reminds them
  of the invariant.
`weeksElapsed` and `interestPaid` are deliberately NOT tested
with negative inputs. The clarified javadoc states this is
undefined behaviour, and freezing undefined behaviour as
"correct" in a test is a contract trap - the test would
prevent a legitimate future change to clamp or throw.
 