### PR TITLE
feat: add stock read services

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/millions/service/StockHistoryService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/StockHistoryService.java
@@ -44,7 +44,8 @@ public final class StockHistoryService {
      * @param converter the converter used for the NOK column; must not be {@code null}
      * @return up to four {@link WeeklyPriceChange} rows, newest first, or an empty list
      *         when fewer than two prices exist (no change has occurred yet)
-     * @throws NullPointerException if {@code stock} or {@code converter} is {@code null}
+     * @throws NullPointerException     if {@code stock} or {@code converter} is {@code null}
+     * @throws IllegalArgumentException if the stock's currency cannot be converted to NOK
      */
     public List<WeeklyPriceChange> getRecentWeeklyChanges(Stock stock, CurrencyConverter converter) {
         return getRecentWeeklyChanges(stock, converter, DEFAULT_MAX_ROWS);
@@ -58,7 +59,8 @@ public final class StockHistoryService {
      * @param maxRows   the maximum number of rows to return; must be greater than zero
      * @return up to {@code maxRows} {@link WeeklyPriceChange} rows, newest first
      * @throws NullPointerException     if {@code stock} or {@code converter} is {@code null}
-     * @throws IllegalArgumentException if {@code maxRows} is not greater than zero
+     * @throws IllegalArgumentException if {@code maxRows} is not greater than zero, or if the
+     *                                  stock's currency cannot be converted to NOK
      */
     public List<WeeklyPriceChange> getRecentWeeklyChanges(Stock stock, CurrencyConverter converter, int maxRows) {
         Objects.requireNonNull(stock, "stock must not be null");

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/StockHistoryService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/StockHistoryService.java
@@ -1,0 +1,91 @@
+package edu.ntnu.idatt2003.millions.service;
+
+import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
+import edu.ntnu.idatt2003.millions.model.stock.Stock;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.Currency;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Stateless read service computing derived price-history values for a {@link Stock}.
+ *
+ * <p>Holds no state and reads freely from the domain without mutating it, in line with
+ * the application's read-service layer ({@link PlayerStatsService}, {@link PortfolioService}).
+ * Views call it directly and render the returned rows: all numeric derivation lives here
+ * rather than in the view, keeping presentation free of business logic.</p>
+ */
+public final class StockHistoryService {
+
+    private static final Currency NOK = Currency.getInstance("NOK");
+    private static final int DEFAULT_MAX_ROWS = 4;
+    private static final int PERCENT_SCALE = 2;
+
+    /**
+     * A single week-over-week price change, from week {@code week - 1} to {@code week}.
+     *
+     * @param week          the week the change leads into (1-based, matching the price index)
+     * @param nativeChange  the price change in the stock's own currency
+     * @param nokChange     the price change converted to NOK
+     * @param percentChange the change as a percentage of the previous price
+     *                      (rounded {@link RoundingMode#HALF_UP} to two decimals)
+     */
+    public record WeeklyPriceChange(int week, BigDecimal nativeChange,
+                                    BigDecimal nokChange, BigDecimal percentChange) {
+    }
+
+    /**
+     * Returns the most recent weekly price changes, newest first, capped at four rows.
+     *
+     * @param stock     the stock whose price history is read; must not be {@code null}
+     * @param converter the converter used for the NOK column; must not be {@code null}
+     * @return up to four {@link WeeklyPriceChange} rows, newest first, or an empty list
+     *         when fewer than two prices exist (no change has occurred yet)
+     * @throws NullPointerException if {@code stock} or {@code converter} is {@code null}
+     */
+    public List<WeeklyPriceChange> getRecentWeeklyChanges(Stock stock, CurrencyConverter converter) {
+        return getRecentWeeklyChanges(stock, converter, DEFAULT_MAX_ROWS);
+    }
+
+    /**
+     * Returns the most recent weekly price changes, newest first, capped at {@code maxRows}.
+     *
+     * @param stock     the stock whose price history is read; must not be {@code null}
+     * @param converter the converter used for the NOK column; must not be {@code null}
+     * @param maxRows   the maximum number of rows to return; must be greater than zero
+     * @return up to {@code maxRows} {@link WeeklyPriceChange} rows, newest first
+     * @throws NullPointerException     if {@code stock} or {@code converter} is {@code null}
+     * @throws IllegalArgumentException if {@code maxRows} is not greater than zero
+     */
+    public List<WeeklyPriceChange> getRecentWeeklyChanges(Stock stock, CurrencyConverter converter, int maxRows) {
+        Objects.requireNonNull(stock, "stock must not be null");
+        Objects.requireNonNull(converter, "converter must not be null");
+        if (maxRows <= 0) {
+            throw new IllegalArgumentException("maxRows must be greater than zero");
+        }
+
+        List<BigDecimal> prices = stock.getHistoricalPrices();
+        int transitions = prices.size() - 1;
+        if (transitions <= 0) {
+            return List.of();
+        }
+
+        int rowCount = Math.min(maxRows, transitions);
+        List<WeeklyPriceChange> rows = new ArrayList<>(rowCount);
+        for (int week = prices.size(); week > prices.size() - rowCount; week--) {
+            BigDecimal current = prices.get(week - 1);
+            BigDecimal previous = prices.get(week - 2);
+            BigDecimal nativeChange = current.subtract(previous);
+            BigDecimal nokChange = converter.convert(nativeChange, stock.getCurrency(), NOK);
+            BigDecimal percentChange = previous.signum() == 0
+                    ? BigDecimal.ZERO
+                    : nativeChange.multiply(BigDecimal.valueOf(100))
+                            .divide(previous, PERCENT_SCALE, RoundingMode.HALF_UP);
+            rows.add(new WeeklyPriceChange(week, nativeChange, nokChange, percentChange));
+        }
+        return rows;
+    }
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/StockStatsService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/StockStatsService.java
@@ -1,0 +1,69 @@
+package edu.ntnu.idatt2003.millions.service;
+
+import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
+import edu.ntnu.idatt2003.millions.model.stock.Stock;
+
+import java.math.BigDecimal;
+import java.util.Currency;
+import java.util.Objects;
+
+/**
+ * Stateless read service computing a stock's current key figures expressed in NOK.
+ *
+ * <p>Provides point-in-time values.</p>
+ *
+ * <p>Complements {@link StockHistoryService}, which derives time-series values (weekly change
+ * rows) across the price history; this service returns single scalar figures instead.</p>
+ */
+public final class StockStatsService {
+
+    private static final Currency NOK = Currency.getInstance("NOK");
+
+    /**
+     * Returns the stock's latest price converted to NOK.
+     *
+     * @param stock     the stock to read from; must not be {@code null}
+     * @param converter the converter used for the conversion; must not be {@code null}
+     * @return the latest price in NOK
+     * @throws NullPointerException     if {@code stock} or {@code converter} is {@code null}
+     * @throws IllegalArgumentException if the stock's currency cannot be converted to NOK
+     */
+    public BigDecimal priceInNok(Stock stock, CurrencyConverter converter) {
+        Objects.requireNonNull(stock, "stock must not be null");
+        Objects.requireNonNull(converter, "converter must not be null");
+        return converter.convert(stock.getSalesPrice(), stock.getCurrency(), NOK);
+    }
+
+    /**
+     * Returns the stock's latest week-over-week price change converted to NOK.
+     *
+     * @param stock     the stock to read from; must not be {@code null}
+     * @param converter the converter used for the conversion; must not be {@code null}
+     * @return the latest price change in NOK (zero when only one price exists)
+     * @throws NullPointerException     if {@code stock} or {@code converter} is {@code null}
+     * @throws IllegalArgumentException if the stock's currency cannot be converted to NOK
+     */
+    public BigDecimal changeInNok(Stock stock, CurrencyConverter converter) {
+        Objects.requireNonNull(stock, "stock must not be null");
+        Objects.requireNonNull(converter, "converter must not be null");
+        return converter.convert(stock.getLatestPriceChange(), stock.getCurrency(), NOK);
+    }
+
+    /**
+     * Returns the high-low price range over the most recent {@code weeks} prices, in NOK.
+     *
+     * @param stock     the stock to read from; must not be {@code null}
+     * @param converter the converter used for the conversion; must not be {@code null}
+     * @param weeks     the number of recent weeks to consider; must be greater than zero
+     * @return the high-low range in NOK
+     * @throws NullPointerException     if {@code stock} or {@code converter} is {@code null}
+     * @throws IllegalArgumentException if {@code weeks} is not greater than zero, or if the
+     *                                  stock's currency cannot be converted to NOK
+     */
+    public BigDecimal highLowRangeInNok(Stock stock, CurrencyConverter converter, int weeks) {
+        Objects.requireNonNull(stock, "stock must not be null");
+        Objects.requireNonNull(converter, "converter must not be null");
+        BigDecimal range = stock.getRecentHigh(weeks).subtract(stock.getRecentLow(weeks));
+        return converter.convert(range, stock.getCurrency(), NOK);
+    }
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/table/SortProvider.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/table/SortProvider.java
@@ -1,12 +1,8 @@
 package edu.ntnu.idatt2003.millions.view.component.table;
 
-import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
-import edu.ntnu.idatt2003.millions.model.stock.Stock;
 import edu.ntnu.idatt2003.millions.util.SortState;
 
-import java.math.BigDecimal;
 import java.util.Comparator;
-import java.util.Currency;
 import java.util.List;
 
 /**
@@ -64,45 +60,4 @@ public abstract class SortProvider<T, C> {
      * @return a comparator for the given column
      */
     protected abstract Comparator<T> buildComparator(C column);
-
-    /**
-     * Returns the latest price of the given stock converted to NOK.
-     *
-     * @param stock     the stock to read from
-     * @param converter the converter used for currency conversion
-     * @param nok       the NOK currency instance
-     * @return the latest price in NOK
-     */
-    protected static BigDecimal priceInNok(Stock stock, CurrencyConverter converter, Currency nok) {
-        return converter.convert(stock.getSalesPrice(), stock.getCurrency(), nok);
-    }
-
-    /**
-     * Returns the latest price change of the given stock converted to NOK.
-     *
-     * @param stock     the stock to read from
-     * @param converter the converter used for currency conversion
-     * @param nok       the NOK currency instance
-     * @return the latest price change in NOK
-     */
-    protected static BigDecimal changeInNok(Stock stock, CurrencyConverter converter, Currency nok) {
-        return converter.convert(stock.getLatestPriceChange(), stock.getCurrency(), nok);
-    }
-
-    /**
-     * Returns the NOK range between the high and low price over the most recent
-     * {@code weeks} prices, read from {@link Stock#getRecentHigh(int)} and
-     * {@link Stock#getRecentLow(int)}.
-     *
-     * @param stock     the stock to read from
-     * @param converter the converter used for currency conversion
-     * @param nok       the NOK currency instance
-     * @param weeks     the number of recent weeks to consider
-     * @return the high-low range in NOK
-     */
-    protected static BigDecimal highLowRange(Stock stock, CurrencyConverter converter,
-                                             Currency nok, int weeks) {
-        BigDecimal range = stock.getRecentHigh(weeks).subtract(stock.getRecentLow(weeks));
-        return converter.convert(range, stock.getCurrency(), nok);
-    }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/watchlist/StockInfoCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/watchlist/StockInfoCard.java
@@ -2,6 +2,7 @@ package edu.ntnu.idatt2003.millions.view.dashboard.watchlist;
 
 import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
 import edu.ntnu.idatt2003.millions.model.stock.Stock;
+import edu.ntnu.idatt2003.millions.service.StockStatsService;
 import edu.ntnu.idatt2003.millions.util.ChangeFormatter;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
 import edu.ntnu.idatt2003.millions.view.component.chart.SparklineChart;
@@ -12,7 +13,6 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 
 import java.math.BigDecimal;
-import java.util.Currency;
 import java.util.List;
 
 /**
@@ -31,7 +31,7 @@ import java.util.List;
 class StockInfoCard extends VBox {
 
     private static final int SPARKLINE_WEEKS = 8;
-    private static final Currency NOK = Currency.getInstance("NOK");
+    private final StockStatsService statsService = new StockStatsService();
 
     /**
      * Constructs a new {@link StockInfoCard} for the given stock.
@@ -44,7 +44,7 @@ class StockInfoCard extends VBox {
 
         String currencyCode = stock.getCurrency().getCurrencyCode();
         BigDecimal price = stock.getSalesPrice();
-        BigDecimal priceNok = converter.convert(price, stock.getCurrency(), NOK);
+        BigDecimal priceNok = statsService.priceInNok(stock, converter);
         BigDecimal changePercent = stock.getWeeklyChangePercent();
 
         getChildren().addAll(

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/watchlist/WatchlistRowRenderer.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/watchlist/WatchlistRowRenderer.java
@@ -4,6 +4,7 @@ import edu.ntnu.idatt2003.millions.controller.TradeController;
 import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
 import edu.ntnu.idatt2003.millions.model.stock.Stock;
 import edu.ntnu.idatt2003.millions.service.GameService;
+import edu.ntnu.idatt2003.millions.service.StockStatsService;
 import edu.ntnu.idatt2003.millions.util.ChangeFormatter;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
 import edu.ntnu.idatt2003.millions.util.TableCells;
@@ -18,7 +19,6 @@ import javafx.scene.image.ImageView;
 import javafx.scene.layout.HBox;
 
 import java.math.BigDecimal;
-import java.util.Currency;
 import java.util.Objects;
 import java.util.function.Consumer;
 
@@ -36,9 +36,9 @@ class WatchlistRowRenderer extends RowRenderer {
 
     private static final int MAX_SPARKLINE_WEEKS = 8;
     private static final int HIGH_LOW_WEEKS = 4;
-    private static final Currency NOK = Currency.getInstance("NOK");
 
     private final GameService gameService;
+    private final StockStatsService statsService = new StockStatsService();
     private final TradeController tradeController;
     private final Consumer<String> onRemove;
     private final Consumer<WatchlistItem> onNote;
@@ -76,12 +76,12 @@ class WatchlistRowRenderer extends RowRenderer {
         Label tickerLabel = TableCells.data(stock.getSymbol());
         Label companyLabel = TableCells.data(stock.getCompany());
 
-        BigDecimal priceNok = converter.convert(stock.getSalesPrice(), stock.getCurrency(), NOK);
+        BigDecimal priceNok = statsService.priceInNok(stock, converter);
         Label priceNokLabel = TableCells.data(ChangeFormatter.formatPlain(priceNok));
         Label currencyLabel = TableCells.data(stock.getCurrency().getCurrencyCode());
         Label priceAltLabel = TableCells.data(ChangeFormatter.formatPlain(stock.getSalesPrice()));
 
-        BigDecimal changeNok = converter.convert(stock.getLatestPriceChange(), stock.getCurrency(), NOK);
+        BigDecimal changeNok = statsService.changeInNok(stock, converter);
         Label changeNokLabel = ChangeFormatter.styledAmount(changeNok, "table-cell");
         Label changePctLabel = ChangeFormatter.styledPercent(stock.getWeeklyChangePercent(), "table-cell");
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/watchlist/WatchlistSort.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/watchlist/WatchlistSort.java
@@ -2,13 +2,14 @@ package edu.ntnu.idatt2003.millions.view.dashboard.watchlist;
 
 import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
 import edu.ntnu.idatt2003.millions.model.stock.Stock;
+import edu.ntnu.idatt2003.millions.service.StockStatsService;
+import edu.ntnu.idatt2003.millions.util.LanguageManager;
 import edu.ntnu.idatt2003.millions.view.component.table.SortProvider;
 import edu.ntnu.idatt2003.millions.view.component.table.TableColumnDef;
 import java.util.List;
 import javafx.geometry.HPos;
 
 import java.util.Comparator;
-import java.util.Currency;
 import java.util.Objects;
 
 /**
@@ -21,7 +22,6 @@ import java.util.Objects;
 class WatchlistSort extends SortProvider<WatchlistItem, WatchlistSort.SortColumn> {
 
     private static final int HIGH_LOW_WEEKS = 4;
-    private static final Currency NOK = Currency.getInstance("NOK");
 
     /**
      * All columns in the watchlist table.
@@ -35,6 +35,7 @@ class WatchlistSort extends SortProvider<WatchlistItem, WatchlistSort.SortColumn
         TREND, TRADE, NOTE, REMOVE
     }
 
+    private final StockStatsService statsService = new StockStatsService();
     private final CurrencyConverter converter;
 
     /**
@@ -98,10 +99,10 @@ class WatchlistSort extends SortProvider<WatchlistItem, WatchlistSort.SortColumn
             case COMPANY -> Comparator.comparing(i -> i.stock().getCompany());
             case CURRENCY -> Comparator.comparing(i -> i.stock().getCurrency().getCurrencyCode());
             case PRICE_ALT -> Comparator.comparing(i -> i.stock().getSalesPrice());
-            case PRICE_NOK -> Comparator.comparing(i -> priceInNok(i.stock(), converter, NOK));
-            case CHANGE_NOK -> Comparator.comparing(i -> changeInNok(i.stock(), converter, NOK));
+            case PRICE_NOK -> Comparator.comparing(i -> statsService.priceInNok(i.stock(), converter));
+            case CHANGE_NOK -> Comparator.comparing(i -> statsService.changeInNok(i.stock(), converter));
             case CHANGE_PCT -> Comparator.comparing(i -> i.stock().getWeeklyChangePercent());
-            case HIGH_LOW -> Comparator.comparing(i -> highLowRange(i.stock(), converter, NOK, HIGH_LOW_WEEKS));
+            case HIGH_LOW -> Comparator.comparing(i -> statsService.highLowRangeInNok(i.stock(), converter, HIGH_LOW_WEEKS));
             case TREND, TRADE, NOTE, REMOVE ->
                     throw new IllegalStateException(column + " is not sortable");
         };

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/exchange/stocks/StocksSort.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/exchange/stocks/StocksSort.java
@@ -2,12 +2,12 @@ package edu.ntnu.idatt2003.millions.view.exchange.stocks;
 
 import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
 import edu.ntnu.idatt2003.millions.model.stock.Stock;
+import edu.ntnu.idatt2003.millions.service.StockStatsService;
 import edu.ntnu.idatt2003.millions.view.component.table.RowCells;
 import edu.ntnu.idatt2003.millions.view.component.table.SortColumnTable;
 import edu.ntnu.idatt2003.millions.view.component.table.SortProvider;
 import edu.ntnu.idatt2003.millions.view.component.table.TableColumnDef;
 import java.util.Comparator;
-import java.util.Currency;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Predicate;
@@ -22,8 +22,6 @@ import javafx.geometry.HPos;
  */
 public class StocksSort extends SortProvider<Stock, StocksSort.SortColumn> {
 
-    private static final Currency NOK = Currency.getInstance("NOK");
-
     /**
      * All columns in the stocks table.
      * Sortable columns are WATCHLIST, TICKER, PRICE_NOK,
@@ -34,6 +32,7 @@ public class StocksSort extends SortProvider<Stock, StocksSort.SortColumn> {
         WATCHLIST, TICKER, COMPANY, PRICE_NOK, CHANGE_KR, CHANGE_PCT, TREND, TRADE, DETAILS
     }
 
+    private final StockStatsService statsService = new StockStatsService();
     private final CurrencyConverter converter;
     private final Predicate<String> isWatched;
 
@@ -90,8 +89,8 @@ public class StocksSort extends SortProvider<Stock, StocksSort.SortColumn> {
         return switch (column) {
             case WATCHLIST -> Comparator.comparing(s -> !isWatched.test(s.getSymbol()));
             case TICKER -> Comparator.comparing(Stock::getSymbol);
-            case PRICE_NOK -> Comparator.comparing(s -> priceInNok(s, converter, NOK));
-            case CHANGE_KR -> Comparator.comparing(s -> changeInNok(s, converter, NOK));
+            case PRICE_NOK -> Comparator.comparing(s -> statsService.priceInNok(s, converter));
+            case CHANGE_KR -> Comparator.comparing(s -> statsService.changeInNok(s, converter));
             case CHANGE_PCT -> Comparator.comparing(Stock::getWeeklyChangePercent);
             case COMPANY, TREND, TRADE, DETAILS ->
                     throw new IllegalStateException(column + " is not sortable");

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/exchange/stocks/card/StocksRowRenderer.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/exchange/stocks/card/StocksRowRenderer.java
@@ -5,6 +5,7 @@ import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
 import edu.ntnu.idatt2003.millions.model.stock.Share;
 import edu.ntnu.idatt2003.millions.model.stock.Stock;
 import edu.ntnu.idatt2003.millions.service.GameService;
+import edu.ntnu.idatt2003.millions.service.StockStatsService;
 import edu.ntnu.idatt2003.millions.util.ChangeFormatter;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
 import edu.ntnu.idatt2003.millions.util.TableCells;
@@ -20,7 +21,6 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
 
 import java.math.BigDecimal;
-import java.util.Currency;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -39,9 +39,9 @@ import static edu.ntnu.idatt2003.millions.view.exchange.stocks.StocksSort.SortCo
 class StocksRowRenderer extends RowRenderer {
 
     private static final int MAX_SPARKLINE_WEEKS = 8;
-    private static final Currency NOK = Currency.getInstance("NOK");
 
     private final GameService gameService;
+    private final StockStatsService statsService = new StockStatsService();
     private final TradeController controller;
     private final Consumer<String> onWatchlistToggle;
     private final Consumer<Stock> onDetailClick;
@@ -105,9 +105,9 @@ class StocksRowRenderer extends RowRenderer {
         }
 
         Label companyLabel = TableCells.data(stock.getCompany());
-        BigDecimal priceInNok = converter.convert(stock.getSalesPrice(), stock.getCurrency(), NOK);
+        BigDecimal priceInNok = statsService.priceInNok(stock, converter);
         Label priceNokLabel = TableCells.data(ChangeFormatter.formatPlain(priceInNok));
-        BigDecimal changeInNok = converter.convert(stock.getLatestPriceChange(), stock.getCurrency(), NOK);
+        BigDecimal changeInNok = statsService.changeInNok(stock, converter);
         Label changeKrLabel = ChangeFormatter.styledAmount(changeInNok, "table-cell");
         Label changePctLabel = ChangeFormatter.styledPercent(stock.getWeeklyChangePercent(), "table-cell");
         SparklineChart sparkline = buildSparkline(stock, MAX_SPARKLINE_WEEKS);

--- a/src/test/java/edu/ntnu/idatt2003/millions/service/StockHistoryServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/service/StockHistoryServiceTest.java
@@ -1,0 +1,269 @@
+package edu.ntnu.idatt2003.millions.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
+import edu.ntnu.idatt2003.millions.model.stock.Stock;
+import edu.ntnu.idatt2003.millions.service.StockHistoryService.WeeklyPriceChange;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Currency;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link StockHistoryService}.
+ */
+class StockHistoryServiceTest {
+
+    private static final Currency USD = Currency.getInstance("USD");
+    private static final Currency EUR = Currency.getInstance("EUR");
+    private static final Currency NOK = Currency.getInstance("NOK");
+    private static final BigDecimal USD_TO_NOK = BigDecimal.valueOf(10);
+
+    private StockHistoryService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new StockHistoryService();
+    }
+
+    /**
+     * A simple deterministic converter: USD is worth ten NOK, identity for equal
+     * currencies, and any other source currency is rejected with
+     * {@link IllegalArgumentException} (matching the {@link CurrencyConverter} contract).
+     */
+    private static CurrencyConverter converter() {
+        return (amount, from, to) -> {
+            if (from.equals(to)) {
+                return amount;
+            }
+            if (from.equals(USD) && to.equals(NOK)) {
+                return amount.multiply(USD_TO_NOK);
+            }
+            throw new IllegalArgumentException("Unsupported currency: " + from.getCurrencyCode());
+        };
+    }
+
+    private static Stock stockWith(Currency currency, double... prices) {
+        List<BigDecimal> list = new ArrayList<>();
+        for (double price : prices) {
+            list.add(BigDecimal.valueOf(price));
+        }
+        return new Stock("TST", "Test Inc.", list, currency);
+    }
+
+    private static Stock usdStock(double... prices) {
+        return stockWith(USD, prices);
+    }
+
+    private static List<Integer> weeksOf(List<WeeklyPriceChange> rows) {
+        return rows.stream().map(WeeklyPriceChange::week).toList();
+    }
+
+    private static void assertBigDecimalEquals(BigDecimal expected, BigDecimal actual) {
+        assertEquals(0, expected.compareTo(actual),
+                () -> "expected " + expected + " but was " + actual);
+    }
+
+    @Nested
+    @DisplayName("getRecentWeeklyChanges()")
+    class GetRecentWeeklyChanges {
+
+        @Test
+        @DisplayName("Should return four rows newest first when five prices exist")
+        void returnsFourRowsNewestFirstWhenFivePricesExist() {
+            // Arrange
+            Stock stock = usdStock(100, 110, 105, 120, 126);
+
+            // Act
+            List<WeeklyPriceChange> rows = service.getRecentWeeklyChanges(stock, converter());
+
+            // Assert
+            assertEquals(4, rows.size());
+            assertEquals(List.of(5, 4, 3, 2), weeksOf(rows));
+        }
+
+        @Test
+        @DisplayName("Should compute native change, NOK change and percent for the newest week")
+        void computesNativeNokAndPercentForNewestWeek() {
+            // Arrange: week 5 = 126, week 4 = 120 -> native = 6, nok = 6 * 10 = 60,
+            //          percent = 6 / 120 * 100 = 5.00
+            Stock stock = usdStock(100, 110, 105, 120, 126);
+
+            // Act
+            WeeklyPriceChange newest = service.getRecentWeeklyChanges(stock, converter()).get(0);
+
+            // Assert
+            assertEquals(5, newest.week());
+            assertBigDecimalEquals(BigDecimal.valueOf(6), newest.nativeChange());
+            assertBigDecimalEquals(BigDecimal.valueOf(60), newest.nokChange());
+            assertBigDecimalEquals(new BigDecimal("5.00"), newest.percentChange());
+        }
+
+        @Test
+        @DisplayName("Should round percent half up to two decimals")
+        void roundsPercentHalfUpToTwoDecimals() {
+            // Arrange: prev = 160, cur = 181 -> native = 21,
+            //          percent = 2100 / 160 = 13.125 -> HALF_UP to 2 decimals = 13.13
+            Stock stock = usdStock(160, 181);
+
+            // Act
+            WeeklyPriceChange row = service.getRecentWeeklyChanges(stock, converter()).get(0);
+
+            // Assert
+            assertBigDecimalEquals(new BigDecimal("13.13"), row.percentChange());
+        }
+
+        @Test
+        @DisplayName("Should produce a negative change and percent when the price falls")
+        void producesNegativeChangeWhenPriceFalls() {
+            // Arrange: prev = 200, cur = 190 -> native = -10, nok = -100,
+            //          percent = -10 / 200 * 100 = -5.00
+            Stock stock = usdStock(200, 190);
+
+            // Act
+            WeeklyPriceChange row = service.getRecentWeeklyChanges(stock, converter()).get(0);
+
+            // Assert
+            assertBigDecimalEquals(BigDecimal.valueOf(-10), row.nativeChange());
+            assertBigDecimalEquals(BigDecimal.valueOf(-100), row.nokChange());
+            assertBigDecimalEquals(new BigDecimal("-5.00"), row.percentChange());
+        }
+
+        @Test
+        @DisplayName("Should return an empty list in week one when only one price exists")
+        void returnsEmptyListWhenOnlyOnePriceExists() {
+            // Arrange
+            Stock stock = usdStock(100);
+
+            // Act
+            List<WeeklyPriceChange> rows = service.getRecentWeeklyChanges(stock, converter());
+
+            // Assert
+            assertTrue(rows.isEmpty());
+        }
+
+        @Test
+        @DisplayName("Should return one row in week two when two prices exist")
+        void returnsOneRowWhenTwoPricesExist() {
+            // Arrange
+            Stock stock = usdStock(100, 110);
+
+            // Act
+            List<WeeklyPriceChange> rows = service.getRecentWeeklyChanges(stock, converter());
+
+            // Assert
+            assertEquals(List.of(2), weeksOf(rows));
+        }
+
+        @Test
+        @DisplayName("Should return two rows in week three when three prices exist")
+        void returnsTwoRowsWhenThreePricesExist() {
+            // Arrange
+            Stock stock = usdStock(100, 110, 120);
+
+            // Act
+            List<WeeklyPriceChange> rows = service.getRecentWeeklyChanges(stock, converter());
+
+            // Assert
+            assertEquals(List.of(3, 2), weeksOf(rows));
+        }
+
+        @Test
+        @DisplayName("Should cap at four rows by default when many prices exist")
+        void capsAtFourRowsByDefaultWhenManyPricesExist() {
+            // Arrange: six prices (weeks 1..6)
+            Stock stock = usdStock(10, 20, 30, 40, 50, 60);
+
+            // Act
+            List<WeeklyPriceChange> rows = service.getRecentWeeklyChanges(stock, converter());
+
+            // Assert
+            assertEquals(List.of(6, 5, 4, 3), weeksOf(rows));
+        }
+
+        @Test
+        @DisplayName("Should respect a custom maxRows smaller than the number of transitions")
+        void respectsCustomMaxRowsSmallerThanTransitions() {
+            // Arrange: five prices -> four transitions, but only two requested
+            Stock stock = usdStock(100, 110, 120, 130, 140);
+
+            // Act
+            List<WeeklyPriceChange> rows = service.getRecentWeeklyChanges(stock, converter(), 2);
+
+            // Assert
+            assertEquals(List.of(5, 4), weeksOf(rows));
+        }
+
+        @Test
+        @DisplayName("Should adapt to the available transitions when maxRows exceeds them")
+        void adaptsToAvailableTransitionsWhenMaxRowsExceedsThem() {
+            // Arrange: three prices -> only two transitions, ten requested
+            Stock stock = usdStock(100, 110, 120);
+
+            // Act
+            List<WeeklyPriceChange> rows = service.getRecentWeeklyChanges(stock, converter(), 10);
+
+            // Assert
+            assertEquals(List.of(3, 2), weeksOf(rows));
+        }
+
+        @Test
+        @DisplayName("Should throw NullPointerException when stock is null")
+        void throwsNullPointerExceptionWhenStockIsNull() {
+            // Act & Assert
+            assertThrows(NullPointerException.class,
+                    () -> service.getRecentWeeklyChanges(null, converter()));
+        }
+
+        @Test
+        @DisplayName("Should throw NullPointerException when converter is null")
+        void throwsNullPointerExceptionWhenConverterIsNull() {
+            // Arrange
+            Stock stock = usdStock(100, 110);
+
+            // Act & Assert
+            assertThrows(NullPointerException.class,
+                    () -> service.getRecentWeeklyChanges(stock, null));
+        }
+
+        @Test
+        @DisplayName("Should throw IllegalArgumentException when maxRows is zero")
+        void throwsIllegalArgumentExceptionWhenMaxRowsIsZero() {
+            // Arrange
+            Stock stock = usdStock(100, 110);
+
+            // Act & Assert
+            assertThrows(IllegalArgumentException.class,
+                    () -> service.getRecentWeeklyChanges(stock, converter(), 0));
+        }
+
+        @Test
+        @DisplayName("Should throw IllegalArgumentException when maxRows is negative")
+        void throwsIllegalArgumentExceptionWhenMaxRowsIsNegative() {
+            // Arrange
+            Stock stock = usdStock(100, 110);
+
+            // Act & Assert
+            assertThrows(IllegalArgumentException.class,
+                    () -> service.getRecentWeeklyChanges(stock, converter(), -1));
+        }
+
+        @Test
+        @DisplayName("Should throw IllegalArgumentException when the stock currency is unsupported")
+        void throwsIllegalArgumentExceptionWhenCurrencyIsUnsupported() {
+            // Arrange: the converter rejects EUR as a source currency
+            Stock stock = stockWith(EUR, 100, 110);
+
+            // Act & Assert
+            assertThrows(IllegalArgumentException.class,
+                    () -> service.getRecentWeeklyChanges(stock, converter()));
+        }
+    }
+}

--- a/src/test/java/edu/ntnu/idatt2003/millions/service/StockStatsServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/service/StockStatsServiceTest.java
@@ -1,0 +1,237 @@
+package edu.ntnu.idatt2003.millions.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
+import edu.ntnu.idatt2003.millions.model.stock.Stock;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Currency;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link StockStatsService}.
+ */
+class StockStatsServiceTest {
+
+    private static final Currency USD = Currency.getInstance("USD");
+    private static final Currency EUR = Currency.getInstance("EUR");
+    private static final Currency NOK = Currency.getInstance("NOK");
+    private static final BigDecimal USD_TO_NOK = BigDecimal.valueOf(10);
+
+    private StockStatsService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new StockStatsService();
+    }
+
+    /**
+     * A simple deterministic converter: USD is worth ten NOK, identity for equal
+     * currencies, and any other source currency is rejected with
+     * {@link IllegalArgumentException} (matching the {@link CurrencyConverter} contract).
+     */
+    private static CurrencyConverter converter() {
+        return (amount, from, to) -> {
+            if (from.equals(to)) {
+                return amount;
+            }
+            if (from.equals(USD) && to.equals(NOK)) {
+                return amount.multiply(USD_TO_NOK);
+            }
+            throw new IllegalArgumentException("Unsupported currency: " + from.getCurrencyCode());
+        };
+    }
+
+    private static Stock stockWith(Currency currency, double... prices) {
+        List<BigDecimal> list = new ArrayList<>();
+        for (double price : prices) {
+            list.add(BigDecimal.valueOf(price));
+        }
+        return new Stock("Alva", "Dara Inc.", list, currency);
+    }
+
+    private static Stock usdStock(double... prices) {
+        return stockWith(USD, prices);
+    }
+
+    private static void assertBigDecimalEquals(BigDecimal expected, BigDecimal actual) {
+        assertEquals(0, expected.compareTo(actual),
+                () -> "expected " + expected + " but was " + actual);
+    }
+
+    @Nested
+    @DisplayName("priceInNok()")
+    class PriceInNok {
+
+        @Test
+        @DisplayName("Should convert the latest price to NOK")
+        void convertsLatestPriceToNok() {
+            // Arrange: latest = 126 USD -> 126 * 10 = 1260 NOK
+            Stock stock = usdStock(100, 110, 105, 126);
+
+            // Act
+            BigDecimal result = service.priceInNok(stock, converter());
+
+            // Assert
+            assertBigDecimalEquals(BigDecimal.valueOf(1260), result);
+        }
+
+        @Test
+        @DisplayName("Should throw NullPointerException when stock is null")
+        void throwsNullPointerExceptionWhenStockIsNull() {
+            // Act & Assert
+            assertThrows(NullPointerException.class,
+                    () -> service.priceInNok(null, converter()));
+        }
+
+        @Test
+        @DisplayName("Should throw NullPointerException when converter is null")
+        void throwsNullPointerExceptionWhenConverterIsNull() {
+            // Arrange
+            Stock stock = usdStock(100);
+
+            // Act & Assert
+            assertThrows(NullPointerException.class,
+                    () -> service.priceInNok(stock, null));
+        }
+
+        @Test
+        @DisplayName("Should throw IllegalArgumentException when the stock currency is unsupported")
+        void throwsIllegalArgumentExceptionWhenCurrencyIsUnsupported() {
+            // Arrange: the converter rejects EUR as a source currency
+            Stock stock = stockWith(EUR, 100, 110);
+
+            // Act & Assert
+            assertThrows(IllegalArgumentException.class,
+                    () -> service.priceInNok(stock, converter()));
+        }
+    }
+
+    @Nested
+    @DisplayName("changeInNok()")
+    class ChangeInNok {
+
+        @Test
+        @DisplayName("Should convert the latest weekly change to NOK")
+        void convertsLatestChangeToNok() {
+            // Arrange: change = 126 - 105 = 21 USD -> 21 * 10 = 210 NOK
+            Stock stock = usdStock(100, 110, 105, 126);
+
+            // Act
+            BigDecimal result = service.changeInNok(stock, converter());
+
+            // Assert
+            assertBigDecimalEquals(BigDecimal.valueOf(210), result);
+        }
+
+        @Test
+        @DisplayName("Should return zero when only one price exists")
+        void returnsZeroWhenOnlyOnePriceExists() {
+            // Arrange: a single price means no change yet
+            Stock stock = usdStock(100);
+
+            // Act
+            BigDecimal result = service.changeInNok(stock, converter());
+
+            // Assert
+            assertBigDecimalEquals(BigDecimal.ZERO, result);
+        }
+
+        @Test
+        @DisplayName("Should throw NullPointerException when stock is null")
+        void throwsNullPointerExceptionWhenStockIsNull() {
+            // Act & Assert
+            assertThrows(NullPointerException.class,
+                    () -> service.changeInNok(null, converter()));
+        }
+
+        @Test
+        @DisplayName("Should throw NullPointerException when converter is null")
+        void throwsNullPointerExceptionWhenConverterIsNull() {
+            // Arrange
+            Stock stock = usdStock(100, 110);
+
+            // Act & Assert
+            assertThrows(NullPointerException.class,
+                    () -> service.changeInNok(stock, null));
+        }
+    }
+
+    @Nested
+    @DisplayName("highLowRangeInNok()")
+    class HighLowRangeInNok {
+
+        @Test
+        @DisplayName("Should convert the full-window high-low range to NOK")
+        void convertsFullWindowRangeToNok() {
+            // Arrange: over four weeks high = 126, low = 100 -> range = 26 -> 260 NOK
+            Stock stock = usdStock(100, 110, 105, 126);
+
+            // Act
+            BigDecimal result = service.highLowRangeInNok(stock, converter(), 4);
+
+            // Assert
+            assertBigDecimalEquals(BigDecimal.valueOf(260), result);
+        }
+
+        @Test
+        @DisplayName("Should consider only the most recent weeks of the window")
+        void considersOnlyTheMostRecentWeeks() {
+            // Arrange: last two weeks = [105, 126] -> range = 21 -> 210 NOK
+            Stock stock = usdStock(100, 110, 105, 126);
+
+            // Act
+            BigDecimal result = service.highLowRangeInNok(stock, converter(), 2);
+
+            // Assert
+            assertBigDecimalEquals(BigDecimal.valueOf(210), result);
+        }
+
+        @Test
+        @DisplayName("Should throw NullPointerException when stock is null")
+        void throwsNullPointerExceptionWhenStockIsNull() {
+            // Act & Assert
+            assertThrows(NullPointerException.class,
+                    () -> service.highLowRangeInNok(null, converter(), 4));
+        }
+
+        @Test
+        @DisplayName("Should throw NullPointerException when converter is null")
+        void throwsNullPointerExceptionWhenConverterIsNull() {
+            // Arrange
+            Stock stock = usdStock(100, 110);
+
+            // Act & Assert
+            assertThrows(NullPointerException.class,
+                    () -> service.highLowRangeInNok(stock, null, 4));
+        }
+
+        @Test
+        @DisplayName("Should throw IllegalArgumentException when weeks is zero")
+        void throwsIllegalArgumentExceptionWhenWeeksIsZero() {
+            // Arrange
+            Stock stock = usdStock(100, 110);
+
+            // Act & Assert
+            assertThrows(IllegalArgumentException.class,
+                    () -> service.highLowRangeInNok(stock, converter(), 0));
+        }
+
+        @Test
+        @DisplayName("Should throw IllegalArgumentException when the stock currency is unsupported")
+        void throwsIllegalArgumentExceptionWhenCurrencyIsUnsupported() {
+            // Arrange: the converter rejects EUR as a source currency
+            Stock stock = stockWith(EUR, 100, 110);
+
+            // Act & Assert
+            assertThrows(IllegalArgumentException.class,
+                    () -> service.highLowRangeInNok(stock, converter(), 2));
+        }
+    }
+}


### PR DESCRIPTION
### Summary
Introduces two stateless read services for stock-derived values and routes all
"stock price/figures in NOK" computation through a single source of truth. No
user-facing behaviour changes. This is groundwork (with full unit tests) for the
upcoming stock detail dialog, plus a consolidation refactor that removes duplicated
currency-conversion logic from the view and sort layers.

### Background / Motivation
The codebase converted a stock's native-currency price and weekly change into NOK
inline in four separate places (`StocksRowRenderer`, `WatchlistRowRenderer`,
`StockInfoCard`, and the static helpers on `SortProvider`). That duplication was
about to become a fifth copy in the planned stock detail dialog. At the same time,
the adaptive weekly-change calculation the dialog needs is real derived logic that
must not live in a view.

This PR adds the service layer those needs share, and unifies the existing NOK
conversion behind it, bringing `StocksSort`/`WatchlistSort` in line with how
`HoldingsSort` already delegates its NOK figures to `PortfolioService`.

### Changes
**New read services (`service/`)**
- `StockHistoryService`  time-series derivation. `getRecentWeeklyChanges(stock,
  converter[, maxRows])` returns adaptive week-over-week rows (`WeeklyPriceChange`
  record: week, native change, NOK change, percent), newest first, capped at
  `min(maxRows, prices.size() - 1)`. Returns an empty list in week 1 (no change yet)
  instead of zero-filled rows. Percent uses `RoundingMode.HALF_UP`, 2 decimals.
- `StockStatsService`  point-in-time figures in NOK: `priceInNok`, `changeInNok`,
  `highLowRangeInNok(weeks)`.

Both are stateless, validate arguments with `Objects.requireNonNull` (NPE) and
`IllegalArgumentException` for invalid bounds.

**Consolidation refactor**
- `StocksRowRenderer`, `WatchlistRowRenderer`, `StockInfoCard` now call
  `StockStatsService` instead of inline `converter.convert(...)`.
- Removed the stock-specific static helpers (`priceInNok`, `changeInNok`,
  `highLowRange`) from the generic `SortProvider` base — they were an SRP leak in a
  type-agnostic `SortProvider<T, C>`. `StocksSort` and `WatchlistSort` now hold a
  `StockStatsService` and call it directly.

**Tests**
- `StockHistoryServiceTest` (14 tests) and `StockStatsServiceTest` (12 tests):
  AAA, `@Nested` per method, positive / edge / negative cases, spec-derived expected
  values, specific exception types, and `assertBigDecimalEquals` for scale-safe
  comparisons.

### Architecture / SoC
Keeps derived computation out of the view and centralises currency conversion:
read freely, compute in stateless services. `StockHistoryService` (time series) and
`StockStatsService` (current key figures) are split by cohesive concern, mirroring
`PlayerStatsService` vs `RealizedReturnsService`.

### Behaviour
No functional change. Table values and sort order are identical; only the source of
the computation moved.

### Out of scope (follow-up branches)
- `feat/stock-detail-dialog` the dialog itself, `PriceHistoryList`, controller
  wiring, CSS and i18n (consumes both services).
- `refactor/move-loan-calculations-into-service` moving the loan cards' inline
  business calculations into a service.