### PR TITLE
test: cover TransactionArchive's range query methods.

### DIFF
--- a/src/test/java/edu/ntnu/idatt2003/millions/model/transaction/TransactionArchiveTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/transaction/TransactionArchiveTest.java
@@ -401,6 +401,159 @@ class TransactionArchiveTest {
         }
     }
 
+    @Nested
+    @DisplayName("getTransactionsInRange()")
+    class GetTransactionsInRange {
+
+        @Test
+        @DisplayName("Should throw IllegalArgumentException when fromWeek is zero")
+        void throwsWhenFromWeekIsZero() {
+            // Act & Assert
+            assertThrows(IllegalArgumentException.class, () ->
+                    archive.getTransactionsInRange(0, 5));
+        }
+
+        @Test
+        @DisplayName("Should throw IllegalArgumentException when fromWeek is negative")
+        void throwsWhenFromWeekIsNegative() {
+            // Act & Assert
+            assertThrows(IllegalArgumentException.class, () ->
+                    archive.getTransactionsInRange(-1, 5));
+        }
+
+        @Test
+        @DisplayName("Should return only transactions within the requested week range")
+        void returnsOnlyTransactionsInRange() {
+            // Arrange — transactions at weeks 1, 2, 3; request [2, 3]
+            // week 1 is below fromWeek=2 and must be excluded → 2 results
+            Purchase week1 = new Purchase(share, 1);
+            Purchase week2 = new Purchase(share, 2);
+            Purchase week3 = new Purchase(share, 3);
+            archive.add(week1);
+            archive.add(week2);
+            archive.add(week3);
+            // Act
+            List<Transaction> result = archive.getTransactionsInRange(2, 3);
+            // Assert
+            assertEquals(2, result.size());
+            assertTrue(result.contains(week2));
+            assertTrue(result.contains(week3));
+            assertFalse(result.contains(week1));
+        }
+
+        @Test
+        @DisplayName("Should return transactions in cross-week order, earlier weeks first")
+        void returnsTransactionsInCrossWeekOrder() {
+            // Arrange — add week 3 before week 1 (insertion order reversed) to prove
+            // result order follows week number, not insertion order
+            Purchase week3 = new Purchase(share, 3);
+            Purchase week1 = new Purchase(share, 1);
+            archive.add(week3);
+            archive.add(week1);
+            // Act
+            List<Transaction> result = archive.getTransactionsInRange(1, 3);
+            // Assert — week 1 transaction must appear before week 3 transaction
+            assertTrue(result.indexOf(week1) < result.indexOf(week3));
+        }
+
+        @Test
+        @DisplayName("Should return empty list when toWeek is less than fromWeek")
+        void returnsEmptyListWhenRangeIsInverted() {
+            // Arrange — archive has a transaction but inverted range [5, 3] matches none
+            archive.add(new Purchase(share, 4));
+            // Act & Assert
+            assertTrue(archive.getTransactionsInRange(5, 3).isEmpty());
+        }
+
+        @Test
+        @DisplayName("Should return a fresh mutable copy independent of archive state")
+        void returnedListIsFreshMutableCopy() {
+            // Arrange — one transaction in week 1
+            archive.add(new Purchase(share, 1));
+            // Act — retrieve and immediately clear the returned list
+            List<Transaction> result = archive.getTransactionsInRange(1, 1);
+            result.clear();
+            // Assert — archive must be unaffected; a second call still returns 1 transaction
+            assertEquals(1, archive.getTransactionsInRange(1, 1).size());
+        }
+    }
+
+    @Nested
+    @DisplayName("countPurchasesInRange()")
+    class CountPurchasesInRange {
+
+        @Test
+        @DisplayName("Should throw IllegalArgumentException when fromWeek is invalid")
+        void throwsWhenFromWeekIsInvalid() {
+            // Act & Assert
+            assertThrows(IllegalArgumentException.class, () ->
+                    archive.countPurchasesInRange(0, 5));
+        }
+
+        @Test
+        @DisplayName("Should count only purchases, not sales, in the requested range")
+        void countsOnlyPurchasesInRange() {
+            // Arrange — 2 purchases (weeks 2, 3) + 1 sale (week 2) in range [2, 3]
+            // only purchases count → expected result: 2
+            Share saleShare = makeShare("NKE", new BigDecimal("100.00"), new BigDecimal("50.00"));
+            archive.add(new Purchase(share, 2));
+            archive.add(new Purchase(share, 3));
+            archive.add(new Sale(saleShare, 2));
+            // Act
+            int result = archive.countPurchasesInRange(2, 3);
+            // Assert
+            assertEquals(2, result);
+        }
+
+        @Test
+        @DisplayName("Should return zero when toWeek is less than fromWeek")
+        void returnsZeroWhenRangeIsInverted() {
+            // Arrange — archive has purchases but inverted range [4, 2] matches none
+            archive.add(new Purchase(share, 3));
+            // Act & Assert
+            assertEquals(0, archive.countPurchasesInRange(4, 2));
+        }
+    }
+
+    @Nested
+    @DisplayName("countSalesInRange()")
+    class CountSalesInRange {
+
+        @Test
+        @DisplayName("Should throw IllegalArgumentException when fromWeek is invalid")
+        void throwsWhenFromWeekIsInvalid() {
+            // Act & Assert
+            assertThrows(IllegalArgumentException.class, () ->
+                    archive.countSalesInRange(0, 5));
+        }
+
+        @Test
+        @DisplayName("Should count only sales, not purchases, in the requested range")
+        void countsOnlySalesInRange() {
+            // Arrange — 1 purchase (week 2) + 2 sales (weeks 2, 3) in range [2, 3]
+            // only sales count → expected result: 2
+            Share saleShare1 = makeShare("NKE", new BigDecimal("100.00"), new BigDecimal("50.00"));
+            Share saleShare2 = makeShare("AAPL", new BigDecimal("150.00"), new BigDecimal("80.00"));
+            archive.add(new Purchase(share, 2));
+            archive.add(new Sale(saleShare1, 2));
+            archive.add(new Sale(saleShare2, 3));
+            // Act
+            int result = archive.countSalesInRange(2, 3);
+            // Assert
+            assertEquals(2, result);
+        }
+
+        @Test
+        @DisplayName("Should return zero when toWeek is less than fromWeek")
+        void returnsZeroWhenRangeIsInverted() {
+            // Arrange — archive has sales but inverted range [4, 2] matches none
+            Share saleShare = makeShare("NKE", new BigDecimal("100.00"), new BigDecimal("50.00"));
+            archive.add(new Sale(saleShare, 3));
+            // Act & Assert
+            assertEquals(0, archive.countSalesInRange(4, 2));
+        }
+    }
+
     private static Share makeShare(String symbol, BigDecimal salesPrice, BigDecimal purchasePrice) {
         return new Share(
                 new Stock(symbol, "Test Co",


### PR DESCRIPTION
## Why

After the service-layer and Share testing work, JaCoCo's last
remaining gap in the business-logic layer was
`TransactionArchive`: 75.8% lines, 60% branches, with three
uncovered methods - `getTransactionsInRange`,
`countPurchasesInRange`, `countSalesInRange`.

These are not internal helpers - all three are called from the
Transactions dashboard tab and the activity summary card.
Documented contracts (the `IllegalArgumentException` guard on
`fromWeek < 1`, "inverted range yields empty list", cross-week
ordering, "fresh mutable list never null") are real
invariants the UI depends on. A silent regression in any of
them would produce wrong or empty transaction history on the
dashboard.

The same spec-first discipline as the Loan, Share, and
service-layer rounds was applied: the expected contract for
each method was stated from the javadoc BEFORE writing tests,
and confirmed before tests were committed.

## What the tests catch

A few regressions worth highlighting:

- `returnsOnlyTransactionsInRange` - fails on an off-by-one in
  the loop bounds (`< toWeek` instead of `<= toWeek` would
  miss the last week's transactions on the dashboard).
- `returnsTransactionsInCrossWeekOrder` - fails if a refactor
  replaces the week-by-week iteration with an unordered stream
  filter, breaking the documented low-to-high ordering the
  Transactions card relies on for display.
- `returnsEmptyListWhenRangeIsInverted` - fails if a change
  throws on inverted ranges instead of returning empty;
  inverted range is a valid UI state (e.g. the first week of
  a game) and throwing would crash the activity summary card.
- `returnedListIsFreshMutableCopy` - fails if a refactor
  returns the internal list directly; pins the documented
  "fresh mutable list" guarantee.
- `countsOnlyPurchasesInRange` / `countsOnlySalesInRange` -
  fail on a copy-paste error where both count methods delegate
  to the same underlying filter, producing identical purchase
  and sale counts in the activity summary.

## Deliberate non-decision

Within-week insertion ordering of `getTransactionsInRange` was
NOT tested. The javadoc mentions it ("within each week:
insertion order"), but it is an `ArrayList` implementation
detail leaking into the documentation. Testing it would
freeze the internal storage choice as contract and block a
legitimate future change to a different data structure.
Cross-week ordering IS tested, because the dashboard relies on
it for chronological display - that is a meaningful invariant.