### PR TITLE
refactor: idiomatic streams in TransactionArchive and Exchange

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/millions/model/exchange/Exchange.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/exchange/Exchange.java
@@ -307,9 +307,8 @@ public class Exchange {
      */
     public void advance() {
         week++;
-        for (Stock stock : stockMap.values()) {
-            stock.addNewSalesPrice(simulator.nextPrice(stock.getSalesPrice()));
-        }
+        stockMap.values().forEach(
+                stock -> stock.addNewSalesPrice(simulator.nextPrice(stock.getSalesPrice())));
     }
 
     //--- Private validation helpers ---

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/TransactionArchive.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/TransactionArchive.java
@@ -80,11 +80,10 @@ public class TransactionArchive {
      */
     public List<Transaction> getTransactionsInRange(int fromWeek, int toWeek) {
         if (fromWeek < 1) throw new IllegalArgumentException("fromWeek must be at least 1");
-        List<Transaction> list = new ArrayList<>();
-        for (int week = fromWeek; week <= toWeek; week++) {
-            list.addAll(getTransactions(week));
-        }
-        return list;
+        return java.util.stream.IntStream.rangeClosed(fromWeek, toWeek)
+                .boxed()
+                .flatMap(w -> getTransactions(w).stream())
+                .collect(java.util.stream.Collectors.toCollection(ArrayList::new));
     }
 
     /**
@@ -97,11 +96,9 @@ public class TransactionArchive {
      */
     public int countPurchasesInRange(int fromWeek, int toWeek) {
         if (fromWeek < 1) throw new IllegalArgumentException("fromWeek must be at least 1");
-        int total = 0;
-        for (int week = fromWeek; week <= toWeek; week++) {
-            total += getPurchases(week).size();
-        }
-        return total;
+        return java.util.stream.IntStream.rangeClosed(fromWeek, toWeek)
+                .map(w -> getPurchases(w).size())
+                .sum();
     }
 
     /**
@@ -114,11 +111,9 @@ public class TransactionArchive {
      */
     public int countSalesInRange(int fromWeek, int toWeek) {
         if (fromWeek < 1) throw new IllegalArgumentException("fromWeek must be at least 1");
-        int total = 0;
-        for (int week = fromWeek; week <= toWeek; week++) {
-            total += getSales(week).size();
-        }
-        return total;
+        return java.util.stream.IntStream.rangeClosed(fromWeek, toWeek)
+                .map(w -> getSales(w).size())
+                .sum();
     }
 
     /**


### PR DESCRIPTION
## Why
 
A functional-programming audit against the rubric's A-level
criterion ("benytter lambda i samlinger, i stedenfor while/
for-løkker, hvor det er hensiktsmessig") confirmed that the
codebase already uses streams idiomatically across most
collection-handling code - `PortfolioService`,
`RealizedReturnsService`, `Exchange.getGainers/Losers`,
`PlayerStatsService`, and most of `TransactionArchive`
itself.
 
The audit flagged four imperative loops as MEDIUM-severity
inconsistencies - for-loops in classes that otherwise use
streams. This PR converts those four to idiomatic stream
forms.
 
The other loops in the codebase have legitimate imperative
justifications (I/O with checked exceptions, dual side
effects, mutating accumulators) and were left untouched per
the audit's recommendation.
 
## What changed
 
### TransactionArchive - three integer-range loops
 
| Method | Before | After |
|---|---|---|
| `getTransactionsInRange` | for-loop with `addAll` | `IntStream.rangeClosed.boxed().flatMap(w -> getTransactions(w).stream()).collect(toCollection(ArrayList::new))` |
| `countPurchasesInRange` | for-loop with counter | `IntStream.rangeClosed.map(w -> getPurchases(w).size()).sum()` |
| `countSalesInRange` | for-loop with counter | `IntStream.rangeClosed.map(w -> getSales(w).size()).sum()` |
 
Note on the collector choice: `getTransactionsInRange` uses
`toCollection(ArrayList::new)` rather than `.toList()`
because the existing Javadoc and test contract require a
fresh mutable list. `.toList()` returns an unmodifiable view
and would break that contract. Preserving behaviour was
preferred over picking the shorter idiom.
 
### Exchange - one side-effect loop
 
`advance()`: replaced `for (Stock stock : stockMap.values())`
with `stockMap.values().forEach(stock -> ...)`. Pure
side-effect iteration; `forEach` is the conventional form.
 