### PR TITLE
feat+fix: add timeserieschart and cache weekbar

### DIFF
--- a/leaderboard.json
+++ b/leaderboard.json
@@ -75,5 +75,16 @@
     "status": "NOVICE",
     "outcome": "ACTIVE",
     "lastUpdated": "2026-05-23T22:45:08.189689Z"
+  },
+  {
+    "sessionId": "4cdd0ae7-af4f-4227-b473-9f6f91b668f4",
+    "playerName": "dara",
+    "startingCapital": 100,
+    "finalNetWorth": 100,
+    "returnPercent": 0.0,
+    "weeksPlayed": 3,
+    "status": "NOVICE",
+    "outcome": "ACTIVE",
+    "lastUpdated": "2026-05-23T23:05:18.185036Z"
   }
 ]

--- a/leaderboard.json
+++ b/leaderboard.json
@@ -64,5 +64,16 @@
     "status": "NOVICE",
     "outcome": "RETIRED",
     "lastUpdated": "2026-05-16T10:15:16.965925300Z"
+  },
+  {
+    "sessionId": "131547e8-d90e-42b0-8093-e1fde92fae6d",
+    "playerName": "dara",
+    "startingCapital": 100,
+    "finalNetWorth": 100,
+    "returnPercent": 0.0,
+    "weeksPlayed": 2,
+    "status": "NOVICE",
+    "outcome": "ACTIVE",
+    "lastUpdated": "2026-05-23T22:45:08.189689Z"
   }
 ]

--- a/leaderboard.json
+++ b/leaderboard.json
@@ -64,27 +64,5 @@
     "status": "NOVICE",
     "outcome": "RETIRED",
     "lastUpdated": "2026-05-16T10:15:16.965925300Z"
-  },
-  {
-    "sessionId": "131547e8-d90e-42b0-8093-e1fde92fae6d",
-    "playerName": "dara",
-    "startingCapital": 100,
-    "finalNetWorth": 100,
-    "returnPercent": 0.0,
-    "weeksPlayed": 2,
-    "status": "NOVICE",
-    "outcome": "ACTIVE",
-    "lastUpdated": "2026-05-23T22:45:08.189689Z"
-  },
-  {
-    "sessionId": "4cdd0ae7-af4f-4227-b473-9f6f91b668f4",
-    "playerName": "dara",
-    "startingCapital": 100,
-    "finalNetWorth": 100,
-    "returnPercent": 0.0,
-    "weeksPlayed": 3,
-    "status": "NOVICE",
-    "outcome": "ACTIVE",
-    "lastUpdated": "2026-05-23T23:05:18.185036Z"
   }
 ]

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/MainView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/MainView.java
@@ -7,7 +7,6 @@ import edu.ntnu.idatt2003.millions.keyboard.SearchFocusRegistry;
 import edu.ntnu.idatt2003.millions.keyboard.TabNavigationRegistry;
 import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.service.toast.ToastService;
-import edu.ntnu.idatt2003.millions.view.component.Header;
 import edu.ntnu.idatt2003.millions.view.component.toast.ToastOverlay;
 import edu.ntnu.idatt2003.millions.view.component.StatusFooter;
 import edu.ntnu.idatt2003.millions.view.component.WeekBar;
@@ -31,9 +30,17 @@ import javafx.stage.Stage;
  * between different views depending on user navigation.
  *
  * <p>Navigation between Dashboard, Exchange and Leaderboard is handled
- * internally as purely visual state. The {@link DashboardView} is cached
- * so that sub-views survive tab switches and keyboard shortcuts
- * (Shift+1–4) can jump directly to a dashboard tab.</p>
+ * internally as purely visual state. All three top-level views are cached
+ * after their first creation so that sub-view state (active tab, scroll
+ * position) survives navigation, and keyboard shortcuts (Shift+1–4) can
+ * jump directly to a dashboard tab.</p>
+ *
+ * <p>Each view owns its own {@link WeekBar} instance. Because a JavaFX node
+ * can only have one parent at a time, sharing a single instance across views
+ * would cause it to disappear from whichever view last lost focus. Giving
+ * each view its own instance avoids this node-stealing issue without
+ * requiring any cleanup logic, since all three views live for the entire
+ * application lifetime.</p>
  *
  * <p>Notifies the injected {@link SearchFocusRegistry} whenever the active
  * view changes, so the {@code Cmd/Ctrl+F} shortcut registered in
@@ -49,15 +56,19 @@ public class MainView {
     private final TradeController tradeController;
     private final LoanController loanController;
     private final ToastService toastService;
+    private final Runnable onAdvanceWeek;
     private final SearchFocusRegistry searchFocusRegistry;
     private final TabNavigationRegistry tabNavigationRegistry;
     private final StackPane outerRoot;
     private final BorderPane content;
-    private final WeekBar weekBar;
     private final StatusFooter footer;
 
     private DashboardView dashboardView;
     private ScrollPane dashboardScrollable;
+    private ExchangeView exchangeView;
+    private ScrollPane exchangeScrollable;
+    private LeaderboardView leaderboardView;
+    private ScrollPane leaderboardScrollable;
 
     /**
      * Constructs a new MainView with a platform-appropriate title bar and
@@ -85,9 +96,9 @@ public class MainView {
         this.tradeController = tradeController;
         this.loanController = loanController;
         this.toastService = toastService;
+        this.onAdvanceWeek = onAdvanceWeek;
         this.searchFocusRegistry = searchFocusRegistry;
         this.tabNavigationRegistry = tabNavigationRegistry;
-        this.weekBar = new WeekBar(gameService, onAdvanceWeek);
         titleBar.setOnDashboard(this::showDashboard);
         titleBar.setOnExchange(this::showExchange);
         titleBar.setOnLeaderboard(this::showLeaderboard);
@@ -156,12 +167,13 @@ public class MainView {
     /**
      * Switches the content area to the dashboard view.
      * The {@link DashboardView} is created once and reused on subsequent calls
-     * so sub-view state (lazy init, scroll position) survives navigation.
+     * so sub-view state (active tab, scroll position) survives navigation.
      */
     public void showDashboard() {
         if (dashboardScrollable == null) {
+            WeekBar dashboardWeekBar = new WeekBar(gameService, onAdvanceWeek);
             dashboardView = new DashboardView(
-                    gameService, tradeController, loanController, weekBar, this::showExchangeOnStocksTab);
+                    gameService, tradeController, loanController, dashboardWeekBar, this::showExchangeOnStocksTab);
             dashboardScrollable = wrapScrollable(dashboardView);
         }
         searchFocusRegistry.setActive(dashboardView);
@@ -171,28 +183,54 @@ public class MainView {
 
     /**
      * Switches the content area to the exchange view.
+     * The {@link ExchangeView} is created once and reused on subsequent calls
+     * so sub-view state (active tab, scroll position) survives navigation.
      */
     public void showExchange() {
-        ExchangeView exchangeView = new ExchangeView(gameService, weekBar, tradeController);
+        ensureExchangeView();
         searchFocusRegistry.setActive(exchangeView);
         tabNavigationRegistry.setActive(exchangeView::showTab);
-        content.setCenter(wrapScrollable(exchangeView));
+        content.setCenter(exchangeScrollable);
     }
 
     /**
      * Switches the content area to the leaderboard view.
+     * The {@link LeaderboardView} is created once and reused on subsequent calls
+     * so sub-view state (scroll position) survives navigation.
      */
     public void showLeaderboard() {
-        LeaderboardView leaderboardView = new LeaderboardView(gameService, toastService, weekBar);
+        if (leaderboardScrollable == null) {
+            WeekBar leaderboardWeekBar = new WeekBar(gameService, onAdvanceWeek);
+            leaderboardView = new LeaderboardView(gameService, toastService, leaderboardWeekBar);
+            leaderboardScrollable = wrapScrollable(leaderboardView);
+        }
         searchFocusRegistry.setActive(leaderboardView);
         tabNavigationRegistry.setActive(null);
-        content.setCenter(wrapScrollable(leaderboardView));
+        content.setCenter(leaderboardScrollable);
     }
 
+    /**
+     * Switches the content area to the exchange view with the stocks tab pre-selected.
+     * Reuses the cached {@link ExchangeView} if it already exists.
+     */
     private void showExchangeOnStocksTab() {
-        ExchangeView exchangeView = new ExchangeView(gameService, weekBar, tradeController);
+        ensureExchangeView();
         exchangeView.selectStocksTab();
-        content.setCenter(wrapScrollable(exchangeView));
+        searchFocusRegistry.setActive(exchangeView);
+        tabNavigationRegistry.setActive(exchangeView::showTab);
+        content.setCenter(exchangeScrollable);
+    }
+
+    /**
+     * Lazily initialises the {@link ExchangeView} and its {@link WeekBar} on first use.
+     * Subsequent calls are no-ops.
+     */
+    private void ensureExchangeView() {
+        if (exchangeScrollable == null) {
+            WeekBar exchangeWeekBar = new WeekBar(gameService, onAdvanceWeek);
+            exchangeView = new ExchangeView(gameService, exchangeWeekBar, tradeController);
+            exchangeScrollable = wrapScrollable(exchangeView);
+        }
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/MainView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/MainView.java
@@ -171,9 +171,8 @@ public class MainView {
      */
     public void showDashboard() {
         if (dashboardScrollable == null) {
-            WeekBar dashboardWeekBar = new WeekBar(gameService, onAdvanceWeek);
             dashboardView = new DashboardView(
-                    gameService, tradeController, loanController, dashboardWeekBar, this::showExchangeOnStocksTab);
+                    gameService, tradeController, loanController, createWeekBar(), this::showExchangeOnStocksTab);
             dashboardScrollable = wrapScrollable(dashboardView);
         }
         searchFocusRegistry.setActive(dashboardView);
@@ -200,8 +199,7 @@ public class MainView {
      */
     public void showLeaderboard() {
         if (leaderboardScrollable == null) {
-            WeekBar leaderboardWeekBar = new WeekBar(gameService, onAdvanceWeek);
-            leaderboardView = new LeaderboardView(gameService, toastService, leaderboardWeekBar);
+            leaderboardView = new LeaderboardView(gameService, toastService, createWeekBar());
             leaderboardScrollable = wrapScrollable(leaderboardView);
         }
         searchFocusRegistry.setActive(leaderboardView);
@@ -227,10 +225,20 @@ public class MainView {
      */
     private void ensureExchangeView() {
         if (exchangeScrollable == null) {
-            WeekBar exchangeWeekBar = new WeekBar(gameService, onAdvanceWeek);
-            exchangeView = new ExchangeView(gameService, exchangeWeekBar, tradeController);
+            exchangeView = new ExchangeView(gameService, createWeekBar(), tradeController);
             exchangeScrollable = wrapScrollable(exchangeView);
         }
+    }
+
+    /**
+     * Creates a new {@link WeekBar} bound to the current game service and advance-week callback.
+     * Each top-level view owns its own instance to avoid JavaFX node-stealing,
+     * since a node can only belong to one parent at a time.
+     *
+     * @return a new {@link WeekBar} instance
+     */
+    private WeekBar createWeekBar() {
+        return new WeekBar(gameService, onAdvanceWeek);
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/RowRenderer.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/RowRenderer.java
@@ -1,6 +1,7 @@
 package edu.ntnu.idatt2003.millions.view.component;
 
 import edu.ntnu.idatt2003.millions.model.stock.Stock;
+import edu.ntnu.idatt2003.millions.view.component.chart.SparklineChart;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.List;

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/ViewHeader.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/ViewHeader.java
@@ -34,7 +34,8 @@ public class ViewHeader extends VBox {
      *
      * @param titleKey  the i18n key for the view title
      * @param labelKeys the i18n keys for the tab labels in order
-     * @param weekBar   the shared week bar component
+     * @param weekBar   the week bar owned exclusively by the enclosing view; each top-level view
+     *                  receives its own instance since a JavaFX node can only belong to one parent at a time
      */
     public ViewHeader(String titleKey, List<String> labelKeys, WeekBar weekBar) {
         this.titleKey = titleKey;

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/chart/SparklineChart.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/chart/SparklineChart.java
@@ -1,4 +1,4 @@
-package edu.ntnu.idatt2003.millions.view.component;
+package edu.ntnu.idatt2003.millions.view.component.chart;
 
 import javafx.scene.canvas.Canvas;
 import javafx.scene.canvas.GraphicsContext;

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/chart/TimeSeriesChart.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/chart/TimeSeriesChart.java
@@ -1,0 +1,117 @@
+package edu.ntnu.idatt2003.millions.view.component.chart;
+
+import javafx.collections.ListChangeListener;
+import javafx.scene.chart.AreaChart;
+import javafx.scene.chart.NumberAxis;
+import javafx.scene.chart.XYChart;
+import javafx.util.StringConverter;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Reusable area chart component for plotting a series of {@link BigDecimal} values over time.
+ *
+ * <p>Extends {@link AreaChart} with the conventions used across the game's charts:
+ * manual x-axis bounds (lower = 1, upper = data size + 0.5), Norwegian-locale y-axis
+ * formatting, hidden data-point nodes, no animation, and the shared {@code area-chart}
+ * CSS class.
+ */
+public class TimeSeriesChart extends AreaChart<Number, Number> {
+
+  private final NumberAxis xAxis;
+  private final XYChart.Series<Number, Number> series;
+
+  /**
+   * Constructs a {@code TimeSeriesChart} pre-loaded with the given values.
+   *
+   * <p>The chart hides individual data-point nodes so only the filled area and
+   * line are visible.</p>
+   *
+   * @param values     the initial data points to plot, oldest first; must not be {@code null}
+   * @param xAxisLabel the label shown on the x-axis (e.g. «UKE»); must not be {@code null}
+   * @throws NullPointerException if {@code values} or {@code xAxisLabel} is {@code null}
+   */
+  public TimeSeriesChart(List<BigDecimal> values, String xAxisLabel) {
+    super(new NumberAxis(), new NumberAxis());
+    Objects.requireNonNull(values, "values must not be null");
+    Objects.requireNonNull(xAxisLabel, "xAxisLabel must not be null");
+
+    xAxis = (NumberAxis) getXAxis();
+    NumberAxis yAxis = (NumberAxis) getYAxis();
+
+    xAxis.setLabel(xAxisLabel);
+    xAxis.setAutoRanging(false);
+    xAxis.setForceZeroInRange(false);
+    xAxis.setLowerBound(1);
+    xAxis.setTickUnit(1);
+    xAxis.setTickLabelFormatter(new StringConverter<>() {
+      @Override
+      public String toString(Number n) {
+        double v = n.doubleValue();
+        return v == Math.floor(v) ? String.valueOf((int) v) : "";
+      }
+
+      @Override
+      public Number fromString(String s) {
+        return null;
+      }
+    });
+
+    yAxis.setAutoRanging(true);
+    yAxis.setForceZeroInRange(false);
+    yAxis.setTickLabelFormatter(new StringConverter<>() {
+      @Override
+      public String toString(Number n) {
+        return String.format(Locale.of("no"), "%,.0f", n.doubleValue());
+      }
+
+      @Override
+      public Number fromString(String s) {
+        return null;
+      }
+    });
+
+    series = new XYChart.Series<>();
+    series.getData().addListener((ListChangeListener<XYChart.Data<Number, Number>>) change -> {
+      while (change.next()) {
+        change.getAddedSubList().forEach(d -> {
+          if (d.getNode() != null) {
+            d.getNode().setVisible(false);
+          }
+        });
+      }
+    });
+
+    getData().add(series);
+    setLegendVisible(false);
+    setAnimated(false);
+    getStyleClass().add("area-chart");
+
+    for (int i = 0; i < values.size(); i++) {
+      series.getData().add(new XYChart.Data<>(i + 1, values.get(i).doubleValue()));
+    }
+    updateXAxis();
+  }
+
+  /**
+   * Appends a new data point at the next x position and extends the x-axis accordingly.
+   *
+   * @param value the value to append; must not be {@code null}
+   * @throws NullPointerException if {@code value} is {@code null}
+   */
+  public void addPoint(BigDecimal value) {
+    Objects.requireNonNull(value, "value must not be null");
+    int next = series.getData().size() + 1;
+    series.getData().add(new XYChart.Data<>(next, value.doubleValue()));
+    updateXAxis();
+  }
+
+  private void updateXAxis() {
+    int count = series.getData().size();
+    xAxis.setUpperBound(Math.max(2, count) + 0.5);
+    xAxis.requestAxisLayout();
+  }
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/DashboardView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/DashboardView.java
@@ -45,7 +45,8 @@ public class DashboardView extends VBox implements SearchFocusProvider {
      * Constructs a new DashboardView with a tab bar.
      *
      * @param gameService the game manager containing player and exchange
-     * @param weekBar     the week bar shared with the rest of the application
+     * @param weekBar     the week bar owned exclusively by this view; each top-level view
+     *                    receives its own instance since a JavaFX node can only belong to one parent at a time
      */
     public DashboardView(GameService gameService,
                          TradeController tradeController,

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/NetWorthCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/NetWorthCard.java
@@ -7,23 +7,20 @@ import edu.ntnu.idatt2003.millions.util.ColourChange;
 import edu.ntnu.idatt2003.millions.util.CurrencyFormatter;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
 import edu.ntnu.idatt2003.millions.view.component.InfoTooltip;
+import edu.ntnu.idatt2003.millions.view.component.chart.TimeSeriesChart;
 import edu.ntnu.idatt2003.millions.view.component.StyledText;
 import edu.ntnu.idatt2003.millions.view.component.card.WidgetCard;
-import javafx.collections.ListChangeListener;
 import javafx.geometry.Pos;
-import javafx.scene.chart.AreaChart;
-import javafx.scene.chart.NumberAxis;
-import javafx.scene.chart.XYChart;
 import javafx.scene.layout.HBox;
-import javafx.util.StringConverter;
 
 import java.math.BigDecimal;
-import java.util.List;
-import java.util.Locale;
 
 /**
  * Widget card displaying the player's net worth over time as an area chart.
  * Also shows total change in value and percentage since the start of the game.
+ *
+ * <p>Graph rendering is delegated to {@link StockPriceChart}, which owns all
+ * chart configuration and data management.
  */
 public class NetWorthCard extends WidgetCard {
 
@@ -31,58 +28,21 @@ public class NetWorthCard extends WidgetCard {
     private final PlayerStatsService statsService = new PlayerStatsService();
     private final StyledText netWorthLabel = StyledText.widgetValue();
     private final StyledText changeLabel = StyledText.widgetChange();
-    private final NumberAxis xAxis;
-    private final XYChart.Series<Number, Number> series;
+    private final TimeSeriesChart chart;
 
+    /**
+     * Constructs a {@code NetWorthCard} pre-loaded with the player's existing net-worth history.
+     *
+     * @param gameService the game service used to read player state and currency conversion;
+     *                    must not be {@code null}
+     */
     public NetWorthCard(GameService gameService) {
         super(gameService, "dashboard.netWorth");
         this.gameService = gameService;
 
-        int historySize = gameService.getPlayer().getNetWorthHistory().size();
-
-        xAxis = new NumberAxis();
-        xAxis.setLabel(LanguageManager.get("app.week").toUpperCase());
-        xAxis.setAutoRanging(false);
-        xAxis.setForceZeroInRange(false);
-        xAxis.setLowerBound(1);
-        xAxis.setUpperBound(Math.max(2, historySize));
-        xAxis.setTickUnit(1);
-        xAxis.setTickLabelFormatter(new StringConverter<>() {
-            @Override
-            public String toString(Number n) {
-                double v = n.doubleValue();
-                return v == Math.floor(v) ? String.valueOf((int) v) : "";
-            }
-            @Override
-            public Number fromString(String s) { return null; }
-        });
-
-        NumberAxis yAxis = new NumberAxis();
-        yAxis.setAutoRanging(true);
-        yAxis.setForceZeroInRange(false);
-        yAxis.setTickLabelFormatter(new StringConverter<>() {
-            @Override
-            public String toString(Number n) {
-                return String.format(Locale.of("no"), "%,.0f", n.doubleValue());
-            }
-            @Override
-            public Number fromString(String s) { return null; }
-        });
-
-        series = new XYChart.Series<>();
-        series.getData().addListener((ListChangeListener<XYChart.Data<Number, Number>>) change -> {
-            while (change.next()) {
-                change.getAddedSubList().forEach(d -> {
-                    if (d.getNode() != null) d.getNode().setVisible(false);
-                });
-            }
-        });
-
-        AreaChart<Number, Number> chart = new AreaChart<>(xAxis, yAxis);
-        chart.getData().add(series);
-        chart.setLegendVisible(false);
-        chart.setAnimated(false);
-        chart.getStyleClass().add("area-chart");
+        chart = new TimeSeriesChart(
+                gameService.getPlayer().getNetWorthHistory(),
+                LanguageManager.get("app.week").toUpperCase());
 
         InfoTooltip infoTooltip = new InfoTooltip("tooltip.dashboard.netWorth");
         HBox titleRow = new HBox(5, titleLabel, infoTooltip);
@@ -90,25 +50,7 @@ public class NetWorthCard extends WidgetCard {
         infoTooltip.attachToParent(titleRow);
         getChildren().addAll(titleRow, netWorthLabel, changeLabel, chart);
 
-        loadHistory();
-        updateXAxis();
         refreshDisplay();
-    }
-
-    private void loadHistory() {
-        List<BigDecimal> history = gameService.getPlayer().getNetWorthHistory();
-        for (int i = 0; i < history.size(); i++) {
-            series.getData().add(new XYChart.Data<>(i + 1, history.get(i).doubleValue()));
-        }
-    }
-
-    private void updateXAxis() {
-        int weeks = series.getData().size();
-        xAxis.setAutoRanging(false);
-        xAxis.setLowerBound(1);
-        xAxis.setUpperBound(Math.max(2, weeks) + 0.5);
-        xAxis.setTickUnit(1);
-        xAxis.requestAxisLayout();
     }
 
     /**
@@ -133,16 +75,15 @@ public class NetWorthCard extends WidgetCard {
 
     /**
      * Called when the game state has changed.
-     * Adds a new data point to the chart, extends the x-axis and refreshes the display.
+     * Appends a new data point to the chart via {@link StockPriceChart#addPoint(BigDecimal)}
+     * and refreshes the displayed labels.
      * Overrides {@link WidgetCard#onGameUpdated()} because this card has additional
      * update logic (chart point) beyond just refreshing text.
      */
     @Override
     public void onGameUpdated() {
-        int nextPoint = series.getData().size() + 1;
-        double netWorth = statsService.getNetWorth(gameService.getPlayer(), gameService.getCurrencyConverter()).doubleValue();
-        series.getData().add(new XYChart.Data<>(nextPoint, netWorth));
-        updateXAxis();
+        BigDecimal netWorth = statsService.getNetWorth(gameService.getPlayer(), gameService.getCurrencyConverter());
+        chart.addPoint(netWorth);
         refreshDisplay();
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/watchlist/StockInfoCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/watchlist/StockInfoCard.java
@@ -4,7 +4,7 @@ import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
 import edu.ntnu.idatt2003.millions.model.stock.Stock;
 import edu.ntnu.idatt2003.millions.util.ChangeFormatter;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
-import edu.ntnu.idatt2003.millions.view.component.SparklineChart;
+import edu.ntnu.idatt2003.millions.view.component.chart.SparklineChart;
 import edu.ntnu.idatt2003.millions.view.component.StyledText;
 import javafx.geometry.Pos;
 import javafx.scene.control.Label;

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/watchlist/WatchlistRowRenderer.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/watchlist/WatchlistRowRenderer.java
@@ -8,7 +8,7 @@ import edu.ntnu.idatt2003.millions.util.ChangeFormatter;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
 import edu.ntnu.idatt2003.millions.util.TableCells;
 import edu.ntnu.idatt2003.millions.view.component.RowRenderer;
-import edu.ntnu.idatt2003.millions.view.component.SparklineChart;
+import edu.ntnu.idatt2003.millions.view.component.chart.SparklineChart;
 import edu.ntnu.idatt2003.millions.view.component.table.SortColumnTable;
 import javafx.geometry.Pos;
 import javafx.geometry.VPos;

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/exchange/ExchangeView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/exchange/ExchangeView.java
@@ -30,7 +30,8 @@ public class ExchangeView extends VBox implements SearchFocusProvider {
      * Constructs a new ExchangeView with the overview tab active.
      *
      * @param gameService the game manager containing player and exchange
-     * @param weekBar     the week bar shared with the rest of the application
+     * @param weekBar     the week bar owned exclusively by this view; each top-level view
+     *                    receives its own instance since a JavaFX node can only belong to one parent at a time
      * @param controller  the portfolio controller used to open buy/sell dialogs
      */
     public ExchangeView(GameService gameService, WeekBar weekBar, TradeController controller) {

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/exchange/stocks/card/StocksRowRenderer.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/exchange/stocks/card/StocksRowRenderer.java
@@ -9,7 +9,7 @@ import edu.ntnu.idatt2003.millions.util.ChangeFormatter;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
 import edu.ntnu.idatt2003.millions.util.TableCells;
 import edu.ntnu.idatt2003.millions.view.component.RowRenderer;
-import edu.ntnu.idatt2003.millions.view.component.SparklineChart;
+import edu.ntnu.idatt2003.millions.view.component.chart.SparklineChart;
 import edu.ntnu.idatt2003.millions.view.component.table.SortColumnTable;
 import javafx.geometry.Pos;
 import javafx.geometry.VPos;

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/leaderboard/LeaderboardView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/leaderboard/LeaderboardView.java
@@ -30,7 +30,8 @@ public class LeaderboardView extends VBox implements SearchFocusProvider {
      *
      * @param gameService  the game service used by the card for observer registration
      * @param toastService the toast service used to display notifications
-     * @param weekBar      the shared week bar component
+     * @param weekBar      the week bar owned exclusively by this view; each top-level view
+     *                     receives its own instance since a JavaFX node can only belong to one parent at a time
      */
     public LeaderboardView(GameService gameService, ToastService toastService, WeekBar weekBar) {
         getStyleClass().add("content-area");


### PR DESCRIPTION
## Chart component extraction
The area chart logic that previously lived inline in NetWorthCard has been extracted into a reusable TimeSeriesChart component. It accepts a List<BigDecimal> and an x-axis label, and internally handles all JavaFX chart conventions: manual x-axis bounds (lower = 1, upper = data size + 0.5), Norwegian-locale y-axis formatting, hidden data-point nodes, no animation, and the shared area-chart CSS class.

**SparklineChart** has been moved from view/component/ into the new view/component/chart/ sub-package alongside TimeSeriesChart, following the same convention as the existing card/, table/, and notification/ sub-packages. NetWorthCard is refactored to delegate all chart concerns to TimeSeriesChart and contains no chart logic itself.
TimeSeriesChart will be reused by StockDetailDialog in the next PR.

## Fix: WeekBar disappears when navigating between views
WeekBar extends HBox, making it a JavaFX node. A node can only have one parent at a time. The previous implementation created a single shared WeekBar instance in MainView and passed it to all three top-level views. DashboardView was cached, but ExchangeView and LeaderboardView were recreated on every navigation.

**This caused node-stealing:** navigating to Exchange moved weekBar into ExchangeView's scene graph. Returning to the cached DashboardView left it without a WeekBar, so the advance week button disappeared.
Additionally, recreating ExchangeView and LeaderboardView on every navigation registered new GameObserver and LanguageManager observers on each visit, with no mechanism to remove the stale ones.
Solution

Cache ExchangeView and LeaderboardView using the same lazy-init pattern already used for DashboardView. Each view is created once on first navigation and reused thereafter.
Each view receives its own WeekBar instance. Since all three views now live for the entire application lifetime, each WeekBar registers its observers exactly once,  no cleanup logic required.
Store onAdvanceWeek as a field on MainView so it is available when each view is initialised on first use.
Extract ensureExchangeView() to avoid duplicating init logic between showExchange() and showExchangeOnStocksTab().