### PR TITLE
test+docs+refactor: close the last model gap and make the TableCells convention explicit

### DIFF
--- a/docs/view_css_conventions.md
+++ b/docs/view_css_conventions.md
@@ -100,6 +100,48 @@ Typography classes define **zero padding**. Spacing between text elements is the
 
 ---
 
+## Table cells — `TableCells` and `holdings.css`
+
+`holdings.css` is the source of truth for what header and data cells look like. `TableCells` is the only way to create those cells in Java code - it ensures the correct CSS class is applied and prevents raw `new Label()` + `getStyleClass().add()` calls from scattering class names across the codebase.
+
+```java
+// Correct
+Label cell   = TableCells.data(stock.getSymbol());
+Label header = TableCells.header("Company");
+
+// Wrong
+Label cell = new Label(stock.getSymbol());
+cell.getStyleClass().add("holdings-cell");
+```
+
+### Cell factories
+
+| Factory method | CSS class(es) | Typical use |
+|---|---|---|
+| `TableCells.header(text)` | `holdings-header` | Non-interactive column header label |
+| `TableCells.sortHeader(text, active, ascending, onClick)` | `holdings-header` | Sortable column header button |
+| `TableCells.data(text)` | `holdings-cell` | Plain data cell |
+| `TableCells.boldData(text)` | `holdings-cell`, `bold` | Bold data cell for total rows |
+| `TableCells.empty(text)` | `holdings-empty` | Centered empty-state message |
+
+Specialised cells that carry more than a typography class belong elsewhere: use `ChangeFormatter.styledAmount` / `styledPercent` for sign-colored values, component CSS for badges, and manual `Button` construction for action links. Do not add styling shortcuts for one-off cases to `TableCells`.
+
+### Grid helpers
+
+Three methods write directly to a `GridPane` and remove boilerplate that every table card would otherwise duplicate:
+
+- `configureColumns(grid, widths, alignments)` — applies percentage widths and horizontal alignments from parallel arrays. Call once during construction; does not clear existing constraints.
+- `addHeaderRow(grid, headers)` — writes one `header(text)` cell per entry at row 0.
+- `renderEmptyState(grid, message, columnCount)` — adds the `empty(text)` label at row 1, centered and spanning all columns.
+
+### Adding a new cell factory
+
+1. Add the CSS class to `holdings.css`.
+2. Add a static factory method to `TableCells` that applies it.
+3. Use the factory method everywhere that cell type appears — do not mix direct `Label` construction for the same role.
+
+---
+
 ## Component-specific CSS
 
 Rules that only apply to one component belong in that component's CSS file (e.g. `holdings.css`, `modal.css`). Use a consistent prefix so the scope is immediately clear:

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/HoldingsCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/HoldingsCard.java
@@ -188,13 +188,11 @@ public class HoldingsCard extends SortableTableCard<Share, HoldingsSort.SortColu
         GridPane.setColumnSpan(divider, sort.getColumnDefs().size());
         totalGrid.add(divider, 0, 0);
 
-        Label totalLabel = new Label(LanguageManager.get("dashboard.portfolio.total"));
-        totalLabel.getStyleClass().addAll("holdings-cell", "bold");
+        Label totalLabel = TableCells.boldData(LanguageManager.get("dashboard.portfolio.total"));
         totalGrid.add(totalLabel, TOTAL_COL_COMPANY, 1);
 
-        Label valueNok = new Label(MoneyFormatter.format(
+        Label valueNok = TableCells.boldData(MoneyFormatter.format(
                 portfolioService.getValue(gameService.getPlayer(), gameService.getCurrencyConverter())));
-        valueNok.getStyleClass().addAll("holdings-cell", "bold");
         totalGrid.add(valueNok, TOTAL_COL_VALUE_NOK, 1);
 
         totalGrid.add(coloredPercentCell(portfolioService.getTotalReturnPercent(

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/exchange/stocks/card/StocksRowRenderer.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/exchange/stocks/card/StocksRowRenderer.java
@@ -80,8 +80,7 @@ class StocksRowRenderer extends RowRenderer {
         }
         starButton.setOnAction(e -> onWatchlistToggle.accept(stock.getSymbol()));
 
-        Label tickerLabel = new Label(stock.getSymbol());
-        tickerLabel.getStyleClass().add("holdings-cell");
+        Label tickerLabel = TableCells.data(stock.getSymbol());
 
         HBox.setHgrow(tickerLabel, Priority.ALWAYS);
         tickerLabel.setMaxWidth(Double.MAX_VALUE);

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/stock/ShareTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/stock/ShareTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for the {@link Share} class.
@@ -34,6 +35,11 @@ class ShareTest {
         stock = new Stock("NKE", "Nike, Inc",
                 new ArrayList<>(List.of(new BigDecimal("120.00"))));
         share = new Share(stock, new BigDecimal("10"), new BigDecimal("90.00"));
+    }
+
+    private static void assertBigDecimalEquals(BigDecimal expected, BigDecimal actual) {
+        assertEquals(0, expected.compareTo(actual),
+                "Expected " + expected + " but was " + actual);
     }
 
     @Nested
@@ -133,6 +139,63 @@ class ShareTest {
             BigDecimal price = share.getPurchasePrice();
             // Assert
             assertEquals(new BigDecimal("90.00"), price);
+        }
+    }
+
+    @Nested
+    @DisplayName("getReturnPercent()")
+    class GetReturnPercent {
+
+        @Test
+        @DisplayName("Should return positive percent when current price exceeds purchase price")
+        void returnsPositivePercentForGain() {
+            // Arrange — stock price=120, qty=10, purchasePrice=90
+            // cost=900, currentValue=1200, returnNative=300
+            // returnPercent = 300×100/900 = 33.333... → HALF_UP 2dp = 33.33
+            // Act
+            BigDecimal result = share.getReturnPercent();
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("33.33"), result);
+        }
+
+        @Test
+        @DisplayName("Should return negative percent when current price is below purchase price")
+        void returnsNegativePercentForLoss() {
+            // Arrange — stock price=80, qty=10, purchasePrice=100
+            // cost=1000, currentValue=800, returnNative=−200
+            // returnPercent = −200×100/1000 = −20.00
+            Stock losingStock = new Stock("AAPL", "Apple Inc.",
+                    new ArrayList<>(List.of(new BigDecimal("80.00"))));
+            Share losingShare = new Share(losingStock, new BigDecimal("10"), new BigDecimal("100.00"));
+            // Act
+            BigDecimal result = losingShare.getReturnPercent();
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("-20.00"), result);
+        }
+
+        @Test
+        @DisplayName("Should return zero when cost basis is zero")
+        void returnsZeroWhenCostBasisIsZero() {
+            // Arrange — purchasePrice=0, qty=10: cost=0 → zero-cost guard activates
+            Share zeroCostShare = new Share(stock, new BigDecimal("10"), BigDecimal.ZERO);
+            // Act & Assert
+            assertBigDecimalEquals(BigDecimal.ZERO, zeroCostShare.getReturnPercent());
+        }
+    }
+
+    @Nested
+    @DisplayName("mergedWith()")
+    class MergedWith {
+
+        @Test
+        @DisplayName("Should throw exception when merging shares of different stocks")
+        void throwsExceptionWhenSymbolsDiffer() {
+            // Arrange
+            Stock otherStock = new Stock("AAPL", "Apple Inc.",
+                    new ArrayList<>(List.of(new BigDecimal("200.00"))));
+            Share otherShare = new Share(otherStock, new BigDecimal("5"), new BigDecimal("180.00"));
+            // Act & Assert
+            assertThrows(IllegalArgumentException.class, () -> share.mergedWith(otherShare));
         }
     }
 }


### PR DESCRIPTION
## Why

Two loose ends from the testing/documentation cleanup:

1. JaCoCo flagged `Share` at 77% lines / 63% branches with one
   public method (`getReturnPercent`) entirely uncovered. The
   method is used across HoldingsCard, ShareDetailsModal,
   ForcedSaleDialog and similar - a regression there would
   show as a wrong return percentage in the UI for every
   position. The reason coverage was zero is structural: every
   call site is in `view.*`, which is not unit-tested.
2. `view_css_conventions.md` documented `StyledText` as the
   enforced access point for text roles in Java code, but
   made no equivalent statement about `TableCells`, even
   though `TableCells` plays the exact same role for table
   cell construction across the codebase. A reader checking
   the doc against the code would find `TableCells.data(...)`
   calls everywhere with no mention of the convention they
   embody. Once the documentation gap was closed, a quick grep
   surfaced three call sites that violated the now-documented
   convention - bypassing `TableCells` with raw `new Label(...)`
   + `getStyleClass().add("holdings-cell", ...)`. Those three
   sites are brought into compliance in the third commit.

## Commits

1. **`test: add tests for Share's uncovered methods`** -
   spec-derived tests for `getReturnPercent()` (positive
   return, negative return, zero-cost-basis guard) and one
   negative test for `mergedWith()` when the two shares belong
   to different stock symbols. The `mergedWith` mismatch is a
   domain invariant (same-stock requirement for weighted-
   average GAV merging), not a trivial null check - worth
   pinning because the type system cannot enforce it and the
   guard is the only thing standing between a programming
   error and silently-incorrect averages.
2. **`docs: document TableCells as the enforced access point
   for table cell construction`** - added a section to
   `view_css_conventions.md` mirroring the existing
   `StyledText` section: what `TableCells` is, why it exists
   (same reason - prevent raw `Label` construction with manual
   style class application), its factory methods, correct vs
   incorrect usage, and a pointer to the `holdings-cell` CSS
   class. No other section of the doc was touched.
3. **`refactor: route bypassed holdings-cell labels through
   TableCells`** - three call sites that bypassed the
   convention: two cells in HoldingsCard's totals row
   (replaced with `TableCells.boldData(...)`) and the ticker
   label in StocksRowRenderer (replaced with
   `TableCells.data(...)`). The StocksRowRenderer change keeps
   the local `tickerLabel` reference because `HBox.setHgrow`
   and `setMaxWidth` are applied to it afterwards - that still
   works because `TableCells.data()` returns a `Label`. Net
   deletion (raw construction lines removed), no new
   styling behaviour.

## How the third commit was found

After documenting the `TableCells` convention, the natural
next question was whether the code actually followed it. A
grep for raw `holdings-cell` class applications outside
`TableCells` itself returned three hits - all in cell-renderer
contexts where the convention is most important to keep
uniform. Treated as small follow-ups rather than ignored,
since leaving documented-but-violated conventions in place
would have made the new doc section misleading on day one.