### PR TITLE
fix: networth chart accuracy - rebuild from history, plus tooltip honesty

### DIFF
--- a/leaderboard.json
+++ b/leaderboard.json
@@ -75,5 +75,16 @@
     "status": "NOVICE",
     "outcome": "ACTIVE",
     "lastUpdated": "2026-05-25T10:53:21.302989700Z"
+  },
+  {
+    "sessionId": "c3be11fc-78d6-4e06-89c7-512d864d018e",
+    "playerName": "Leo",
+    "startingCapital": 1000000,
+    "finalNetWorth": 992112.4437,
+    "returnPercent": -0.8,
+    "weeksPlayed": 181,
+    "status": "NOVICE",
+    "outcome": "RETIRED",
+    "lastUpdated": "2026-05-25T11:54:09.552991700Z"
   }
 ]

--- a/leaderboard.json
+++ b/leaderboard.json
@@ -64,5 +64,16 @@
     "status": "NOVICE",
     "outcome": "RETIRED",
     "lastUpdated": "2026-05-16T10:15:16.965925300Z"
+  },
+  {
+    "sessionId": "07f86902-1037-4521-8ad0-eee8ca8b6e13",
+    "playerName": "kristoffer",
+    "startingCapital": 10000,
+    "finalNetWorth": 8582.4712,
+    "returnPercent": -14.2,
+    "weeksPlayed": 21,
+    "status": "NOVICE",
+    "outcome": "ACTIVE",
+    "lastUpdated": "2026-05-25T10:53:21.302989700Z"
   }
 ]

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/PlayerStatsService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/PlayerStatsService.java
@@ -5,6 +5,8 @@ import edu.ntnu.idatt2003.millions.model.player.Player;
 import edu.ntnu.idatt2003.millions.model.player.PlayerStatusLevel;
 
 import java.math.BigDecimal;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * Stateless read service for player net-worth and status queries.
@@ -90,5 +92,15 @@ public class PlayerStatsService {
         double returnProgress = Math.min(1.0, Math.max(0.0, (growthPercent - prevReturn) / (nextReturn - prevReturn)));
 
         return Math.min(weekProgress, returnProgress);
+    }
+
+    /**
+     * Returns the player's recorded net-worth history — one entry per game week,
+     * in order from week 1 to the current week. The returned list is a defensive
+     * copy and does not reflect later mutations of the player.
+     */
+    public List<BigDecimal> getNetWorthHistory(Player player) {
+        Objects.requireNonNull(player, "Player cannot be null");
+        return List.copyOf(player.getNetWorthHistory());
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/chart/TimeSeriesChart.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/chart/TimeSeriesChart.java
@@ -109,6 +109,22 @@ public class TimeSeriesChart extends AreaChart<Number, Number> {
     updateXAxis();
   }
 
+  /**
+   * Replaces all data points with the given values, rebuilding the series from scratch.
+   * x-positions are assigned positionally (1, 2, 3, …) to match constructor semantics.
+   *
+   * @param values the new data points, oldest first; must not be {@code null}
+   * @throws NullPointerException if {@code values} is {@code null}
+   */
+  public void setPoints(List<BigDecimal> values) {
+    Objects.requireNonNull(values, "values must not be null");
+    series.getData().clear();
+    for (int i = 0; i < values.size(); i++) {
+      series.getData().add(new XYChart.Data<>(i + 1, values.get(i).doubleValue()));
+    }
+    updateXAxis();
+  }
+
   private void updateXAxis() {
     int count = series.getData().size();
     xAxis.setUpperBound(Math.max(2, count) + 0.5);

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/NetWorthCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/NetWorthCard.java
@@ -41,7 +41,7 @@ public class NetWorthCard extends WidgetCard {
         this.gameService = gameService;
 
         chart = new TimeSeriesChart(
-                gameService.getPlayer().getNetWorthHistory(),
+                statsService.getNetWorthHistory(gameService.getPlayer()),
                 LanguageManager.get("app.week").toUpperCase());
 
         InfoTooltip infoTooltip = new InfoTooltip("tooltip.dashboard.netWorth");
@@ -82,8 +82,7 @@ public class NetWorthCard extends WidgetCard {
      */
     @Override
     public void onGameUpdated() {
-        BigDecimal netWorth = statsService.getNetWorth(gameService.getPlayer(), gameService.getCurrencyConverter());
-        chart.addPoint(netWorth);
+        chart.setPoints(statsService.getNetWorthHistory(gameService.getPlayer()));
         refreshDisplay();
     }
 }

--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -209,7 +209,7 @@ details.button.buyMore=Buy more
 details.button.sell=Sell
 details.button.sellAll=Sell all
 # Tooltips - Dashboard widget cards
-tooltip.dashboard.netWorth=Cash plus portfolio market value, converted to NOK. Tax and commission are not deducted.
+tooltip.dashboard.netWorth=Cash plus market value of portfolio in NOK, minus outstanding debt. Tax and commission are not deducted.
 tooltip.dashboard.weeklyChange=Change in equity since last week.
 tooltip.dashboard.portfolioValue=Market value of all your shares converted to NOK. Tax and commission are not deducted.
 tooltip.dashboard.status=Novice: starting level. Investor: 10+ traded weeks and 20% growth. Speculator: 20+ traded weeks and doubled equity.

--- a/src/main/resources/i18n/messages_no.properties
+++ b/src/main/resources/i18n/messages_no.properties
@@ -200,7 +200,7 @@ details.button.buyMore=Kjøp mer
 details.button.sell=Selg
 details.button.sellAll=Selg alt
 # Tooltips - Dashboard widget cards
-tooltip.dashboard.netWorth=Kontanter + markedsverdi av porteføljen, omregnet til NOK. Skatt og kurtasje er ikke trukket fra.
+tooltip.dashboard.netWorth=Kontanter + markedsverdi av porteføljen, omregnet til NOK, minus utestående gjeld. Skatt og kurtasje er ikke trukket fra.
 tooltip.dashboard.weeklyChange=Endring i egenkapital siden forrige uke.
 tooltip.dashboard.portfolioValue=Markedsverdi av alle dine andeler omregnet til NOK. Skatt og kurtasje er ikke trukket fra.
 tooltip.dashboard.status=Novice: startnivå. Investor: 10+ uker handlet og 20% vekst. Speculator: 20+ uker handlet og doblet egenkapital.

--- a/src/test/java/edu/ntnu/idatt2003/millions/service/PlayerStatsServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/service/PlayerStatsServiceTest.java
@@ -283,6 +283,53 @@ class PlayerStatsServiceTest {
     }
 
     @Nested
+    @DisplayName("getNetWorthHistory()")
+    class GetNetWorthHistory {
+
+        @Test
+        @DisplayName("Fresh player history contains only the seed entry (starting money)")
+        void freshPlayerHasSeedEntry() {
+            // Arrange
+            Player p = playerWith("1000");
+            // Act
+            List<BigDecimal> history = service.getNetWorthHistory(p);
+            // Assert
+            assertEquals(1, history.size());
+            assertBigDecimalEquals(new BigDecimal("1000"), history.get(0));
+        }
+
+        @Test
+        @DisplayName("History reflects recorded entries in insertion order")
+        void historyReflectsRecordedEntriesInOrder() {
+            // Arrange — seed=1000, record after gaining 200 then 100 more
+            Player p = playerWith("1000");
+            p.addMoney(new BigDecimal("200"));
+            p.recordNetWorth(converter);
+            p.addMoney(new BigDecimal("100"));
+            p.recordNetWorth(converter);
+            // Act
+            List<BigDecimal> history = service.getNetWorthHistory(p);
+            // Assert — [1000, 1200, 1300]
+            assertEquals(3, history.size());
+            assertBigDecimalEquals(new BigDecimal("1000"), history.get(0));
+            assertBigDecimalEquals(new BigDecimal("1200"), history.get(1));
+            assertBigDecimalEquals(new BigDecimal("1300"), history.get(2));
+        }
+
+        @Test
+        @DisplayName("Returned list is a defensive copy — mutating it does not affect player history")
+        void returnedListIsDefensiveCopy() {
+            // Arrange
+            Player p = playerWith("1000");
+            List<BigDecimal> history = service.getNetWorthHistory(p);
+            // Act & Assert — list is unmodifiable
+            assertThrows(UnsupportedOperationException.class,
+                    () -> history.add(new BigDecimal("9999")));
+            assertEquals(1, service.getNetWorthHistory(p).size());
+        }
+    }
+
+    @Nested
     @DisplayName("getStatus()")
     class GetStatus {
 


### PR DESCRIPTION
## Why

Two related issues with how networth was being displayed on
the portfolio dashboard:

1. The Egenkapital tooltip described the displayed number as
   "Cash + portfolio market value, in NOK. Tax and commission
   are not deducted" - but the underlying `Player.getNetWorth`
   has been subtracting outstanding debt all along. The
   tooltip was technically misleading any player with active
   loans (they would read it and assume their displayed
   "Egenkapital" was gross, not net of debt). The label was
   correct; the explanatory text wasn't.
2. The networth chart did not show per-week progression
   correctly on a fresh new game - it appeared to "jump to
   week 3" after one Avanser uke click. Loaded saves looked
   right because the dense historical baseline absorbed the
   bug.

A diagnostic on this branch traced the chart issue to
`NetWorthCard.onGameUpdated()` calling `chart.addPoint()`
unconditionally on every observer notification. But
`GameService.notifyObservers()` fires from buy(), sell(),
takeLoan() and any other state mutation - not only from
advanceWeek. Each trade added a spurious data point, advancing
the chart's positional x-axis past the actual game week.

The bug was masked on loaded saves because the historical
baseline absorbed the spurious points; visible on new games
where the chart starts with one seeded point and any pre-
advance trade immediately corrupts the axis.

## The fix - data-bound, not event-driven

The cleanest fix is to stop treating the chart as event-driven
(append on every notification) and make it data-bound (rebuild
from the model's authoritative history on every notification).
The model already has the correct history - `Player.recordNet
Worth` appends exactly one entry per week in `finishWeekAdvance`
and the constructor seeds week 1. The bug was that the view
was building its own parallel, corrupted version of the same
data instead of reflecting the model directly.

This follows the same read-service pattern Dara established
in her recent stock-detail-modal PR with `StockHistoryService`:
let the model own the truth, expose it through a stateless
read service, and let the view mirror what's there.