### PR TITLE
# refactor: structural audit follow-ups

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/MainController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/MainController.java
@@ -12,7 +12,7 @@ import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.service.toast.ToastService;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
 import edu.ntnu.idatt2003.millions.view.MainView;
-import edu.ntnu.idatt2003.millions.view.component.toast.ToastType;
+import edu.ntnu.idatt2003.millions.service.toast.ToastType;
 import edu.ntnu.idatt2003.millions.view.dialog.EndGameDialog;
 import edu.ntnu.idatt2003.millions.view.titlebar.TitleBar;
 import edu.ntnu.idatt2003.millions.view.titlebar.TitleBarFactory;

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/TradeController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/TradeController.java
@@ -6,7 +6,7 @@ import edu.ntnu.idatt2003.millions.model.stock.Share;
 import edu.ntnu.idatt2003.millions.model.stock.Stock;
 import edu.ntnu.idatt2003.millions.model.transaction.Transaction;
 import edu.ntnu.idatt2003.millions.model.transaction.TransactionPreview;
-import edu.ntnu.idatt2003.millions.model.transaction.TransactionPreviewService;
+import edu.ntnu.idatt2003.millions.service.TransactionPreviewService;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
 import edu.ntnu.idatt2003.millions.view.dashboard.portfolio.dialog.*;
 import edu.ntnu.idatt2003.millions.view.dialog.StockDetailModal;

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/exchange/Exchange.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/exchange/Exchange.java
@@ -1,7 +1,7 @@
 package edu.ntnu.idatt2003.millions.model.exchange;
 
 import edu.ntnu.idatt2003.millions.factory.TransactionFactory;
-import edu.ntnu.idatt2003.millions.file.game.JsonGameFileHandler;
+import edu.ntnu.idatt2003.millions.file.game.GameFileHandler;
 import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
 import edu.ntnu.idatt2003.millions.model.transaction.Sale;
 import edu.ntnu.idatt2003.millions.model.transaction.Transaction;
@@ -410,7 +410,7 @@ public class Exchange {
 
     /**
      * Reinitializes transient fields after deserialization.
-     * Must be called by {@link JsonGameFileHandler} after loading a game from file,
+     * Must be called by {@link GameFileHandler} after loading a game from file,
      * since Gson does not invoke constructors and transient fields are not restored.
      *
      * @param currencyConverter the converter to use for the loaded game session

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/TransactionPreview.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/TransactionPreview.java
@@ -1,5 +1,7 @@
 package edu.ntnu.idatt2003.millions.model.transaction;
 
+import edu.ntnu.idatt2003.millions.service.TransactionPreviewService;
+
 import java.math.BigDecimal;
 
 /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/TransactionPreviewService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/TransactionPreviewService.java
@@ -1,4 +1,4 @@
-package edu.ntnu.idatt2003.millions.model.transaction;
+package edu.ntnu.idatt2003.millions.service;
 
 import edu.ntnu.idatt2003.millions.model.calculator.PurchaseCalculator;
 import edu.ntnu.idatt2003.millions.model.calculator.SalesCalculator;
@@ -6,9 +6,9 @@ import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
 import edu.ntnu.idatt2003.millions.model.player.Player;
 import edu.ntnu.idatt2003.millions.model.stock.Share;
 import edu.ntnu.idatt2003.millions.model.stock.Stock;
+import edu.ntnu.idatt2003.millions.model.transaction.TransactionPreview;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.Currency;
 
 /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/toast/Toast.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/toast/Toast.java
@@ -1,3 +1,3 @@
-package edu.ntnu.idatt2003.millions.view.component.toast;
+package edu.ntnu.idatt2003.millions.service.toast;
 
 public record Toast(long id, ToastType type, String message) {}

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/toast/ToastService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/toast/ToastService.java
@@ -1,7 +1,5 @@
 package edu.ntnu.idatt2003.millions.service.toast;
 
-import edu.ntnu.idatt2003.millions.view.component.toast.Toast;
-import edu.ntnu.idatt2003.millions.view.component.toast.ToastType;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/toast/ToastType.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/toast/ToastType.java
@@ -1,0 +1,6 @@
+package edu.ntnu.idatt2003.millions.service.toast;
+
+public enum ToastType {
+    SUCCESS,
+    ERROR
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/toast/ToastNode.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/toast/ToastNode.java
@@ -1,5 +1,7 @@
 package edu.ntnu.idatt2003.millions.view.component.toast;
 
+import edu.ntnu.idatt2003.millions.service.toast.Toast;
+import edu.ntnu.idatt2003.millions.service.toast.ToastType;
 import javafx.geometry.Pos;
 import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/toast/ToastOverlay.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/toast/ToastOverlay.java
@@ -1,5 +1,6 @@
 package edu.ntnu.idatt2003.millions.view.component.toast;
 
+import edu.ntnu.idatt2003.millions.service.toast.Toast;
 import edu.ntnu.idatt2003.millions.service.toast.ToastService;
 import javafx.animation.FadeTransition;
 import javafx.animation.PauseTransition;

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/toast/ToastType.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/toast/ToastType.java
@@ -1,6 +1,0 @@
-package edu.ntnu.idatt2003.millions.view.component.toast;
-
-public enum ToastType {
-    SUCCESS,
-    ERROR
-}

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/leaderboard/card/LeaderboardCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/leaderboard/card/LeaderboardCard.java
@@ -6,7 +6,7 @@ import edu.ntnu.idatt2003.millions.model.player.PlayerStatusLevel;
 import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.service.LeaderboardService;
 import edu.ntnu.idatt2003.millions.service.toast.ToastService;
-import edu.ntnu.idatt2003.millions.view.component.toast.ToastType;
+import edu.ntnu.idatt2003.millions.service.toast.ToastType;
 import edu.ntnu.idatt2003.millions.util.ChangeFormatter;
 import edu.ntnu.idatt2003.millions.util.CurrencyFormatter;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/transaction/TransactionPreviewServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/transaction/TransactionPreviewServiceTest.java
@@ -5,6 +5,7 @@ import edu.ntnu.idatt2003.millions.model.currency.FixedRateCurrencyConverter;
 import edu.ntnu.idatt2003.millions.model.player.Player;
 import edu.ntnu.idatt2003.millions.model.stock.Share;
 import edu.ntnu.idatt2003.millions.model.stock.Stock;
+import edu.ntnu.idatt2003.millions.service.TransactionPreviewService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/src/test/java/edu/ntnu/idatt2003/millions/service/toast/ToastServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/service/toast/ToastServiceTest.java
@@ -1,7 +1,7 @@
 package edu.ntnu.idatt2003.millions.service.toast;
 
-import edu.ntnu.idatt2003.millions.view.component.toast.Toast;
-import edu.ntnu.idatt2003.millions.view.component.toast.ToastType;
+import edu.ntnu.idatt2003.millions.service.toast.Toast;
+import edu.ntnu.idatt2003.millions.service.toast.ToastType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;


### PR DESCRIPTION
## Why

A structural audit of `model.*`, `service.*`, `controller.*`,
`factory.*`, and `file.*` against the rubric's structure
criteria found three concrete improvements worth acting on,
plus a wider confirmation that nothing else in those layers
needed changing.

For context on the wider confirmation (which doesn't show up
in the diff but is the report's main finding): public APIs
consistently return interface types for collections (no
`ArrayList`, `HashMap`, etc. anywhere in public signatures),
package names are role-describing, no backward dependencies
between layers other than the two flagged below, no mutable
static state, and method cohesion is high across the audited
packages. The three commits below address the only real
findings.

## Commits

### 1. `refactor: move TransactionPreviewService from model to service layer`

`TransactionPreviewService` was in `model.transaction` but is
structurally identical to the other stateless read services
(`PlayerStatsService`, `PortfolioService`,
`RealizedReturnsService`, etc.) which all live in `service.*`:
no fields, no mutation, coordinates multiple domain objects
to compute a preview. Its own Javadoc said "Used by
controllers to feed dialogs and other view components", which
made the misplacement visible - controllers were reaching
into `model.*` to find what is functionally a service.

Moved to `service.*` (same flat layout as the other stateless
services). Import updates only; no logic changes.

### 2. `refactor: move Toast and ToastType out of view layer`

`ToastService` in the service layer imported `Toast` (a plain
`record`) and `ToastType` (a two-value `enum`) from
`view.component.toast`. Neither type contained any JavaFX
code - they were domain-adjacent message-payload types
misfiled in the view package. The result was a service → view
backward dependency that violated the layering described in
`SoC.md`.

Moved both files to `service.toast`. The view directory
`view.component.toast` still houses `ToastNode` and
`ToastOverlay`, which ARE genuine JavaFX components and
correctly stay there. They now import `Toast`/`ToastType` from
`service.toast` (the normal direction — view depends on
service, not the other way around).

### 3. `docs: refer to GameFileHandler interface in Exchange javadoc`

`Exchange.java` imported `JsonGameFileHandler` (a concrete
file implementation) solely so the Javadoc `{@link
JsonGameFileHandler}` on `reinitialize()` would resolve. The
class had no executable dependency on the concrete handler.
The import existed entirely to make a Javadoc tag work, and
it pointed at the wrong abstraction level - `Exchange` should
reference the `GameFileHandler` interface, not a particular
JSON implementation.

Changed the `@link` target to the interface and swapped the
import. One Javadoc word, one import line. Smallest possible
change for the cleanest result.
