### PR TITLE
refactor: remove redundant arrow-key tab navigation from viewheader

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/ViewHeader.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/ViewHeader.java
@@ -2,9 +2,7 @@ package edu.ntnu.idatt2003.millions.view.component;
 
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
 import javafx.geometry.Pos;
-import javafx.scene.Node;
 import javafx.scene.control.Button;
-import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
@@ -15,9 +13,9 @@ import java.util.List;
 /**
  * Reusable view header with a title, a tab bar, and a {@code WeekBar}.
  *
- * <p>Arrow keys navigate between tabs when a tab button has focus.
- * LEFT/RIGHT move to the adjacent tab and activate it; ENTER/SPACE fire
- * the focused tab. Language changes update all labels automatically.</p>
+ * <p>Tab switching is handled centrally via {@code Shift+1–4} shortcuts and by
+ * mouse click; this component owns only the tab buttons and their active-state
+ * styling. Language changes update all labels automatically.</p>
  */
 public class ViewHeader extends VBox {
 
@@ -62,7 +60,6 @@ public class ViewHeader extends VBox {
         }
 
         tabBar.getStyleClass().add("tab-bar");
-        tabBar.addEventFilter(KeyEvent.KEY_PRESSED, this::handleTabKeyNavigation);
 
         if (!tabButtons.isEmpty()) {
             setActive(tabButtons.getFirst());
@@ -127,39 +124,5 @@ public class ViewHeader extends VBox {
     public void setTabAction(int index, Runnable action) {
         Button button = getTabButton(index);
         button.setOnAction(e -> { setActive(button); action.run(); });
-    }
-
-    /**
-     * Handles LEFT/RIGHT arrow navigation and SPACE activation
-     * when focus is inside the tab bar.
-     *
-     * <p>ENTER is intentionally omitted: {@code KeyboardNavigationService} fires
-     * the focused button on ENTER at the scene level and consumes the event before
-     * it reaches this filter, making an ENTER case here unreachable.</p>
-     */
-    private void handleTabKeyNavigation(KeyEvent event) {
-        Node focused = tabBar.getScene() != null ? tabBar.getScene().getFocusOwner() : null;
-        int index = tabButtons.indexOf(focused);
-        if (index < 0) {
-            return;
-        }
-        int last = tabButtons.size() - 1;
-        switch (event.getCode()) {
-            case LEFT  -> { if (index > 0)    { activateTabAt(index - 1); event.consume(); } }
-            case RIGHT -> { if (index < last) { activateTabAt(index + 1); event.consume(); } }
-            case SPACE -> { tabButtons.get(index).fire(); event.consume(); }
-            default -> {}
-        }
-    }
-
-    /**
-     * Requests focus on and fires the tab at the given index.
-     *
-     * @param index zero-based tab index
-     */
-    private void activateTabAt(int index) {
-        Button button = getTabButton(index);
-        button.requestFocus();
-        button.fire();
     }
 }


### PR DESCRIPTION
Removed the redudant arrowkey tab <- -> for switching tab navigation since short-cuts was implemented to be more intuitive.