### PR TITLE
docs: javadoc pass and structural cleanups across the model layer

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/ForcedSaleController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/ForcedSaleController.java
@@ -51,7 +51,7 @@ public class ForcedSaleController {
 
         ForcedSaleDialog[] ref = new ForcedSaleDialog[1];
         ref[0] = new ForcedSaleDialog(
-                shares, interestDue, maturityDue, player.getMoney(), netNokByShare, currentWeek,
+                shares, interestDue, maturityDue, player.getCash(), netNokByShare, currentWeek,
                 selectedShares -> handleConfirm(ref[0], selectedShares, currentWeek)
         );
         ref[0].show();

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/LoanController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/LoanController.java
@@ -55,7 +55,7 @@ public class LoanController {
         Player player = gameService.getPlayer();
         int currentWeek = gameService.getExchange().getWeek();
         RepayLoanDialog[] ref = new RepayLoanDialog[1];
-        ref[0] = new RepayLoanDialog(loan, loanIndex, player.getMoney(), currentWeek,
+        ref[0] = new RepayLoanDialog(loan, loanIndex, player.getCash(), currentWeek,
                 validateRepay(loan));
         ref[0].setOnConfirm(l -> handleRepayConfirm(ref[0], l, loanIndex));
         ref[0].show();
@@ -102,7 +102,7 @@ public class LoanController {
      * Returns empty if allowed; present with an i18n error key if not.
      */
     private Optional<String> validateRepay(Loan loan) {
-        if (gameService.getPlayer().getMoney().compareTo(loan.principal()) < 0) {
+        if (gameService.getPlayer().getCash().compareTo(loan.principal()) < 0) {
             return Optional.of("loans.repay.error.insufficientFunds");
         }
         return Optional.empty();
@@ -119,11 +119,11 @@ public class LoanController {
 
     private void handleRepayConfirm(RepayLoanDialog dialog, Loan loan, int loanIndex) {
         try {
-            BigDecimal balanceBefore = gameService.getPlayer().getMoney();
+            BigDecimal balanceBefore = gameService.getPlayer().getCash();
             int week = gameService.getExchange().getWeek();
             gameService.repayLoan(loan);
             dialog.close();
-            BigDecimal balanceAfter = gameService.getPlayer().getMoney();
+            BigDecimal balanceAfter = gameService.getPlayer().getCash();
             Platform.runLater(() ->
                     new LoanRepaymentReceipt(loan, loanIndex, balanceBefore, balanceAfter, week).show());
         } catch (IllegalArgumentException e) {

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/TradeController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/TradeController.java
@@ -50,7 +50,7 @@ public class TradeController {
      * @return the player's available funds
      */
     public BigDecimal getCurrentBalance() {
-        return gameService.getPlayer().getMoney();
+        return gameService.getPlayer().getCash();
     }
 
     /**
@@ -155,7 +155,7 @@ public class TradeController {
     // Mutating operations
 
     private void buy(Stock stock, BigDecimal quantity, BuyDialog dialog) {
-        BigDecimal balanceBefore = gameService.getPlayer().getMoney();
+        BigDecimal balanceBefore = gameService.getPlayer().getCash();
         TransactionPreview preview = previewService.previewPurchase(
                 stock, quantity, gameService.getPlayer(),
                 gameService.getCurrencyConverter());
@@ -167,7 +167,7 @@ public class TradeController {
         try {
             Transaction transaction = gameService.buy(stock.getSymbol(), quantity);
             dialog.close();
-            BigDecimal balanceAfter = gameService.getPlayer().getMoney();
+            BigDecimal balanceAfter = gameService.getPlayer().getCash();
             Platform.runLater(() ->
                     new BuyReceipt(transaction, balanceBefore, balanceAfter, preview).show());
         } catch (IllegalArgumentException | IllegalStateException e) {
@@ -180,7 +180,7 @@ public class TradeController {
     }
 
     private void sell(Share share, BigDecimal quantity, AbstractSellDialog dialog) {
-        BigDecimal balanceBefore = gameService.getPlayer().getMoney();
+        BigDecimal balanceBefore = gameService.getPlayer().getCash();
         TransactionPreview preview = previewService.previewSale(
                 share, quantity, gameService.getPlayer(),
                 gameService.getCurrencyConverter());
@@ -192,7 +192,7 @@ public class TradeController {
         try {
             Transaction transaction = gameService.sell(share, quantity);
             dialog.close();
-            BigDecimal balanceAfter = gameService.getPlayer().getMoney();
+            BigDecimal balanceAfter = gameService.getPlayer().getCash();
             Platform.runLater(() ->
                     new SellReceipt(transaction, balanceBefore, balanceAfter, preview).show());
         } catch (IllegalArgumentException | IllegalStateException e) {

--- a/src/main/java/edu/ntnu/idatt2003/millions/factory/TransactionFactory.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/factory/TransactionFactory.java
@@ -3,7 +3,6 @@ package edu.ntnu.idatt2003.millions.factory;
 import edu.ntnu.idatt2003.millions.model.stock.Share;
 import edu.ntnu.idatt2003.millions.model.transaction.Purchase;
 import edu.ntnu.idatt2003.millions.model.transaction.Sale;
-import edu.ntnu.idatt2003.millions.model.transaction.Transaction;
 
 import java.math.BigDecimal;
 
@@ -36,7 +35,7 @@ public class TransactionFactory {
      * @throws NullPointerException     if share is null
      * @throws IllegalArgumentException if week is less than 1
      */
-    public static Transaction createPurchase(Share share, int week) {
+    public static Purchase createPurchase(Share share, int week) {
         return new Purchase(share, week);
     }
 
@@ -50,7 +49,7 @@ public class TransactionFactory {
      * @throws NullPointerException     if share or settlement amount is null
      * @throws IllegalArgumentException if week is less than 1 or settlement amount is negative
      */
-    public static Transaction createPurchase(Share share, int week, BigDecimal settlementAmount) {
+    public static Purchase createPurchase(Share share, int week, BigDecimal settlementAmount) {
         return new Purchase(share, week, settlementAmount);
     }
 
@@ -63,7 +62,7 @@ public class TransactionFactory {
      * @throws NullPointerException     if share is null
      * @throws IllegalArgumentException if week is less than 1
      */
-    public static Transaction createSale(Share share, int week) {
+    public static Sale createSale(Share share, int week) {
         return new Sale(share, week);
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/calculator/PurchaseCalculator.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/calculator/PurchaseCalculator.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.model.calculator;
 
 import edu.ntnu.idatt2003.millions.model.stock.Share;
@@ -23,7 +24,7 @@ public class PurchaseCalculator implements TransactionCalculator {
     /**
      * Constructs a PurchaseCalculator for the given share.
      *
-     * @param share the share being purchased, used to retrieve purchase price and quantity
+     * @param share the share being purchased
      * @throws NullPointerException if the share is null
      */
     public PurchaseCalculator(Share share) {
@@ -36,7 +37,7 @@ public class PurchaseCalculator implements TransactionCalculator {
      * Calculates the gross value of the purchase.
      * Gross value is defined as purchase price multiplied by quantity.
      *
-     * @return the gross value as a {@link BigDecimal}
+     * @return the gross purchase value
      */
     @Override
     public BigDecimal calculateGross() {
@@ -47,7 +48,7 @@ public class PurchaseCalculator implements TransactionCalculator {
      * Calculates the commission fee for the purchase.
      * Commission is 0.5% of the gross value.
      *
-     * @return the commission amount as a {@link BigDecimal}
+     * @return the commission amount
      */
     @Override
     public BigDecimal calculateCommission() {
@@ -58,7 +59,7 @@ public class PurchaseCalculator implements TransactionCalculator {
      * Returns the tax for a purchase transaction.
      * No tax is applied on purchases, so this always returns zero.
      *
-     * @return {@link BigDecimal#ZERO}
+     * @return always zero; purchases are not taxed
      */
     @Override
     public BigDecimal calculateTax() {
@@ -67,9 +68,8 @@ public class PurchaseCalculator implements TransactionCalculator {
 
     /**
      * Calculates the total cost of the purchase.
-     * Total is defined as gross value plus commission plus tax.
      *
-     * @return the total cost as a {@link BigDecimal}
+     * @return the total cost to the buyer
      */
     @Override
     public BigDecimal calculateTotal() {

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/calculator/SalesCalculator.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/calculator/SalesCalculator.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.model.calculator;
 
 import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
@@ -32,7 +33,7 @@ public class SalesCalculator implements TransactionCalculator {
     /**
      * Constructs a SalesCalculator for the given share.
      *
-     * @param share the share being sold, used to retrieve sales price, quantity, and purchase costs
+     * @param share the share being sold
      * @throws NullPointerException if the share is null
      */
     public SalesCalculator(Share share) {
@@ -44,9 +45,7 @@ public class SalesCalculator implements TransactionCalculator {
     }
 
     /**
-     * Calculates the realized profit (or loss) from this sale, after
-     * commission and tax. Profit is the total received minus the original
-     * purchase costs.
+     * Calculates the realized profit (or loss) from this sale, after commission and tax.
      *
      * @return the realized profit (positive) or loss (negative)
      */
@@ -73,7 +72,7 @@ public class SalesCalculator implements TransactionCalculator {
      * Calculates the gross value of the sale.
      * Gross value is defined as sales price multiplied by quantity.
      *
-     * @return the gross value as a {@link BigDecimal}
+     * @return the gross sale value
      */
     @Override
     public BigDecimal calculateGross() {
@@ -84,7 +83,7 @@ public class SalesCalculator implements TransactionCalculator {
      * Calculates the commission fee for the sale.
      * Commission is 1% of the gross value.
      *
-     * @return the commission amount as a {@link BigDecimal}
+     * @return the commission amount
      */
     @Override
     public BigDecimal calculateCommission() {
@@ -93,10 +92,9 @@ public class SalesCalculator implements TransactionCalculator {
 
     /**
      * Calculates the tax for the sale.
-     * Tax is 30% of the profit, where profit is gross value minus commission minus purchase costs.
-     * If the profit is zero or negative (i.e. a loss), zero tax is returned.
+     * Tax is 30% of the pre-tax profit. Returns zero if the position was sold at a loss.
      *
-     * @return the tax amount as a {@link BigDecimal}, or {@link BigDecimal#ZERO} if there is no profit
+     * @return the tax amount, or zero if there is no profit
      */
     @Override
     public BigDecimal calculateTax() {
@@ -109,9 +107,8 @@ public class SalesCalculator implements TransactionCalculator {
 
     /**
      * Calculates the total net payout of the sale.
-     * Total is defined as gross value minus commission minus tax.
      *
-     * @return the total net payout as a {@link BigDecimal}
+     * @return the net payout to the seller
      */
     @Override
     public BigDecimal calculateTotal() {
@@ -122,9 +119,10 @@ public class SalesCalculator implements TransactionCalculator {
      * Calculates the net payout of selling the entire position and converts
      * the result to NOK using the given currency converter.
      *
-     * @param share     the share being sold; must not be null
+     * @param share     the share being sold
      * @param converter the converter used to translate the native-currency net to NOK
      * @return the net sale value in NOK
+     * @throws NullPointerException if share or converter is null
      */
     public static BigDecimal calculateNetNok(Share share, CurrencyConverter converter) {
         Objects.requireNonNull(share, "Share cannot be null");

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/calculator/TransactionCalculator.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/calculator/TransactionCalculator.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.model.calculator;
 
 import java.math.BigDecimal;
@@ -13,29 +14,28 @@ public interface TransactionCalculator {
     /**
      * Calculates the gross value of the transaction.
      *
-     * @return the gross value as a {@link BigDecimal}
+     * @return the gross transaction value
      */
     BigDecimal calculateGross();
 
     /**
      * Calculates the commission fee for the transaction.
      *
-     * @return the commission amount as a {@link BigDecimal}
+     * @return the commission amount
      */
     BigDecimal calculateCommission();
 
     /**
      * Calculates the tax applied to the transaction.
      *
-     * @return the tax amount as a {@link BigDecimal}
+     * @return the tax amount
      */
     BigDecimal calculateTax();
 
     /**
-     * Calculates the total cost or profit of the transaction,
-     * typically the sum of gross, commission, and tax.
+     * Calculates the total amount the player pays or receives for the transaction.
      *
-     * @return the total amount as a {@link BigDecimal}
+     * @return the total transaction amount
      */
     BigDecimal calculateTotal();
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/currency/CurrencyConverter.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/currency/CurrencyConverter.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.model.currency;
 
 import java.math.BigDecimal;
@@ -7,8 +8,7 @@ import java.util.Currency;
  * Converts monetary amounts between currencies.
  *
  * <p>Implementations are expected to be stateless and thread-safe.
- * The {@link FixedRateCurrencyConverter} provides hardcoded rates;
- * other implementations may use live exchange rates in the future.
+ * {@link FixedRateCurrencyConverter} provides hardcoded exchange rates.
  */
 public interface CurrencyConverter {
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/currency/FixedRateCurrencyConverter.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/currency/FixedRateCurrencyConverter.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.model.currency;
 
 import java.math.BigDecimal;
@@ -10,14 +11,13 @@ import java.util.Objects;
 /**
  * A {@link CurrencyConverter} backed by a fixed table of exchange rates.
  *
- * <p> All rates are defined relative to NOK and used as the pivot for
- * conversion between any two supported currencies. Conversion follows
- * the formula: {@code (amount * fromRateToNok) / toRateToNok}.</p>
+ * <p>All rates are defined relative to NOK, which is used as the pivot for
+ * conversion between any two supported currencies.</p>
  *
- * <p> Supported currencies: NOK, USD, EUR, GBP. Conversion of an amount
- * to and from the same currency returns the original amount unchanged.</p>
+ * <p>Supported currencies: NOK, USD, EUR, GBP, SEK, DKK. Converting between
+ * identical currencies returns the original amount unchanged.</p>
  *
- * <p> Last updated currency: 8. May 2026</p>
+ * <p>Rates last updated: 8 May 2026.</p>
  */
 public class FixedRateCurrencyConverter implements CurrencyConverter {
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/exchange/Exchange.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/exchange/Exchange.java
@@ -268,7 +268,7 @@ public class Exchange {
 
         Sale sale = TransactionFactory.createSale(soldPortion, week);
         BigDecimal totalValueInNok = currencyConverter.convert(
-                sale.getTotal(), share.getStock().getCurrency(), NOK);
+                sale.getSignedTotalNative(), share.getStock().getCurrency(), NOK);
         player.addMoney(totalValueInNok);
 
         sale.commit(player);

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/exchange/Exchange.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/exchange/Exchange.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.model.exchange;
 
 import edu.ntnu.idatt2003.millions.factory.TransactionFactory;
@@ -21,7 +22,7 @@ import java.util.stream.Stream;
 /**
  * Represents a stock exchange where players can buy and sell shares.
  * The exchange keeps track of all listed stocks and the current week.
- * Prices are updated each week using the advance() method.
+ * Prices advance each week via {@link #advance()}.
  *
  * <p>Buy and sell transactions are denominated in each stock's native currency
  * but converted to NOK via a {@link CurrencyConverter} before the player's
@@ -47,7 +48,6 @@ public class Exchange {
 
     /**
      * Creates a new exchange with a {@link RandomPriceSimulator} as the default pricing model.
-     * Delegates to {@link #Exchange(String, List, CurrencyConverter, PriceSimulator)}.
      *
      * @param name              the name of the exchange
      * @param stocks            the stocks that can be traded on this exchange
@@ -62,8 +62,7 @@ public class Exchange {
 
     /**
      * Creates a new exchange with the given name, list of stocks, currency converter,
-     * and price simulator. The stocks are stored in a map using their symbol as the key.
-     * Week starts at 1.
+     * and price simulator. Week starts at 1.
      *
      * @param name              the name of the exchange
      * @param stocks            the stocks that can be traded on this exchange
@@ -99,38 +98,28 @@ public class Exchange {
         }
     }
 
-    /**
-     * Returns the name of the exchange.
-     *
-     * @return the exchange name
-     */
     public String getName() {
         return name;
     }
 
     /**
-     * Returns the currency converter used by this exchange to translate
-     * stock-currency amounts to NOK.
+     * Returns the currency converter used by this exchange to translate stock-currency amounts to NOK.
+     * Returns null if called before {@link #reinitialize(CurrencyConverter)} after deserialization.
      *
-     * @return the currency converter
+     * @return the currency converter, or null if not yet reinitialized
      */
     public CurrencyConverter getCurrencyConverter() {
         return currencyConverter;
     }
 
-    /**
-     * Returns the current trading week.
-     *
-     * @return the current week number
-     */
     public int getWeek() {
         return week;
     }
 
     /**
-     * Return all stocks listed on this exchange
+     * Returns all stocks listed on this exchange.
      *
-     * @return an unmodifiable list of all stocks.
+     * @return unmodifiable list of all listed stocks
      */
     public List<Stock> getStocks() {
         return List.copyOf(stockMap.values());
@@ -153,8 +142,7 @@ public class Exchange {
 
     /**
      * Checks if a stock with the given symbol is listed on the exchange.
-     * Returns false instead of throwing an exception if the symbol is null or blank,
-     * since this method is meant to be used as a safe check before calling getStock().
+     * Returns false for null or blank symbols instead of throwing.
      *
      * @param symbol the stock symbol to check
      * @return true if the stock is listed, false otherwise
@@ -167,13 +155,10 @@ public class Exchange {
 
     /**
      * Searches for stocks where the symbol or company name contains the search term.
-     * The search is not case-sensitive. If the search term is null or blank, the method
-     * will return an empty list.
+     * The search is case-insensitive. Returns an empty list for null or blank terms.
      *
      * @param searchTerm the word or phrase to search for
-     * @return a list of stocks that match the search term
-     * @throws NullPointerException if the search term is null
-     * @throws IllegalArgumentException if the search term is blank
+     * @return list of matching stocks; empty if the term is null, blank, or no stocks match
      */
     public List<Stock> findStocks(String searchTerm) {
         if (searchTerm == null || searchTerm.isBlank()) return List.of();
@@ -184,10 +169,9 @@ public class Exchange {
     }
 
     /**
-     * Buys a given quantity of a stock for a player.
-     * The total cost is computed in the stock's native currency, converted to NOK
-     * via the active {@link CurrencyConverter}, and passed to {@link TransactionFactory}.
-     * The purchase commits the balance withdrawal and is then returned.
+     * Buys a given quantity of a stock for a player at the current price.
+     * The total cost is deducted from the player's balance in NOK and the
+     * acquired share is added to the portfolio.
      *
      * @param symbol   the symbol of the stock to buy
      * @param quantity how many shares to buy
@@ -195,8 +179,8 @@ public class Exchange {
      * @return the completed purchase transaction
      * @throws NullPointerException     if symbol, quantity, or player is null
      * @throws IllegalArgumentException if the symbol is blank, not found,
-     *                                  or quantity is not greater than zero
-     * @throws IllegalArgumentException if the player does not have enough money
+     *                                  quantity is not greater than zero,
+     *                                  or the player does not have enough funds
      */
     public Transaction buy(String symbol, BigDecimal quantity, Player player) {
         validateSymbol(symbol);
@@ -218,9 +202,7 @@ public class Exchange {
     }
 
     /**
-     * Sells the full quantity of a share for a player. Convenience overload that
-     * delegates to {@link #sell(Share, BigDecimal, Player)} with the share's full
-     * quantity.
+     * Sells the full quantity of a share for a player.
      *
      * @param share  the share to sell
      * @param player the player selling the share
@@ -234,14 +216,11 @@ public class Exchange {
     }
 
     /**
-     * Sells a given quantity of a share for a player. The sold portion is settled
-     * as a {@link Sale}; if the requested quantity is less than the full position,
-     * the remainder stays in the player's portfolio with the original purchase
-     * price preserved so per-share return is unchanged on the remaining position.
+     * Sells a given quantity of a share for a player. For partial sales, the
+     * remainder stays in the portfolio with the original purchase price preserved,
+     * so the per-share return on the remaining position is unchanged.
      *
-     * <p>The net payout is computed in the stock's native currency, converted to
-     * NOK via the active {@link CurrencyConverter}, and added to the player's
-     * balance.</p>
+     * <p>The net payout is added to the player's balance in NOK.</p>
      *
      * @param share    the share to sell from
      * @param quantity the quantity to sell (must be greater than zero and no more
@@ -301,9 +280,7 @@ public class Exchange {
     }
 
     /**
-     * Moves the exchange forward by one week.
-     * The week counter is incremented, and each stock gets a new price
-     * computed by the injected {@link PriceSimulator}.
+     * Moves the exchange forward by one week, updating all stock prices.
      */
     public void advance() {
         week++;
@@ -311,15 +288,6 @@ public class Exchange {
                 stock -> stock.addNewSalesPrice(simulator.nextPrice(stock.getSalesPrice())));
     }
 
-    //--- Private validation helpers ---
-
-    /**
-     * Checks that the given symbol is not null or blank.
-     *
-     * @param symbol the symbol to validate
-     * @throws NullPointerException if the symbol is null
-     * @throws IllegalArgumentException if the symbol is blank
-     */
     private void validateSymbol(String symbol) {
         Objects.requireNonNull(symbol, "Symbol cannot be null");
         if (symbol.isBlank()) {
@@ -327,12 +295,6 @@ public class Exchange {
         }
     }
 
-    /**
-     * Checks that the given player is not null.
-     *
-     * @param player the player to validate
-     * @throws NullPointerException if the player is null
-     */
     private void validatePlayer(Player player) {
         Objects.requireNonNull(player, "Player cannot be null");
     }
@@ -387,21 +349,11 @@ public class Exchange {
         return losersStream().count();
     }
 
-    /**
-     * Returns a stream of stocks with a positive weekly percentage change.
-     *
-     * @return a stream of gaining stocks
-     */
     private Stream<Stock> gainersStream() {
         return stockMap.values().stream()
                 .filter(stock -> stock.getWeeklyChangePercent().compareTo(BigDecimal.ZERO) > 0);
     }
 
-    /**
-     * Returns a stream of stocks with a negative weekly percentage change.
-     *
-     * @return a stream of losing stocks
-     */
     private Stream<Stock> losersStream() {
         return stockMap.values().stream()
                 .filter(stock -> stock.getWeeklyChangePercent().compareTo(BigDecimal.ZERO) < 0);
@@ -409,8 +361,7 @@ public class Exchange {
 
     /**
      * Reinitializes transient fields after deserialization.
-     * Must be called by {@link GameFileHandler} after loading a game from file,
-     * since Gson does not invoke constructors and transient fields are not restored.
+     * Must be called by {@link GameFileHandler} after loading a game from file.
      *
      * @param currencyConverter the converter to use for the loaded game session
      * @throws NullPointerException if currencyConverter is null

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/exchange/Exchange.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/exchange/Exchange.java
@@ -266,7 +266,7 @@ public class Exchange {
             player.getPortfolio().addShare(soldPortion);
         }
 
-        Sale sale = (Sale) TransactionFactory.createSale(soldPortion, week);
+        Sale sale = TransactionFactory.createSale(soldPortion, week);
         BigDecimal totalValueInNok = currencyConverter.convert(
                 sale.getTotal(), share.getStock().getCurrency(), NOK);
         player.addMoney(totalValueInNok);

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/exchange/PriceSimulator.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/exchange/PriceSimulator.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.model.exchange;
 
 import java.math.BigDecimal;
@@ -5,11 +6,8 @@ import java.math.BigDecimal;
 /**
  * Strategy interface for computing the next sales price of a stock.
  *
- * <p>Implementations define a pricing model (for example a random walk or a
- * trend-based model, without coupling the model to {@link Exchange}).
- * The interface is FunctionalInterface-annotated, so implementations
- * may be supplied as lambdas where deterministic behaviour is needed (e.g. in tests)</p>
- *
+ * <p>Implementations define a pricing model (for example a random walk or a trend-based model).
+ * May be supplied as a lambda for deterministic behaviour in tests.</p>
  */
 @FunctionalInterface
 public interface PriceSimulator {

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/exchange/RandomPriceSimulator.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/exchange/RandomPriceSimulator.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.model.exchange;
 
 import java.math.BigDecimal;
@@ -6,12 +7,11 @@ import java.util.Random;
 
 /**
  * A {@link PriceSimulator} that updates stock prices using a random walk model.
- * Owns the random instance.
  *
  * <p>Each call applies a uniformly distributed random percentage change in the range
  * {@code [-MAX_WEEKLY_CHANGE, +MAX_WEEKLY_CHANGE]} to the current price.
- * The result is rounded to two decimal places and floored
- * at {@code MIN_PRICE} so that no stock price reaches zero.</p>
+ * The result is rounded to two decimal places and floored at 0.01
+ * so that no stock price reaches zero.</p>
  */
 public class RandomPriceSimulator implements PriceSimulator {
 
@@ -33,7 +33,7 @@ public class RandomPriceSimulator implements PriceSimulator {
     /**
      * Computes the next price by applying a random percentage change to the current price.
      * The change is uniformly distributed in {@code [-10%, +10%]}.
-     * The result is rounded to two decimal places and is never below {@link #MIN_PRICE}.
+     * The result is rounded to two decimal places and is never below 0.01.
      *
      * @param currentPrice the stock's current sales price
      * @return the new sales price after the random walk step

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/leaderboard/LeaderboardEntry.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/leaderboard/LeaderboardEntry.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.model.leaderboard;
 
 import edu.ntnu.idatt2003.millions.model.player.PlayerStatusLevel;
@@ -15,9 +16,7 @@ import java.util.Objects;
  * many times the player saves.</p>
  *
  * <p>{@code returnPercent} is frozen at construction so sorting is consistent
- * even if exchange rates or domain logic change later. This mirrors how
- * {@link edu.ntnu.idatt2003.millions.model.transaction.Sale} freezes its
- * financial values.</p>
+ * even if exchange rates or domain logic change later.</p>
  *
  * @param sessionId       UUID tying the entry to one game session; never reused
  * @param playerName      the player's display name (need not be unique)

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/leaderboard/Outcome.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/leaderboard/Outcome.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.model.leaderboard;
 
 /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/loan/ExcessiveDebtException.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/loan/ExcessiveDebtException.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.model.loan;
 
 import java.math.BigDecimal;

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/loan/InsufficientSaleProceedsException.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/loan/InsufficientSaleProceedsException.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.model.loan;
 
 import java.math.BigDecimal;

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/loan/Loan.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/loan/Loan.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.model.loan;
 
 import java.math.BigDecimal;
@@ -48,12 +49,20 @@ public record Loan(LoanOffer offer, BigDecimal principal, int takenAtWeek) {
      *
      * <p>Precondition: {@code currentWeek >= takenAtWeek}. Behaviour for earlier
      * weeks is undefined (the result will be negative).
+     *
+     * @param currentWeek the current game week
+     * @return number of weeks since the loan was taken
      */
     public int weeksElapsed(int currentWeek) {
         return currentWeek - takenAtWeek;
     }
 
-    /** Number of weeks remaining in the loan term, floored at zero. */
+    /**
+     * Number of weeks remaining in the loan term, floored at zero.
+     *
+     * @param currentWeek the current game week
+     * @return weeks left in the term, or zero if the loan is at or past its due date
+     */
     public int weeksRemaining(int currentWeek) {
         return Math.max(0, offer.termWeeks() - weeksElapsed(currentWeek));
     }
@@ -63,12 +72,20 @@ public record Loan(LoanOffer offer, BigDecimal principal, int takenAtWeek) {
      *
      * <p>Precondition: {@code currentWeek >= takenAtWeek}. Behaviour for earlier
      * weeks is undefined (the result will be negative).
+     *
+     * @param currentWeek the current game week
+     * @return total interest charged so far
      */
     public BigDecimal interestPaid(int currentWeek) {
         return weeklyInterest().multiply(BigDecimal.valueOf(weeksElapsed(currentWeek)));
     }
 
-    /** Interest that would be saved by repaying now (weeklyInterest × weeksRemaining). */
+    /**
+     * Interest that would be saved by repaying now (weeklyInterest × weeksRemaining).
+     *
+     * @param currentWeek the current game week
+     * @return interest avoided by early repayment
+     */
     public BigDecimal interestSaved(int currentWeek) {
         return weeklyInterest().multiply(BigDecimal.valueOf(weeksRemaining(currentWeek)));
     }
@@ -76,12 +93,11 @@ public record Loan(LoanOffer offer, BigDecimal principal, int takenAtWeek) {
     /**
      * Returns true when this loan's principal is due — that is, when
      * {@code currentWeek >= takenAtWeek + termWeeks}.
+     * Returns true for the due week and all subsequent weeks;
+     * preventing duplicate settlement is the caller's responsibility.
      *
-     * <p>Note that this returns true for the due week and any week thereafter;
-     * preventing duplicate settlement is the caller's responsibility. In
-     * practice, settled loans are removed from the active-loans list
-     * immediately, so this method is only ever evaluated for loans that have
-     * not yet been settled.
+     * @param currentWeek the current game week
+     * @return true if the loan term has expired
      */
     public boolean isDueThisWeek(int currentWeek) {
         return weeksRemaining(currentWeek) == 0;

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/loan/LoanCatalog.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/loan/LoanCatalog.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.model.loan;
 
 import java.math.BigDecimal;
@@ -6,10 +7,6 @@ import java.util.Objects;
 
 /**
  * Centralised source of the standard {@link LoanOffer}s available in the game.
- *
- * <p>Callers retrieve the offers via {@link #getOffers()} or look up a
- * specific offer by its id with {@link #findById(String)}. The returned
- * list is unmodifiable.</p>
  */
 public final class LoanCatalog {
 
@@ -22,9 +19,7 @@ public final class LoanCatalog {
                     new BigDecimal("100000.00"), LoanRiskLevel.HIGH)
     );
 
-    private LoanCatalog() {
-        // Utility class - should not be instantiated
-    }
+    private LoanCatalog() {}
 
     /**
      * Returns the unmodifiable list of standard loan offers.

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/loan/LoanLedgerEntry.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/loan/LoanLedgerEntry.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.model.loan;
 
 import java.math.BigDecimal;

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/loan/LoanLedgerEntryType.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/loan/LoanLedgerEntryType.java
@@ -1,12 +1,13 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.model.loan;
 
 /**
  * Classifies a single entry in the player's loan ledger.
  *
  * <ul>
- *   <li>DISBURSEMENT — principal paid out when a loan is taken</li>
- *   <li>INTEREST     — weekly interest deducted from the player's balance</li>
- *   <li>REPAYMENT    — principal withdrawn when the player repays a loan</li>
+ *   <li>{@link #DISBURSEMENT} — principal paid out when a loan is taken</li>
+ *   <li>{@link #INTEREST}     — weekly interest deducted from the player's balance</li>
+ *   <li>{@link #REPAYMENT}    — principal withdrawn when the player repays a loan</li>
  * </ul>
  */
 public enum LoanLedgerEntryType {

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/loan/LoanOffer.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/loan/LoanOffer.java
@@ -1,7 +1,7 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.model.loan;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.Objects;
 
 /**
@@ -10,11 +10,11 @@ import java.util.Objects;
  * <p>The interest rate is expressed as a per-week decimal (e.g. {@code 0.0015}
  * for 0.15% weekly).</p>
  *
- * @param id                 stable identifier used for i18n lookups
+ * @param id                 stable identifier used for i18n lookups; must not be null or blank
  * @param weeklyInterestRate per-week interest rate as a decimal, strictly positive
  * @param termWeeks          weeks until the principal is due, at least 1
  * @param maxPrincipal       largest principal that may be borrowed, strictly positive
- * @param riskLevel          risk classification used for sort and presentation
+ * @param riskLevel          risk classification used for sort and presentation; must not be null
  */
 public record LoanOffer(String id, BigDecimal weeklyInterestRate,
         int termWeeks, BigDecimal maxPrincipal, LoanRiskLevel riskLevel) {
@@ -37,30 +37,5 @@ public record LoanOffer(String id, BigDecimal weeklyInterestRate,
         if (maxPrincipal.signum() <= 0) {
             throw new IllegalArgumentException("Max principal must be greater than zero");
         }
-    }
-
-    /**
-     * Returns the minimum net worth a player must have to qualify for
-     * borrowing {@code principal} on this offer.
-     * The threshold is {@code principal × riskLevel.collateralRatio()}.
-     *
-     * @param principal the desired loan amount
-     * @return minimum required net worth, rounded to 2 decimal places
-     */
-    public BigDecimal minimumCollateral(BigDecimal principal) {
-        return principal.multiply(riskLevel.collateralRatio())
-                .setScale(2, RoundingMode.HALF_UP);
-    }
-
-    /**
-     * Returns {@code true} if the player's net worth is sufficient to qualify
-     * for a loan of {@code principal} on this offer.
-     *
-     * @param netWorth  the player's current net worth in NOK
-     * @param principal the desired loan amount
-     * @return {@code true} if eligible
-     */
-    public boolean isEligible(BigDecimal netWorth, BigDecimal principal) {
-        return netWorth.compareTo(minimumCollateral(principal)) >= 0;
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/loan/LoanPreview.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/loan/LoanPreview.java
@@ -1,11 +1,11 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.model.loan;
 
 import java.math.BigDecimal;
 
 /**
  * Immutable snapshot of the calculated cost for borrowing a specific principal
- * against a {@link LoanOffer}. Used by the view layer for live preview without
- * mutating any model state.
+ * against a {@link LoanOffer}.
  *
  * @param principal            the amount the player wishes to borrow
  * @param weeklyInterestAmount interest charged each week (principal × weeklyRate)

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/loan/LoanRiskLevel.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/loan/LoanRiskLevel.java
@@ -3,13 +3,12 @@ package edu.ntnu.idatt2003.millions.model.loan;
 
 /**
  * Risk profile of a {@link LoanOffer}.
- * Drives presentational choices in the UI (pill colours, sort order) and
- * the minimum collateral ratio required to qualify for a given principal.
+ * Drives presentational choices in the UI such as pill colours and sort order.
  *
  * <ul>
- *   <li>{@code LOW} - safe baseline loan, modest amount, low rate</li>
- *   <li>{@code MEDIUM} - larger amount and a shorter term at a higher rate</li>
- *   <li>{@code HIGH} - maximum leverage at the highest rate and shortest term</li>
+ *   <li>{@link #LOW}    — safe baseline loan, modest amount, low rate</li>
+ *   <li>{@link #MEDIUM} — larger amount and a shorter term at a higher rate</li>
+ *   <li>{@link #HIGH}   — maximum leverage at the highest rate and shortest term</li>
  * </ul>
  */
 public enum LoanRiskLevel {

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/loan/LoanRiskLevel.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/loan/LoanRiskLevel.java
@@ -14,5 +14,5 @@ package edu.ntnu.idatt2003.millions.model.loan;
 public enum LoanRiskLevel {
     LOW,
     MEDIUM,
-    HIGH;
+    HIGH
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/loan/LoanRiskLevel.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/loan/LoanRiskLevel.java
@@ -1,6 +1,5 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.model.loan;
-
-import java.math.BigDecimal;
 
 /**
  * Risk profile of a {@link LoanOffer}.
@@ -17,19 +16,4 @@ public enum LoanRiskLevel {
     LOW,
     MEDIUM,
     HIGH;
-
-    /**
-     * Returns the minimum collateral ratio for this risk level.
-     * The player's net worth must be at least {@code principal × collateralRatio()}
-     * to qualify for a loan of that size.
-     *
-     * @return collateral ratio as a decimal (e.g. {@code 0.10} = 10 %)
-     */
-    public BigDecimal collateralRatio() {
-        return switch (this) {
-            case LOW    -> new BigDecimal("0.10");
-            case MEDIUM -> new BigDecimal("0.20");
-            case HIGH   -> new BigDecimal("0.30");
-        };
-    }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/notification/Notification.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/notification/Notification.java
@@ -1,7 +1,22 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.model.notification;
 
 import java.util.List;
 
+/**
+ * An immutable notification displayed to the player during a game session.
+ *
+ * <p>Title and body are stored as i18n keys with optional interpolation arguments,
+ * so the record carries no locale-specific text itself.</p>
+ *
+ * @param id       unique identifier assigned at creation
+ * @param severity importance level of the notification
+ * @param titleKey i18n key for the notification title
+ * @param bodyKey  i18n key for the notification body template
+ * @param bodyArgs arguments interpolated into the body template; empty if the template has none
+ * @param week     the game week in which the notification was created
+ * @param read     true if the player has acknowledged this notification
+ */
 public record Notification(
         int id,
         Severity severity,
@@ -11,6 +26,16 @@ public record Notification(
         int week,
         boolean read
 ) {
+    /**
+     * Importance level of a {@link Notification}.
+     *
+     * <ul>
+     *   <li>{@link #SEVERE}    — critical event requiring immediate attention (e.g. bankruptcy risk)</li>
+     *   <li>{@link #WARNING}   — non-critical problem the player should be aware of</li>
+     *   <li>{@link #MILESTONE} — positive achievement or progress update</li>
+     *   <li>{@link #INFO}      — routine information with no action required</li>
+     * </ul>
+     */
     public enum Severity {
         SEVERE,
         WARNING,
@@ -18,6 +43,11 @@ public record Notification(
         INFO
     }
 
+    /**
+     * Returns a copy of this notification with {@code read} set to true.
+     *
+     * @return a new Notification identical to this one except marked as read
+     */
     public Notification markAsRead() {
         return new Notification(id, severity, titleKey, bodyKey, bodyArgs, week, true);
     }

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/player/Player.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/player/Player.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.model.player;
 
 import edu.ntnu.idatt2003.millions.model.calculator.SalesCalculator;
@@ -35,7 +36,7 @@ public class Player {
     private final String name;
     private final BigDecimal startingMoney;
     private final String sessionId;
-    private BigDecimal money;
+    private BigDecimal cash;
 
     private final Portfolio portfolio;
     private final TransactionArchive transactionArchive;
@@ -73,7 +74,7 @@ public class Player {
         this.name = name;
         this.startingMoney = startingMoney;
         this.sessionId = UUID.randomUUID().toString();
-        this.money = startingMoney;
+        this.cash = startingMoney;
 
         this.portfolio = new Portfolio();
         this.transactionArchive = new TransactionArchive();
@@ -83,20 +84,10 @@ public class Player {
         netWorthHistory.add(startingMoney);
     }
 
-    /**
-     * Gets the player's name.
-     *
-     * @return the name
-     */
     public String getName() {
         return name;
     }
 
-    /**
-     * Gets the amount of money the player started with.
-     *
-     * @return the starting balance
-     */
     public BigDecimal getStartingMoney() {
         return startingMoney;
     }
@@ -115,23 +106,13 @@ public class Player {
     }
 
     public BigDecimal getCash() {
-        return money;
+        return cash;
     }
 
-    /**
-     * Gets the player's portfolio of shares.
-     *
-     * @return the portfolio
-     */
     public Portfolio getPortfolio() {
         return portfolio;
     }
 
-    /**
-     * Gets the player's transaction archive.
-     *
-     * @return the transaction archive
-     */
     public TransactionArchive getTransactionArchive() {
         return transactionArchive;
     }
@@ -144,7 +125,7 @@ public class Player {
      */
     public void addMoney(BigDecimal amount) {
         if (amount.compareTo(BigDecimal.ZERO) < 0) throw new IllegalArgumentException("Amount cannot be negative");
-        this.money = this.money.add(amount);
+        this.cash = this.cash.add(amount);
     }
 
     /**
@@ -155,31 +136,31 @@ public class Player {
      */
     public void withdrawMoney(BigDecimal amount) {
         if (amount.compareTo(BigDecimal.ZERO) < 0) throw new IllegalArgumentException("Amount cannot be negative");
-        if (this.money.compareTo(amount) < 0) {
+        if (this.cash.compareTo(amount) < 0) {
             throw new IllegalArgumentException("Cannot withdraw more money than the current balance");
         }
-        this.money = this.money.subtract(amount);
+        this.cash = this.cash.subtract(amount);
     }
 
     /**
      * Returns the player's total net worth in NOK: cash balance plus the market
-     * value of all portfolio positions.
+     * value of all portfolio positions, minus outstanding debt.
      *
      * <p>Market value is {@code salesPrice × quantity} per share, converted to
      * NOK via the given {@link CurrencyConverter}. Sale commission and tax are
      * NOT deducted — this is the gross market value, not a liquidation estimate.
      *
      * @param converter the currency converter used to translate share values to NOK
-     * @return cash plus market value of holdings, in NOK
+     * @return cash plus market value of holdings minus outstanding debt, in NOK
      * @throws NullPointerException if converter is null
      */
     public BigDecimal getNetWorth(CurrencyConverter converter) {
         Objects.requireNonNull(converter, "Converter cannot be null");
-        return money.add(portfolio.getNetWorth(converter)).subtract(getTotalDebt());
+        return cash.add(portfolio.getNetWorth(converter)).subtract(getTotalDebt());
     }
 
     /**
-     * Records the player's current net worth in the history.
+     * Appends the player's current net worth to the history list.
      * Called by {@link edu.ntnu.idatt2003.millions.service.GameService}
      * before advancing the week.
      *
@@ -225,16 +206,16 @@ public class Player {
         this.previousNetWorth = previousNetWorth;
     }
 
-    /**
-     * Returns a defensive copy of the player's active loans.
-     *
-     * @return immutable snapshot of active loans
-     */
     private List<Loan> activeLoansInternal() {
         if (activeLoans == null) activeLoans = new ArrayList<>();
         return activeLoans;
     }
 
+    /**
+     * Returns a defensive copy of the player's active loans.
+     *
+     * @return mutable snapshot of active loans; empty if none have been taken
+     */
     public List<Loan> getActiveLoans() {
         return new ArrayList<>(activeLoansInternal());
     }
@@ -350,14 +331,14 @@ public class Player {
      */
     public void repayLoan(Loan loan, int currentWeek) {
         Objects.requireNonNull(loan, "Loan cannot be null");
-        if (money.compareTo(loan.principal()) < 0) {
+        if (cash.compareTo(loan.principal()) < 0) {
             throw new IllegalArgumentException(
                     "Insufficient funds to repay loan of " + loan.principal() + " NOK");
         }
         if (!activeLoansInternal().remove(loan)) {
             throw new IllegalArgumentException("Loan is not an active loan for this player");
         }
-        money = money.subtract(loan.principal());
+        cash = cash.subtract(loan.principal());
         if (loanLedger == null) loanLedger = new ArrayList<>();
         loanLedger.add(new LoanLedgerEntry(
                 Math.max(currentWeek, 1), loan,
@@ -375,9 +356,8 @@ public class Player {
      * the forced-sale flow that handles shortfalls is tracked separately.</p>
      *
      * @param week the game week in which interest is collected; used for ledger entries
-     * @return the interest amount that could not be paid; zero when fully covered
      */
-    public BigDecimal collectWeeklyInterest(int week) {
+    public void collectWeeklyInterest(int week) {
         List<Loan> loans = activeLoansInternal();
         BigDecimal total = BigDecimal.ZERO;
         if (loanLedger == null) loanLedger = new ArrayList<>();
@@ -390,10 +370,9 @@ public class Player {
                         LoanLedgerEntryType.INTEREST, interest.negate()));
             }
         }
-        if (total.signum() == 0) return BigDecimal.ZERO;
-        BigDecimal paid = total.min(money);
-        money = money.subtract(paid);
-        return total.subtract(paid);
+        if (total.signum() == 0) return;
+        BigDecimal paid = total.min(cash);
+        cash = cash.subtract(paid);
     }
 
     /**
@@ -414,7 +393,7 @@ public class Player {
      * @return true if the player can cover this week's interest without selling shares
      */
     public boolean canCoverInterestThisWeek() {
-        return money.compareTo(getWeeklyInterestDue()) >= 0;
+        return cash.compareTo(getWeeklyInterestDue()) >= 0;
     }
 
     /**
@@ -461,7 +440,7 @@ public class Player {
      * @return true if no forced share sale is required
      */
     public boolean canCoverObligationsThisWeek(int currentWeek) {
-        return money.compareTo(getTotalObligationsThisWeek(currentWeek)) >= 0;
+        return cash.compareTo(getTotalObligationsThisWeek(currentWeek)) >= 0;
     }
 
     /**
@@ -520,7 +499,7 @@ public class Player {
         BigDecimal portfolioLiquidation = portfolio.getShares().stream()
                 .map(s -> SalesCalculator.calculateNetNok(s, converter))
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
-        return money.add(portfolioLiquidation);
+        return cash.add(portfolioLiquidation);
     }
 
     /**
@@ -605,34 +584,68 @@ public class Player {
                 .setScale(1, RoundingMode.HALF_UP);
     }
 
+    /**
+     * Returns an unmodifiable view of the player's notifications, oldest first.
+     *
+     * @return unmodifiable list of notifications; empty if none have been added
+     */
     public List<Notification> getNotifications() {
         if (notifications == null) notifications = new ArrayList<>();
         return Collections.unmodifiableList(notifications);
     }
 
+    /**
+     * Returns the number of notifications the player has not yet read.
+     *
+     * @return count of unread notifications; zero if all have been read or none exist
+     */
     public int getUnreadNotificationCount() {
         if (notifications == null) return 0;
         return (int) notifications.stream().filter(n -> !n.read()).count();
     }
 
+    /**
+     * Returns the debt-threshold flag recorded during the most recent weekly advance.
+     *
+     * @return {@code true} if the player was above the debt threshold when last checked
+     */
     public boolean wasAboveDebtThreshold() {
         return wasAboveDebtThreshold;
     }
 
+    /**
+     * Returns the low-cash flag recorded during the most recent weekly advance.
+     *
+     * @return {@code true} if the player was considered low on cash when last checked
+     */
     public boolean wasLowOnCash() {
         return wasLowOnCash;
     }
 
+    /**
+     * Returns the next notification ID and advances the internal counter.
+     * Each call returns a unique, strictly increasing integer starting at 1.
+     *
+     * @return the next available notification ID
+     */
     public int nextNotificationId() {
         if (nextNotificationId <= 0) nextNotificationId = 1;
         return nextNotificationId++;
     }
 
+    /**
+     * Appends a notification to the player's notification list.
+     *
+     * @param notification the notification to append
+     */
     public void addNotification(Notification notification) {
         if (notifications == null) notifications = new ArrayList<>();
         notifications.add(notification);
     }
 
+    /**
+     * Marks every unread notification as read.
+     */
     public void markAllNotificationsAsRead() {
         if (notifications == null) return;
         for (int i = 0; i < notifications.size(); i++) {
@@ -642,6 +655,9 @@ public class Player {
         }
     }
 
+    /**
+     * Removes all notifications from the player's notification list.
+     */
     public void clearAllNotifications() {
         if (notifications == null) notifications = new ArrayList<>();
         notifications.clear();
@@ -655,6 +671,12 @@ public class Player {
         this.wasLowOnCash = value;
     }
 
+    /**
+     * Returns the player's status level recorded at the end of the previous week.
+     * Returns {@link PlayerStatusLevel#NOVICE} if no status has been recorded yet.
+     *
+     * @return the previously recorded status level; never {@code null}
+     */
     public PlayerStatusLevel getPreviousStatus() {
         return previousStatus == null ? PlayerStatusLevel.NOVICE : previousStatus;
     }
@@ -734,7 +756,7 @@ public class Player {
         }
     }
 
-    /***
+    /**
      * Returns the players current status based on net worth growth and number of weeks with active
      * trading.
      * <ul>

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/player/Player.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/player/Player.java
@@ -349,13 +349,15 @@ public class Player {
      * Deducts one week's interest for every active loan from the player's
      * cash balance and records an INTEREST ledger entry for each loan.
      *
-     * <p>If the balance is insufficient to cover the full amount, the balance
-     * is reduced to zero and the unpaid shortfall is returned so the caller
-     * can trigger forced share sales. The ledger entries always record the
-     * full owed amount regardless of whether the player could cover it;
-     * the forced-sale flow that handles shortfalls is tracked separately.</p>
+     * <p>This method assumes the caller has already verified the player can
+     * cover the obligation — see
+     * {@link #canCoverObligationsThisWeek(int)} and the dispatch logic in
+     * the controller layer. When the player cannot cover obligations from
+     * cash alone, the forced-sale flow runs instead via
+     * {@link edu.ntnu.idatt2003.millions.service.GameService#executeForcedSale}.
      *
-     * @param week the game week in which interest is collected; used for ledger entries
+     * @param week the game week in which interest is collected;
+     *             used for ledger entries
      */
     public void collectWeeklyInterest(int week) {
         List<Loan> loans = activeLoansInternal();

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/player/Player.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/player/Player.java
@@ -114,12 +114,7 @@ public class Player {
         return sessionId;
     }
 
-    /**
-     * Gets the player's current balance.
-     *
-     * @return the current balance
-     */
-    public BigDecimal getMoney() {
+    public BigDecimal getCash() {
         return money;
     }
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/player/PlayerStatusLevel.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/player/PlayerStatusLevel.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.model.player;
 
 /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/player/Portfolio.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/player/Portfolio.java
@@ -60,10 +60,13 @@ public class Portfolio {
     }
 
     /**
-     * Removes a share from the portfolio.
+     * Removes the given Share reference from the portfolio.
+     * Uses reference equality (==), not field equality — see
+     * {@link Share} class documentation for the rationale.
      *
      * @param share the share to remove
-     * @return true if the share was removed, false if it wasn't found
+     * @return true if the share was removed, false if the exact
+     *         reference was not found
      * @throws NullPointerException if the share is null
      */
     public boolean removeShare(Share share) {
@@ -108,10 +111,12 @@ public class Portfolio {
     }
 
     /**
-     * Checks if the portfolio contains a specific share.
+     * Checks if the portfolio contains the given Share reference.
+     * Uses reference equality (==), not field equality — see
+     * {@link Share} class documentation for the rationale.
      *
      * @param share the share to check for
-     * @return true if the share exists in the portfolio
+     * @return true if the exact Share reference exists in the portfolio
      * @throws NullPointerException if the share is null
      */
     public boolean contains(Share share) {

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/player/Portfolio.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/player/Portfolio.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.model.player;
 
 import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
@@ -9,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Currency;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * Represents a portfolio that holds a player's share holdings.
@@ -70,36 +72,33 @@ public class Portfolio {
     }
 
     /**
-     * Gets all shares in the portfolio.
+     * Returns a defensive copy of all share positions in the portfolio.
      *
-     * @return a list of all shares
+     * @return mutable copy of all shares; empty if the portfolio has no holdings
      */
     public List<Share> getShares() {
         return new ArrayList<>(shares);
     }
 
     /**
-     * Gets all shares of a specific stock by symbol.
-     * Returns an empty list if {@code symbol} is null or no shares match.
+     * Returns all shares matching the given stock symbol.
      *
-     * @param symbol the stock symbol to filter by; null returns an empty list
-     * @return a list of shares whose stock symbol equals {@code symbol}, never null
+     * @param symbol the stock symbol to filter by; {@code null} returns an empty list
+     * @return mutable defensive copy of matching shares; empty if {@code symbol} is null or no shares match
      */
     public List<Share> getShares(String symbol) {
         if (symbol == null) return List.of();
 
         return shares.stream()
                 .filter(share -> Objects.equals(share.getStock().getSymbol(), symbol))
-                .toList();
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 
     /**
-     * Replaces all shares in the portfolio with the given list of shares.
-     * Used after deserialization in JsonGameFileHandler to relink shares to the correct
-     * stock references from the exchange.
+     * Replaces all current share positions with the given list.
      *
-     * @param shares the new list of shares to set
-     * @throws NullPointerException if the list or any share in the list is null
+     * @param shares the new list of shares; must not be null, and must contain no null elements
+     * @throws NullPointerException if the list or any element in the list is null
      */
     public void setShares(List<Share> shares) {
         Objects.requireNonNull(shares, "Shares cannot be null");
@@ -121,17 +120,11 @@ public class Portfolio {
     }
 
     /**
-     * Returns the total market value of the portfolio in NOK.
+     * Returns the gross market value of all positions in the portfolio, converted to NOK.
+     * Sale commission and tax are not deducted.
      *
-     * <p>For each share, the current market value ({@link edu.ntnu.idatt2003.millions.model.stock.Share#getCurrentValue()},
-     * i.e. {@code salesPrice × quantity}) is converted to NOK via the given
-     * {@link CurrencyConverter}. The converted values are summed.
-     * Sale commission and tax are NOT deducted — those are transaction-level
-     * concerns handled by {@link edu.ntnu.idatt2003.millions.model.calculator.SalesCalculator}
-     * at the point of sale.
-     *
-     * @param converter the currency converter used to translate each share's market value to NOK
-     * @return the total market value of all positions in NOK
+     * @param converter the currency converter used to translate each position's market value to NOK
+     * @return the total gross market value of all positions in NOK
      * @throws NullPointerException if converter is null
      */
     public BigDecimal getNetWorth(CurrencyConverter converter) {
@@ -140,30 +133,6 @@ public class Portfolio {
         return shares.stream()
                 .map(share -> converter.convert(
                         share.getCurrentValue(), share.getStock().getCurrency(), nok))
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
-    }
-
-    /**
-     * Returns the total current market value of all positions in the portfolio
-     * in each stock's native currency. Only meaningful for single-currency portfolios.
-     *
-     * @return sum of {@link Share#getCurrentValue()} for all shares
-     */
-    public BigDecimal getTotalValueNative() {
-        return shares.stream()
-                .map(Share::getCurrentValue)
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
-    }
-
-    /**
-     * Returns the total absolute return across all positions in each stock's
-     * native currency. Only meaningful for single-currency portfolios.
-     *
-     * @return sum of {@link Share#getReturnNative()} for all shares
-     */
-    public BigDecimal getTotalReturnNative() {
-        return shares.stream()
-                .map(Share::getReturnNative)
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
     }
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/stock/Share.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/stock/Share.java
@@ -14,6 +14,11 @@ import java.util.Objects;
  * {@link edu.ntnu.idatt2003.millions.model.player.Portfolio} into a single Share
  * whose {@code purchasePrice} is the weighted-average of all individual purchase
  * prices (GAV = total cost / total quantity).
+ *
+ * <p>Identity is based on object reference; two Share instances with identical
+ * fields are not considered equal. Portfolio relies on this for
+ * {@code contains()} and {@code removeShare()}.
+ * <p>
  * Shares are held in a player's portfolio and can be sold on an exchange.
  */
 // Not a record: Stock is mutable (prices grow over time), so Share cannot carry value-type semantics.

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/stock/Share.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/stock/Share.java
@@ -36,14 +36,14 @@ public class Share {
      * @param quantity      the number of shares purchased
      * @param purchasePrice the price per share at time of purchase
      * @throws NullPointerException     if the stock, quantity, or purchase price is null
-     * @throws IllegalArgumentException if the quantity is negative
+     * @throws IllegalArgumentException if the quantity is not greater than zero
      * @throws IllegalArgumentException if the purchase price is negative
      */
     public Share(Stock stock, BigDecimal quantity, BigDecimal purchasePrice) {
         Objects.requireNonNull(stock, "Stock cannot be null");
         Objects.requireNonNull(quantity, "Quantity cannot be null");
         Objects.requireNonNull(purchasePrice, "Purchase price cannot be null");
-        if (quantity.compareTo(BigDecimal.ZERO) < 0) throw new IllegalArgumentException("Quantity cannot be negative");
+        if (quantity.compareTo(BigDecimal.ZERO) <= 0) throw new IllegalArgumentException("Quantity must be positive");
         if (purchasePrice.compareTo(BigDecimal.ZERO) < 0)
             throw new IllegalArgumentException("Purchase price cannot be negative");
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/stock/Share.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/stock/Share.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.model.stock;
 
 import edu.ntnu.idatt2003.millions.model.calculator.SalesCalculator;
@@ -15,6 +16,9 @@ import java.util.Objects;
  * prices (GAV = total cost / total quantity).
  * Shares are held in a player's portfolio and can be sold on an exchange.
  */
+// Not a record: Stock is mutable (prices grow over time), so Share cannot carry value-type semantics.
+// Portfolio also relies on reference equality for contains() / remove().
+@SuppressWarnings("ClassCanBeRecord")
 public class Share {
     private final Stock stock;
     private final BigDecimal quantity;
@@ -43,26 +47,16 @@ public class Share {
         this.purchasePrice = purchasePrice;
     }
 
-    /**
-     * Gets the stock associated with this share.
-     *
-     * @return the stock
-     */
     public Stock getStock() {
         return stock;
     }
 
-    /**
-     * Gets the quantity of shares held.
-     *
-     * @return the number of shares
-     */
     public BigDecimal getQuantity() {
         return quantity;
     }
 
     /**
-     * Gets the weighted-average purchase price (GAV) per share.
+     * Returns the weighted-average purchase price (GAV) per share.
      * For a position consolidated from multiple purchases this is the
      * weighted-average of all individual purchase prices; for a single
      * purchase it equals the original price paid.
@@ -140,8 +134,6 @@ public class Share {
     /**
      * Returns the net amount the player would receive if the entire position
      * were sold at the current price, after commission and tax.
-     * Delegates to {@link SalesCalculator} so the business rules for fees
-     * remain in the domain model.
      *
      * @return liquidation value in the stock's native currency
      */

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/stock/Stock.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/stock/Stock.java
@@ -51,7 +51,7 @@ public class Stock {
 
         this.symbol = symbol;
         this.company = company;
-        this.prices = prices;
+        this.prices = new ArrayList<>(prices);
         this.currency = currency;
     }
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/stock/Stock.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/stock/Stock.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.model.stock;
 
 import java.math.BigDecimal;
@@ -11,6 +12,8 @@ import java.util.Objects;
  * A stock has a trading symbol, company name, and price history.
  * Stocks are traded through purchases and sales, with players acquiring shares in them.
  */
+// Not a record: addNewSalesPrice() mutates the internal price list — fundamental mutable state.
+@SuppressWarnings("ClassCanBeRecord")
 public class Stock {
     private final String symbol;
     private final String company;
@@ -69,39 +72,23 @@ public class Stock {
         this(symbol, company, prices, Currency.getInstance("USD"));
     }
 
-    /**
-     * Gets the stock's trading symbol.
-     *
-     * @return the trading symbol
-     */
     public String getSymbol() {
         return symbol;
     }
 
-    /**
-     * Gets the company name.
-     *
-     * @return the company name
-     */
     public String getCompany() {
         return company;
     }
 
     /**
-     * Gets the current sales price (most recent price in history).
+     * Returns the current sales price (most recent price in history).
      *
      * @return the latest price
      */
-
     public BigDecimal getSalesPrice() {
         return prices.getLast();
     }
 
-    /**
-     * Returns the currency the stock is traded in.
-     *
-     * @return the currency
-     */
     public Currency getCurrency() {
         return currency;
     }
@@ -122,17 +109,16 @@ public class Stock {
     }
 
     /**
-     * Returns a list of all registered prices for this Stock.
-     * The list includes every price that has ever been recorded from the initial price to the most recent.
+     * Returns a mutable defensive copy of all historical prices, from the initial price to the most recent.
      *
-     * @return an unmodifiable list of all historical prices.
+     * @return mutable copy of all recorded prices, oldest first
      */
     public List<BigDecimal> getHistoricalPrices() {
         return new ArrayList<>(prices);
     }
 
     /**
-     * Returns the highest price registered for this stock
+     * Returns the highest price registered for this stock.
      *
      * @return the highest recorded price
      */
@@ -143,9 +129,9 @@ public class Stock {
     }
 
     /**
-     * Returns the lowest price recorded for this stock
+     * Returns the lowest price recorded for this stock.
      *
-     * @return the lowest price recorded
+     * @return the lowest recorded price
      */
     public BigDecimal getLowestPrice() {
         return prices.stream()
@@ -155,8 +141,7 @@ public class Stock {
 
     /**
      * Returns the price change between the two most recent registered prices.
-     * If only one price has been registered will this method interpreted as no change and
-     * {@link BigDecimal#ZERO} is returned.
+     * Returns zero if only one price has been registered.
      *
      * @return the difference between the latest and second-to-latest price or zero
      * if only one price exists.

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/stock/Stock.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/stock/Stock.java
@@ -176,12 +176,12 @@ public class Stock {
      * If fewer entries exist than requested, all prices are returned.
      *
      * @param weeks the maximum number of recent prices to return
-     * @return a list of the most recent prices, oldest first
+     * @return mutable defensive copy of the most recent prices, oldest first
      * @throws IllegalArgumentException if weeks is not greater than zero
      */
     public List<BigDecimal> getRecentPrices(int weeks) {
         if (weeks <= 0) throw new IllegalArgumentException("weeks must be greater than zero");
-        return prices.subList(Math.max(0, prices.size() - weeks), prices.size());
+        return new ArrayList<>(prices.subList(Math.max(0, prices.size() - weeks), prices.size()));
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/Purchase.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/Purchase.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.model.transaction;
 
 import edu.ntnu.idatt2003.millions.model.calculator.PurchaseCalculator;
@@ -9,16 +10,15 @@ import java.util.Objects;
 
 /**
  * Represents a purchase transaction for a given share.
- * A purchase records the share bought and the week it was acquired,
- * uses a {@link PurchaseCalculator} to calculate the share cost, and owns
- * the balance withdrawal when the transaction is committed for a {@link Player}.
+ * When committed, withdraws the total cost from the player's balance in NOK
+ * and adds the share to the player's portfolio.
  */
 public class Purchase extends Transaction {
     private final BigDecimal settlementAmount;
 
     /**
      * Constructs a new Purchase for the specified share and week.
-     * The settlement amount defaults to the total calculated by {@link PurchaseCalculator}.
+     * The settlement amount defaults to the total cost of the acquired share.
      *
      * @param share the share being purchased
      * @param week  the week in which the purchase takes place
@@ -40,6 +40,7 @@ public class Purchase extends Transaction {
      * @throws NullPointerException     if the settlement amount is null
      * @throws IllegalArgumentException if the settlement amount is negative
      */
+    @SuppressWarnings("java:S8433") // validation after super() is safe; super has no side effects beyond field assignment
     public Purchase(Share share, int week, BigDecimal settlementAmount) {
         super(share, week, new PurchaseCalculator(share));
         Objects.requireNonNull(settlementAmount, "Settlement amount cannot be null");
@@ -54,11 +55,13 @@ public class Purchase extends Transaction {
         return new PurchaseCalculator(getShare()).calculateCommission();
     }
 
+    /** Purchases are not taxed; always returns zero. */
     @Override
     public BigDecimal getTaxNative() {
         return BigDecimal.ZERO;
     }
 
+    /** Returns the total cost as a negative value — a cash outflow from the buyer's perspective. */
     @Override
     public BigDecimal getSignedTotalNative() {
         return new PurchaseCalculator(getShare()).calculateTotal().negate();

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/Sale.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/Sale.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.model.transaction;
 
 import edu.ntnu.idatt2003.millions.model.calculator.SalesCalculator;
@@ -17,10 +18,6 @@ import java.util.Objects;
  * realized financial values in the transaction archive reflect the price at
  * sale time, not the current price.
  *
- * <p>Note: {@link #getShare()}{@code .getStock().getSalesPrice()} still returns
- * the current stock price, not the sale-time price. The frozen fields on Sale
- * cover all current uses. If a future feature requires the sale-time stock price
- * as a separate piece of data, add a {@code salesPriceAtCommit} field at that point.
  */
 public class Sale extends Transaction {
 
@@ -35,8 +32,6 @@ public class Sale extends Transaction {
 
     /**
      * Constructs a new Sale for the specified share and week.
-     * All financial values are captured immediately from the current stock price
-     * and remain fixed for the lifetime of this object.
      *
      * @param share the share being sold
      * @param week  the week in which the sale takes place
@@ -75,7 +70,7 @@ public class Sale extends Transaction {
     /**
      * Commits this sale for the given player.
      * Removes the share from the player's portfolio and records the transaction
-     * in the archive. Financial values are already frozen from construction.
+     * in the archive.
      *
      * @param player the player executing the sale
      * @throws NullPointerException  if the player is null

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/Sale.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/Sale.java
@@ -81,7 +81,7 @@ public class Sale extends Transaction {
     public void commit(Player player) {
         Objects.requireNonNull(player, "Player cannot be null");
         if (isCommitted()) throw new IllegalStateException("Sale is already committed");
-        if (!player.getPortfolio().contains(getShare())) throw new IllegalStateException("Sale is not in portfolio");
+        if (!player.getPortfolio().contains(getShare())) throw new IllegalStateException("Share is not in portfolio");
 
         player.getPortfolio().removeShare(getShare());
         player.getTransactionArchive().add(this);
@@ -91,21 +91,6 @@ public class Sale extends Transaction {
     /** Returns the gross sale value (sales price × quantity) in native currency. */
     public BigDecimal getGross() {
         return gross;
-    }
-
-    /** Returns the commission paid on this sale (1% of gross) in native currency. */
-    public BigDecimal getCommission() {
-        return commission;
-    }
-
-    /** Returns the tax paid on this sale (30% of profit, or zero if a loss) in native currency. */
-    public BigDecimal getTax() {
-        return tax;
-    }
-
-    /** Returns the net payout of this sale (gross − commission − tax) in native currency. */
-    public BigDecimal getTotal() {
-        return total;
     }
 
     /** Returns the realized profit or loss on this sale (total − original purchase costs) in native currency. */

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/Transaction.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/Transaction.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.model.transaction;
 
 import edu.ntnu.idatt2003.millions.model.calculator.TransactionCalculator;
@@ -9,8 +10,6 @@ import java.util.Objects;
 
 /**
  * Represents an abstract financial transaction involving a share.
- * A transaction records the share, the week it takes place, and the calculator
- * used to process it. Subclasses must implement {@link #commit(Player)}.
  */
 public abstract class Transaction {
     private Share share;
@@ -40,11 +39,6 @@ public abstract class Transaction {
         this.committed = false;
     }
 
-    /**
-     * Gets the share involved in this transaction.
-     *
-     * @return the share
-     */
     public Share getShare() {
         return share;
     }
@@ -62,11 +56,6 @@ public abstract class Transaction {
         this.share = newShare;
     }
 
-    /**
-     * Gets the week in which this transaction takes place.
-     *
-     * @return the week number
-     */
     public int getWeek() {
         return week;
     }
@@ -99,7 +88,7 @@ public abstract class Transaction {
     }
 
     /**
-     * Marks this transactionn as committed.
+     * Marks this transaction as committed.
      */
     protected void markAsCommitted() {
         this.committed = true;
@@ -114,7 +103,6 @@ public abstract class Transaction {
 
     /**
      * Returns the tax paid on this transaction in the stock's native currency.
-     * Always zero for purchases.
      *
      * @return tax amount in native currency
      */
@@ -138,7 +126,6 @@ public abstract class Transaction {
 
     /**
      * Commits this transaction for the given player.
-     * Must be implemented by subclasses.
      *
      * @param player the player executing the transaction
      */

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/TransactionArchive.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/TransactionArchive.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.model.transaction;
 
 import java.math.BigDecimal;
@@ -5,8 +6,7 @@ import java.util.*;
 
 /**
  * Represents an archive of transactions.
- * The archive stores the transactions added and provides methods for retrieving
- * transactions by week, type ({@link Purchase} or {@link Sale}), and counting distinct weeks of activity.
+ * Provides retrieval by week, by type ({@link Purchase} or {@link Sale}), and counting of distinct weeks of activity.
  */
 public class TransactionArchive {
     private final List<Transaction> transactions;
@@ -35,7 +35,7 @@ public class TransactionArchive {
     }
 
     /**
-     * Returns whether the archive contains transactions or not.
+     * Returns whether the archive contains no transactions.
      *
      * @return {@code true} if the archive is empty, {@code false} otherwise
      */
@@ -45,7 +45,6 @@ public class TransactionArchive {
 
     /**
      * Returns all transactions in the archive regardless of week.
-     * Used by the file handler to iterate every archived transaction during relinking.
      *
      * @return a defensive copy of all transactions
      */
@@ -224,11 +223,6 @@ public class TransactionArchive {
                 .count();
     }
 
-    /**
-     * Aggregates per-sale profit values into a sum per currency, applying the
-     * given filter and mapping function. The mapping function is used to convert
-     * the profit value (e.g. take the absolute value for losses).
-     */
     private Map<Currency, BigDecimal> sumSalesByCurrency(
             java.util.function.Predicate<BigDecimal> filter,
             java.util.function.UnaryOperator<BigDecimal> mapper) {
@@ -242,11 +236,6 @@ public class TransactionArchive {
         return result;
     }
 
-    /**
-     * Aggregates a per-sale attribute (e.g. commission, tax) into a sum per
-     * currency. Used by {@link #getTotalSaleCommissionByCurrency()} and
-     * {@link #getTotalSaleTaxByCurrency()}.
-     */
     private Map<Currency, BigDecimal> sumSalesAttribute(
             java.util.function.Function<Sale, BigDecimal> extractor) {
         return getAllSales().stream()

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/TransactionArchive.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/TransactionArchive.java
@@ -187,7 +187,7 @@ public class TransactionArchive {
      * @return commission totals per currency; empty map if no sales exist
      */
     public Map<Currency, BigDecimal> getTotalSaleCommissionByCurrency() {
-        return sumSalesAttribute(Sale::getCommission);
+        return sumSalesAttribute(Sale::getCommissionNative);
     }
 
     /**
@@ -197,7 +197,7 @@ public class TransactionArchive {
      * @return tax totals per currency; empty map if no sales exist
      */
     public Map<Currency, BigDecimal> getTotalSaleTaxByCurrency() {
-        return sumSalesAttribute(Sale::getTax);
+        return sumSalesAttribute(Sale::getTaxNative);
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/TransactionPreview.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/transaction/TransactionPreview.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.model.transaction;
 
 import edu.ntnu.idatt2003.millions.service.TransactionPreviewService;
@@ -8,15 +9,24 @@ import java.math.BigDecimal;
  * Immutable value object representing the computed values for a
  * hypothetical transaction (a "what would happen if..." preview).
  *
- * <p>Produced by {@link TransactionPreviewService} and consumed by
- * the view layer to display gross, commission, tax, total, and the
- * resulting balance without performing the transaction.</p>
+ * <p>Produced by {@link TransactionPreviewService}; consumed by the view layer
+ * to show a preview without performing the transaction.</p>
  *
  * <p>For purchases, {@code tax} is zero and {@code profit},
  * {@code profitPercent}, and {@code profitInNok} are null. For sales,
  * {@code profit} contains the gain or loss in the stock's native
  * currency, and {@code profitInNok} contains the same value converted
  * to NOK (null when the stock is already priced in NOK).</p>
+ *
+ * @param gross          gross transaction value in the stock's native currency
+ * @param commission     commission charged on the transaction in native currency
+ * @param tax            tax on realized profit in native currency; zero for purchases
+ * @param total          net amount paid or received in native currency
+ * @param totalInNok     total converted to NOK; null when native currency is already NOK
+ * @param balanceAfter   projected player balance after the transaction in NOK
+ * @param profit         realized gain or loss in native currency; null for purchases
+ * @param profitPercent  profit as a fraction of original purchase cost; null for purchases
+ * @param profitInNok    profit converted to NOK; null for purchases or when native currency is already NOK
  */
 public record TransactionPreview(
         BigDecimal gross,

--- a/src/main/java/edu/ntnu/idatt2003/millions/model/watchlist/WatchlistEntry.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/model/watchlist/WatchlistEntry.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.model.watchlist;
 
 import java.util.Objects;
@@ -6,9 +7,8 @@ import java.util.Objects;
  * Represents a single entry in the player's watchlist.
  *
  * <p>Each entry is identified by a stock {@link #symbol}, records which
- * game week it was added and carries an optional
- * free-text. The record is immutable; use to produce an updated copy when the player edits
- * the note.</p>
+ * game week it was added, and carries an optional free-text note.
+ * Use {@link #withNote(String)} to produce an updated copy when the player edits the note.</p>
  *
  * <p>Instances are serialised transparently by Gson as part of the player
  * state in the game save file.</p>
@@ -16,8 +16,6 @@ import java.util.Objects;
 public record WatchlistEntry(String symbol, int addedAtWeek, String note) {
 
     /**
-     * Compact constructor that validates all fields.
-     *
      * @param symbol      the stock ticker symbol; must not be null or blank
      * @param addedAtWeek the game week in which this entry was added; must be &gt;= 1
      * @param note        an optional free-text note; {@code null} is normalised to {@code ""}

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/TransactionPreviewService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/TransactionPreviewService.java
@@ -46,7 +46,7 @@ public class TransactionPreviewService {
         BigDecimal tax = calc.calculateTax();
         BigDecimal total = calc.calculateTotal();
         BigDecimal totalInNok = converter.convert(total, stock.getCurrency(), NOK);
-        BigDecimal balanceAfter = player.getMoney().subtract(totalInNok);
+        BigDecimal balanceAfter = player.getCash().subtract(totalInNok);
 
         return new TransactionPreview(
                 gross, commission, tax, total, totalInNok, balanceAfter, null, null, null);
@@ -82,7 +82,7 @@ public class TransactionPreviewService {
         BigDecimal tax = calc.calculateTax();
         BigDecimal total = calc.calculateTotal();
         BigDecimal totalInNok = converter.convert(total, share.getStock().getCurrency(), NOK);
-        BigDecimal balanceAfter = player.getMoney().add(totalInNok);
+        BigDecimal balanceAfter = player.getCash().add(totalInNok);
 
         BigDecimal profit = calc.calculateProfit();
         BigDecimal profitPercent = calc.calculateProfitPercent();

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/notification/NotificationService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/notification/NotificationService.java
@@ -109,10 +109,10 @@ public class NotificationService {
             return;
         }
 
-        boolean isLow = player.getMoney().compareTo(nextObligation) < 0;
+        boolean isLow = player.getCash().compareTo(nextObligation) < 0;
 
         if (isLow && !player.wasLowOnCash()) {
-            BigDecimal shortfall = nextObligation.subtract(player.getMoney());
+            BigDecimal shortfall = nextObligation.subtract(player.getCash());
             push(player, Severity.WARNING,
                     "notification.lowCash.title",
                     "notification.lowCash.body",

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/StatusFooter.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/StatusFooter.java
@@ -129,7 +129,7 @@ public class StatusFooter extends HBox implements GameObserver {
 
         playerValue.setText(player.getName());
         equityValue.setText(CurrencyFormatter.format(statsService.getNetWorth(player, converter)));
-        availableValue.setText(CurrencyFormatter.format(player.getMoney()));
+        availableValue.setText(CurrencyFormatter.format(player.getCash()));
 
         PlayerStatusLevel status = statsService.getStatus(player, converter);
         double progress = statsService.getProgressToNextStatus(player, converter);

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/card/AvailableFundsCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/card/AvailableFundsCard.java
@@ -32,7 +32,7 @@ public class AvailableFundsCard extends SimpleWidgetCard {
     public AvailableFundsCard(GameService gameService, String titleKey, String subtitleKey) {
         super(gameService,
                 titleKey,
-                () -> CurrencyFormatter.format(gameService.getPlayer().getMoney()),
+                () -> CurrencyFormatter.format(gameService.getPlayer().getCash()),
                 subtitleKey != null ? () -> LanguageManager.get(subtitleKey) : null);
     }
 }

--- a/src/test/java/edu/ntnu/idatt2003/millions/file/game/JsonGameFileHandlerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/file/game/JsonGameFileHandlerTest.java
@@ -180,7 +180,7 @@ class JsonGameFileHandlerTest {
             GameState state = handler.loadGame(file.toFile());
             // Assert
             assertEquals(0, new BigDecimal("10000.00")
-                    .compareTo(state.player().getMoney()));
+                    .compareTo(state.player().getCash()));
         }
 
         @Test

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/calculator/PurchaseCalculatorTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/calculator/PurchaseCalculatorTest.java
@@ -70,17 +70,6 @@ class PurchaseCalculatorTest {
             assertBigDecimalEquals(expected, calculated);
         }
 
-        @Test
-        @DisplayName("Should return zero when quantity is zero")
-        void returnsZeroWhenQuantityIsZero() {
-            // Arrange
-            Share zeroShare = new Share(
-                    new Stock("DCL", "Dara Inc", new ArrayList<>(List.of(new BigDecimal("70")))),
-                    new BigDecimal("0"), new BigDecimal("30"));
-            PurchaseCalculator zeroCalculator = new PurchaseCalculator(zeroShare);
-            // Act & Assert
-            assertBigDecimalEquals(BigDecimal.ZERO, zeroCalculator.calculateGross());
-        }
     }
 
     @Nested
@@ -129,16 +118,5 @@ class PurchaseCalculatorTest {
             assertBigDecimalEquals(expected, calculated);
         }
 
-        @Test
-        @DisplayName("Should return zero when quantity is zero")
-        void returnsZeroWhenQuantityIsZero() {
-            // Arrange
-            Share zeroShare = new Share(
-                    new Stock("DCL", "Dara Inc", new ArrayList<>(List.of(new BigDecimal("70")))),
-                    new BigDecimal("0"), new BigDecimal("30"));
-            PurchaseCalculator zeroCalculator = new PurchaseCalculator(zeroShare);
-            // Act & Assert
-            assertBigDecimalEquals(BigDecimal.ZERO, zeroCalculator.calculateTotal());
-        }
     }
 }

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/calculator/SalesCalculatorTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/calculator/SalesCalculatorTest.java
@@ -70,17 +70,6 @@ class SalesCalculatorTest {
             assertBigDecimalEquals(expected, calculated);
         }
 
-        @Test
-        @DisplayName("Should return zero when quantity is zero")
-        void returnsZeroWhenQuantityIsZero() {
-            // Arrange
-            Share zeroShare = new Share(
-                    new Stock("DCL", "Dara Inc", new ArrayList<>(List.of(new BigDecimal("100")))),
-                    new BigDecimal("0"), new BigDecimal("30"));
-            SalesCalculator zeroCalculator = new SalesCalculator(zeroShare);
-            // Act & Assert
-            assertBigDecimalEquals(BigDecimal.ZERO, zeroCalculator.calculateGross());
-        }
     }
 
     @Nested
@@ -132,17 +121,6 @@ class SalesCalculatorTest {
             assertBigDecimalEquals(BigDecimal.ZERO, lossCalculator.calculateTax());
         }
 
-        @Test
-        @DisplayName("Should return zero when quantity is zero")
-        void returnsZeroWhenQuantityIsZero() {
-            // Arrange
-            Share zeroShare = new Share(
-                    new Stock("DCL", "Dara Inc", new ArrayList<>(List.of(new BigDecimal("100")))),
-                    new BigDecimal("0"), new BigDecimal("30"));
-            SalesCalculator zeroCalculator = new SalesCalculator(zeroShare);
-            // Act & Assert
-            assertBigDecimalEquals(BigDecimal.ZERO, zeroCalculator.calculateTax());
-        }
     }
 
     @Nested
@@ -166,16 +144,5 @@ class SalesCalculatorTest {
             assertBigDecimalEquals(expected, calculated);
         }
 
-        @Test
-        @DisplayName("Should return zero when quantity is zero")
-        void returnsZeroWhenQuantityIsZero() {
-            // Arrange
-            Share zeroShare = new Share(
-                    new Stock("DCL", "Dara Inc", new ArrayList<>(List.of(new BigDecimal("100")))),
-                    new BigDecimal("0"), new BigDecimal("30"));
-            SalesCalculator zeroCalculator = new SalesCalculator(zeroShare);
-            // Act & Assert
-            assertBigDecimalEquals(BigDecimal.ZERO, zeroCalculator.calculateTotal());
-        }
     }
 }

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/exchange/ExchangeTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/exchange/ExchangeTest.java
@@ -294,11 +294,11 @@ class ExchangeTest {
         @DisplayName("Should deduct cost from player balance after buy")
         void deductsCostFromBalance() {
             // Arrange
-            BigDecimal balanceBefore = player.getMoney();
+            BigDecimal balanceBefore = player.getCash();
             // Act
             exchange.buy("DIS", new BigDecimal("5"), player);
             // Assert
-            assertTrue(player.getMoney().compareTo(balanceBefore) < 0);
+            assertTrue(player.getCash().compareTo(balanceBefore) < 0);
         }
 
         @Test
@@ -394,11 +394,11 @@ class ExchangeTest {
         @DisplayName("Should add payout to player balance after sell")
         void addsPayoutToBalance() {
             // Arrange
-            BigDecimal balanceBefore = player.getMoney();
+            BigDecimal balanceBefore = player.getCash();
             // Act
             exchange.sell(share, player);
             // Assert
-            assertTrue(player.getMoney().compareTo(balanceBefore) > 0);
+            assertTrue(player.getCash().compareTo(balanceBefore) > 0);
         }
 
         @Test

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/player/PlayerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/player/PlayerTest.java
@@ -90,7 +90,7 @@ class PlayerTest {
         @DisplayName("Should set current balance equal to starting money")
         void setsMoneyEqualToStartingMoney() {
             // Act
-            BigDecimal money = player.getMoney();
+            BigDecimal money = player.getCash();
             // Assert
             assertEquals(new BigDecimal("1000.00"), money);
         }
@@ -170,7 +170,7 @@ class PlayerTest {
             // Act
             player.addMoney(amount);
             // Assert
-            assertEquals(new BigDecimal("1500.00"), player.getMoney());
+            assertEquals(new BigDecimal("1500.00"), player.getCash());
         }
 
         @Test
@@ -196,7 +196,7 @@ class PlayerTest {
             // Act
             player.withdrawMoney(amount);
             // Assert
-            assertEquals(new BigDecimal("500.00"), player.getMoney());
+            assertEquals(new BigDecimal("500.00"), player.getCash());
         }
 
         @Test
@@ -205,7 +205,7 @@ class PlayerTest {
             // Act
             player.withdrawMoney(new BigDecimal("1000.00"));
             // Assert
-            assertEquals(0, BigDecimal.ZERO.compareTo(player.getMoney()));
+            assertEquals(0, BigDecimal.ZERO.compareTo(player.getCash()));
         }
 
         @Test
@@ -237,7 +237,7 @@ class PlayerTest {
         @DisplayName("Should return balance only when portfolio is empty")
         void returnsMoneyWhenPortfolioIsEmpty() {
             // Act & Assert
-            assertEquals(0, player.getMoney().compareTo(player.getNetWorth(converter)));
+            assertEquals(0, player.getCash().compareTo(player.getNetWorth(converter)));
         }
 
         @Test
@@ -247,7 +247,7 @@ class PlayerTest {
             Share share = new Share(nokStock("DCL", "Dara, Inc", new BigDecimal("1000.00")),
                     new BigDecimal("10"), new BigDecimal("700.00"));
             player.getPortfolio().addShare(share);
-            BigDecimal expected = player.getMoney()
+            BigDecimal expected = player.getCash()
                     .add(player.getPortfolio().getNetWorth(converter));
             // Act & Assert
             assertEquals(0, expected.compareTo(player.getNetWorth(converter)));
@@ -258,7 +258,7 @@ class PlayerTest {
         void returnsCorrectNetWorthAfterMoneyIsWithdrawn() {
             // Arrange
             player.withdrawMoney(new BigDecimal("500.00"));
-            BigDecimal expected = player.getMoney()
+            BigDecimal expected = player.getCash()
                     .add(player.getPortfolio().getNetWorth(converter));
             // Act & Assert
             assertEquals(0, expected.compareTo(player.getNetWorth(converter)));
@@ -273,7 +273,7 @@ class PlayerTest {
             player.getPortfolio().addShare(share);
             player.getPortfolio().removeShare(share);
             // Act & Assert
-            assertEquals(0, player.getMoney().compareTo(player.getNetWorth(converter)));
+            assertEquals(0, player.getCash().compareTo(player.getNetWorth(converter)));
         }
 
         @Test
@@ -286,7 +286,7 @@ class PlayerTest {
             // Act
             BigDecimal result = player.getNetWorth(converter);
             // Assert
-            assertTrue(result.compareTo(player.getMoney()) >= 0);
+            assertTrue(result.compareTo(player.getCash()) >= 0);
         }
 
         @Test
@@ -298,7 +298,7 @@ class PlayerTest {
                             new ArrayList<>(List.of(new BigDecimal("100.00"))), USD),
                     new BigDecimal("5"), new BigDecimal("50.00"));
             player.getPortfolio().addShare(usdShare);
-            BigDecimal expected = player.getMoney()
+            BigDecimal expected = player.getCash()
                     .add(player.getPortfolio().getNetWorth(converter));
             // Act
             BigDecimal actual = player.getNetWorth(converter);
@@ -749,12 +749,12 @@ class PlayerTest {
         @DisplayName("takeLoan() increases player money by the principal")
         void takeLoanIncreasesMoney() throws ExcessiveDebtException {
             // Arrange
-            BigDecimal before = player.getMoney();
+            BigDecimal before = player.getCash();
             BigDecimal principal = new BigDecimal("300.00");
             // Act
             player.takeLoan(new Loan(offer, principal, 0), converter);
             // Assert
-            assertEquals(0, before.add(principal).compareTo(player.getMoney()));
+            assertEquals(0, before.add(principal).compareTo(player.getCash()));
         }
 
         @Test
@@ -788,13 +788,13 @@ class PlayerTest {
         @DisplayName("takeLoan() does not modify money or active loans when it throws")
         void takeLoanIsAtomic() {
             // Arrange
-            BigDecimal moneyBefore = player.getMoney();
+            BigDecimal moneyBefore = player.getCash();
             int loanCountBefore = player.getActiveLoans().size();
             // Act — request 600 > capacity 500 → throws
             assertThrows(ExcessiveDebtException.class, () ->
                     player.takeLoan(new Loan(offer, new BigDecimal("600.00"), 0), converter));
             // Assert — state unchanged
-            assertEquals(0, moneyBefore.compareTo(player.getMoney()));
+            assertEquals(0, moneyBefore.compareTo(player.getCash()));
             assertEquals(loanCountBefore, player.getActiveLoans().size());
         }
 
@@ -816,11 +816,11 @@ class PlayerTest {
             // Arrange
             Loan loan = new Loan(offer, new BigDecimal("200.00"), 0);
             player.takeLoan(loan, converter); // money: 1000 + 200 = 1200
-            BigDecimal moneyAfterTake = player.getMoney();
+            BigDecimal moneyAfterTake = player.getCash();
             // Act
             player.repayLoan(loan, 1); // money: 1200 - 200 = 1000
             // Assert
-            assertEquals(0, moneyAfterTake.subtract(new BigDecimal("200.00")).compareTo(player.getMoney()));
+            assertEquals(0, moneyAfterTake.subtract(new BigDecimal("200.00")).compareTo(player.getCash()));
         }
 
         @Test
@@ -1066,7 +1066,7 @@ class PlayerTest {
             // Act
             BigDecimal result = player.getTotalLiquidationValue(converter);
             // Assert
-            assertEquals(0, player.getMoney().compareTo(result));
+            assertEquals(0, player.getCash().compareTo(result));
         }
 
         @Test
@@ -1077,7 +1077,7 @@ class PlayerTest {
             Share share = new Share(stock, new BigDecimal("2"), new BigDecimal("100.00"));
             player.getPortfolio().addShare(share);
             BigDecimal expectedNet = SalesCalculator.calculateNetNok(share, converter);
-            BigDecimal expected = player.getMoney().add(expectedNet);
+            BigDecimal expected = player.getCash().add(expectedNet);
             // Act
             BigDecimal result = player.getTotalLiquidationValue(converter);
             // Assert
@@ -1093,7 +1093,7 @@ class PlayerTest {
             player.takeLoan(new Loan(highRisk, new BigDecimal("500.00"), 1), converter);
             // obligations at week 2 = interest 25 + principal 500 = 525
             // player has 1500 cash → can cover from cash; drain to 0 to force game-over scenario
-            player.withdrawMoney(player.getMoney()); // money = 0
+            player.withdrawMoney(player.getCash()); // money = 0
             // Liquidation value = 0 (no shares) < 525 obligations → false
             assertFalse(player.canCoverWithFullLiquidation(2, converter));
         }

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/player/PortfolioTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/player/PortfolioTest.java
@@ -381,19 +381,6 @@ class PortfolioTest {
         }
 
         @Test
-        @DisplayName("Should return zero when share has zero quantity")
-        void returnsZeroWhenShareHasZeroQuantity() {
-            // Arrange
-            Share zeroShare = new Share(
-                    new Stock("DCL", "Dara, Inc",
-                            new ArrayList<>(List.of(new BigDecimal("100.00"))), NOK),
-                    new BigDecimal("0"), new BigDecimal("50.00"));
-            portfolio.addShare(zeroShare);
-            // Act & Assert
-            assertEquals(0, BigDecimal.ZERO.compareTo(portfolio.getNetWorth(converter)));
-        }
-
-        @Test
         @DisplayName("Should return correct net worth after share is removed")
         void returnsCorrectNetWorthAfterShareIsRemoved() {
             // Arrange

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/stock/ShareTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/stock/ShareTest.java
@@ -1,7 +1,5 @@
 package edu.ntnu.idatt2003.millions.model.stock;
 
-import edu.ntnu.idatt2003.millions.model.stock.Share;
-import edu.ntnu.idatt2003.millions.model.stock.Stock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -13,7 +11,6 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for the {@link Share} class.
@@ -76,6 +73,16 @@ class ShareTest {
             // Act & Assert
             assertThrows(IllegalArgumentException.class, () ->
                     new Share(stock, quantity, purchasePrice));
+        }
+
+        @Test
+        @DisplayName("Should throw exception when quantity is zero")
+        void throwsExceptionWhenQuantityIsZero() {
+            // Arrange
+            BigDecimal purchasePrice = new BigDecimal("90.00");
+            // Act & Assert
+            assertThrows(IllegalArgumentException.class, () ->
+                    new Share(stock, BigDecimal.ZERO, purchasePrice));
         }
 
         @Test

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/transaction/PurchaseTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/transaction/PurchaseTest.java
@@ -143,12 +143,12 @@ class PurchaseTest {
         @DisplayName("Should deduct total cost from player balance after commit")
         void deductsTotalCostFromBalance() {
             // Arrange
-            BigDecimal balanceBefore = player.getMoney();
+            BigDecimal balanceBefore = player.getCash();
             BigDecimal expectedBalance = balanceBefore.subtract(purchase.getCalculator().calculateTotal());
             // Act
             purchase.commit(player);
             // Assert
-            assertEquals(0, expectedBalance.compareTo(player.getMoney()));
+            assertEquals(0, expectedBalance.compareTo(player.getCash()));
         }
 
         @Test
@@ -178,12 +178,12 @@ class PurchaseTest {
         void doesNotChangeBalanceWhenInsufficientFunds() {
             // Arrange
             Player poorPlayer = new Player("Dara", new BigDecimal("100.00"));
-            BigDecimal balanceBefore = poorPlayer.getMoney();
+            BigDecimal balanceBefore = poorPlayer.getCash();
             // Act
             assertThrows(IllegalArgumentException.class, () ->
                     purchase.commit(poorPlayer));
             // Assert
-            assertEquals(0, balanceBefore.compareTo(poorPlayer.getMoney()));
+            assertEquals(0, balanceBefore.compareTo(poorPlayer.getCash()));
         }
 
         @Test

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/transaction/SaleTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/transaction/SaleTest.java
@@ -50,9 +50,9 @@ class SaleTest {
         void valuesAreSetOnConstruction() {
             Sale sale = new Sale(share, 1);
             assertNotNull(sale.getGross());
-            assertNotNull(sale.getCommission());
-            assertNotNull(sale.getTax());
-            assertNotNull(sale.getTotal());
+            assertNotNull(sale.getCommissionNative());
+            assertNotNull(sale.getTaxNative());
+            assertNotNull(sale.getSignedTotalNative());
             assertNotNull(sale.getProfit());
             assertNotNull(sale.getProfitPercent());
         }
@@ -63,9 +63,9 @@ class SaleTest {
             SalesCalculator expected = new SalesCalculator(share);
             Sale sale = new Sale(share, 1);
             assertEquals(0, expected.calculateGross().compareTo(sale.getGross()));
-            assertEquals(0, expected.calculateCommission().compareTo(sale.getCommission()));
-            assertEquals(0, expected.calculateTax().compareTo(sale.getTax()));
-            assertEquals(0, expected.calculateTotal().compareTo(sale.getTotal()));
+            assertEquals(0, expected.calculateCommission().compareTo(sale.getCommissionNative()));
+            assertEquals(0, expected.calculateTax().compareTo(sale.getTaxNative()));
+            assertEquals(0, expected.calculateTotal().compareTo(sale.getSignedTotalNative()));
             assertEquals(0, expected.calculateProfit().compareTo(sale.getProfit()));
             assertEquals(0, expected.calculateProfitPercent().compareTo(sale.getProfitPercent()));
         }
@@ -74,16 +74,16 @@ class SaleTest {
         @DisplayName("Frozen values do not change when stock price advances")
         void valuesDoNotChangeWhenPriceMoves() {
             Sale sale = new Sale(share, 1);
-            BigDecimal frozenCommission = sale.getCommission();
-            BigDecimal frozenTax        = sale.getTax();
-            BigDecimal frozenTotal      = sale.getTotal();
+            BigDecimal frozenCommission = sale.getCommissionNative();
+            BigDecimal frozenTax        = sale.getTaxNative();
+            BigDecimal frozenTotal      = sale.getSignedTotalNative();
             BigDecimal frozenProfit     = sale.getProfit();
 
             share.getStock().addNewSalesPrice(new BigDecimal("999.00"));
 
-            assertEquals(0, frozenCommission.compareTo(sale.getCommission()));
-            assertEquals(0, frozenTax.compareTo(sale.getTax()));
-            assertEquals(0, frozenTotal.compareTo(sale.getTotal()));
+            assertEquals(0, frozenCommission.compareTo(sale.getCommissionNative()));
+            assertEquals(0, frozenTax.compareTo(sale.getTaxNative()));
+            assertEquals(0, frozenTotal.compareTo(sale.getSignedTotalNative()));
             assertEquals(0, frozenProfit.compareTo(sale.getProfit()));
         }
     }

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/transaction/SaleTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/transaction/SaleTest.java
@@ -234,7 +234,7 @@ class SaleTest {
         @DisplayName("Should not change player balance when share is not in portfolio")
         void doesNotChangeBalanceWhenShareNotInPortfolio() {
             // Arrange
-            BigDecimal balanceBefore = player.getMoney();
+            BigDecimal balanceBefore = player.getCash();
             // Act
             try {
                 otherSale.commit(player);
@@ -242,7 +242,7 @@ class SaleTest {
                 // for test purposes
             }
             // Assert
-            assertEquals(0, balanceBefore.compareTo(player.getMoney()));
+            assertEquals(0, balanceBefore.compareTo(player.getCash()));
         }
 
         @Test

--- a/src/test/java/edu/ntnu/idatt2003/millions/service/GameServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/service/GameServiceTest.java
@@ -171,7 +171,7 @@ class GameServiceTest {
             newGameService.createNewGame("Dara", STARTING_MONEY, stockFile);
             // Assert
             assertEquals("Dara", newGameService.getPlayer().getName());
-            assertEquals(0, STARTING_MONEY.compareTo(newGameService.getPlayer().getMoney()));
+            assertEquals(0, STARTING_MONEY.compareTo(newGameService.getPlayer().getCash()));
             assertEquals("MainExchange", newGameService.getExchange().getName());
             assertTrue(newGameService.getExchange().hasStock("AAPL"));
             assertTrue(newGameService.getExchange().hasStock("MSFT"));
@@ -190,7 +190,7 @@ class GameServiceTest {
             newGameService.createNewGame("Dara", STARTING_MONEY);
             // Assert
             assertEquals("Dara", newGameService.getPlayer().getName());
-            assertEquals(0, STARTING_MONEY.compareTo(newGameService.getPlayer().getMoney()));
+            assertEquals(0, STARTING_MONEY.compareTo(newGameService.getPlayer().getCash()));
             assertEquals("MainExchange", newGameService.getExchange().getName());
             assertTrue(newGameService.getExchange().hasStock("NVDA"));
             assertTrue(newGameService.getExchange().hasStock("AAPL"));
@@ -279,7 +279,7 @@ class GameServiceTest {
             // Assert: 5 * 100 USD * 1.005 commission = 502.50 USD; * 9.21 NOK/USD = 4628.0250 NOK
             BigDecimal expectedRemaining = STARTING_MONEY.subtract(new BigDecimal("4628.0250"));
             assertEquals(0,
-                    expectedRemaining.compareTo(newGameService.getPlayer().getMoney()));
+                    expectedRemaining.compareTo(newGameService.getPlayer().getCash()));
             assertEquals(usd,
                     newGameService.getExchange().getStock("AAPL").getCurrency());
         }
@@ -370,7 +370,7 @@ class GameServiceTest {
             assertEquals(1, observer.updateCount);
             assertEquals(0, STARTING_MONEY.subtract(STOCK_PRICE.multiply(QUANTITY))
                     .subtract(PURCHASE_COMMISSION)
-                    .compareTo(gameService.getPlayer().getMoney()));
+                    .compareTo(gameService.getPlayer().getCash()));
         }
     }
 
@@ -394,7 +394,7 @@ class GameServiceTest {
             assertEquals(1, observer.updateCount);
             assertEquals(0, STARTING_MONEY.subtract(PURCHASE_COMMISSION)
                     .subtract(SALE_COMMISSION)
-                    .compareTo(gameService.getPlayer().getMoney()));
+                    .compareTo(gameService.getPlayer().getCash()));
         }
     }
 
@@ -446,14 +446,14 @@ class GameServiceTest {
             gameService.takeLoan(offer, new BigDecimal("500.00"));
             Share share = buyAndGetShare();
             BigDecimal obligations = gameService.getPlayer().getTotalObligationsThisWeek(nextWeek());
-            BigDecimal moneyBefore = gameService.getPlayer().getMoney();
+            BigDecimal moneyBefore = gameService.getPlayer().getCash();
             BigDecimal netNok = SalesCalculator.calculateNetNok(share, gameService.getCurrencyConverter());
             // Act
             gameService.executeForcedSale(List.of(share), nextWeek());
             // Assert — portfolio empty, cash = previous + net sale - obligations
             assertTrue(gameService.getPlayer().getPortfolio().getShares("EQNR").isEmpty());
             BigDecimal expectedMoney = moneyBefore.add(netNok).subtract(obligations);
-            assertEquals(0, expectedMoney.compareTo(gameService.getPlayer().getMoney()));
+            assertEquals(0, expectedMoney.compareTo(gameService.getPlayer().getCash()));
         }
 
         @Test
@@ -494,7 +494,7 @@ class GameServiceTest {
                     new BigDecimal("50000.00"), LoanRiskLevel.HIGH);
             gameService.takeLoan(bigRate, new BigDecimal("4000.00"));
             Share share = buyAndGetShare();
-            BigDecimal moneyBefore = gameService.getPlayer().getMoney();
+            BigDecimal moneyBefore = gameService.getPlayer().getCash();
             int weekBefore = gameService.getExchange().getWeek();
             int nw = nextWeek();
             // Act
@@ -503,7 +503,7 @@ class GameServiceTest {
             } catch (InsufficientSaleProceedsException ignored) {}
             // Assert — no state changed
             assertEquals(weekBefore, gameService.getExchange().getWeek());
-            assertEquals(0, moneyBefore.compareTo(gameService.getPlayer().getMoney()));
+            assertEquals(0, moneyBefore.compareTo(gameService.getPlayer().getCash()));
             assertFalse(gameService.getPlayer().getPortfolio().getShares("EQNR").isEmpty());
         }
 
@@ -591,11 +591,11 @@ class GameServiceTest {
                     new BigDecimal("50000.00"), LoanRiskLevel.LOW);
             BigDecimal principal = new BigDecimal("200.00");
             gameService.takeLoan(shortOffer, principal);
-            BigDecimal moneyAfterLoan = gameService.getPlayer().getMoney(); // starting + principal
+            BigDecimal moneyAfterLoan = gameService.getPlayer().getCash(); // starting + principal
             BigDecimal interest = principal.multiply(new BigDecimal("0.01")).setScale(2, java.math.RoundingMode.HALF_UP);
             gameService.advanceWeek();
             BigDecimal expectedMoney = moneyAfterLoan.subtract(interest).subtract(principal);
-            assertEquals(0, expectedMoney.compareTo(gameService.getPlayer().getMoney()));
+            assertEquals(0, expectedMoney.compareTo(gameService.getPlayer().getCash()));
         }
     }
 
@@ -721,13 +721,13 @@ class GameServiceTest {
             assertFalse(gameService.getPlayer().getPortfolio().getShares().isEmpty(),
                     "player must own shares before sell-all");
 
-            BigDecimal moneyBeforeSell = gameService.getPlayer().getMoney();
+            BigDecimal moneyBeforeSell = gameService.getPlayer().getCash();
 
             gameService.sellAllAndExit();
 
             assertTrue(gameService.getPlayer().getPortfolio().getShares().isEmpty(),
                     "portfolio must be empty after sell-all");
-            assertTrue(gameService.getPlayer().getMoney().compareTo(moneyBeforeSell) > 0,
+            assertTrue(gameService.getPlayer().getCash().compareTo(moneyBeforeSell) > 0,
                     "money must increase after liquidation");
             assertEquals(1, lbService.getAllEntries().size());
             assertEquals(Outcome.RETIRED, lbService.getAllEntries().get(0).outcome());

--- a/src/test/java/edu/ntnu/idatt2003/millions/service/notification/NotificationServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/service/notification/NotificationServiceTest.java
@@ -179,7 +179,7 @@ class NotificationServiceTest {
             Loan loan = new Loan(offer, new BigDecimal("10000"), 0);
             try { player.takeLoan(loan, converter); } catch (Exception ignored) {}
             // Drain almost all cash so obligation at week+1 exceeds cash
-            player.withdrawMoney(player.getMoney().subtract(new BigDecimal("5")));
+            player.withdrawMoney(player.getCash().subtract(new BigDecimal("5")));
 
             service.onWeekAdvanced(player, exchange, converter);
 
@@ -194,7 +194,7 @@ class NotificationServiceTest {
                     new BigDecimal("100000"), LoanRiskLevel.LOW);
             Loan loan = new Loan(offer, new BigDecimal("10000"), 0);
             try { player.takeLoan(loan, converter); } catch (Exception ignored) {}
-            player.withdrawMoney(player.getMoney().subtract(new BigDecimal("5")));
+            player.withdrawMoney(player.getCash().subtract(new BigDecimal("5")));
 
             service.onWeekAdvanced(player, exchange, converter);
             service.onWeekAdvanced(player, exchange, converter);


### PR DESCRIPTION
## Why

A file-by-file Javadoc audit against the rubric's A-level
criteria for documentation:

- Every class has a clear role/responsibility description
- Every public method has Javadoc describing WHAT (the
  contract), not HOW (the implementation)
- `@param`, `@return`, `@throws` consistently used and
  cross-checked against the method body
- Overlong or implementation-mirroring Javadoc tightened
- Trivial getter/setter Javadoc removed
- AI-assistance markers added on files where Javadoc was
  substantively reworked (per the assignment's KI-use
  documentation requirement)

The audit also flagged code-quality observations along the
way (`Part B` of the per-file prompt). Most were noted and
left; the ones below were addressed because they were real
bug risks, dead code, or rubric-discriminator findings.

## Substantive code changes (not just docs)

Each was driven by an observation surfaced during the
Javadoc audit, diagnosed before changing anything, and
landed as its own commit so the trail is auditable.

### `Player.getMoney()` renamed to `getCash()`
The old name implied an abstract "amount of money", but the
field represents specifically the player's liquid cash
balance (not net worth, not portfolio value). The new name
matches its actual semantic.

### `Player.collectWeeklyInterest` javadoc rewritten
The old javadoc claimed the method returned an unpaid
shortfall when cash was insufficient. The method has always
been `void`. A diagnostic traced the actual forced-sale
mechanism: it triggers prospectively from
`MainController.handleAdvanceWeek` via
`canCoverObligationsThisWeek`, BEFORE
`collectWeeklyInterest` is ever called. The shortfall
scenario the javadoc described cannot occur. Rewritten to
match the actual contract — caller guarantees solvency.

### Share constructor rejects zero quantity
A zero-quantity Share represents no holding, which is the
same as having no Share at all — not a meaningful domain
state. The constructor now rejects `quantity <= 0`,
matching the prospective validation already done by
`Exchange.buy` and `Exchange.sell`. Six tests that
exercised zero-quantity calculator behavior were removed
because the scenario they covered became structurally
impossible; one new test verifies the tighter guard.

### Share/Portfolio reference-equality contract documented
A diagnostic verified that `Portfolio.contains` and
`Portfolio.removeShare` rely on reference equality (no
`equals`/`hashCode` override on Share), and that every call
site in production code passes references sourced from the
portfolio itself. The design is correct and intentional —
each Share represents a distinct purchase event with its
own purchase price. Documented explicitly on both Share's
class javadoc and the two Portfolio methods so future
maintainers don't introduce field-based equality by
accident.

### `Stock.getRecentPrices` returns a defensive copy
Previously returned `prices.subList(...)` — a live view of
the internal list. A caller mutating the returned list
would corrupt the stock's price history. Wrapped in `new
ArrayList<>(...)` to match the defensive-copy pattern used
elsewhere in the model.

### `Stock` constructor defensive-copies the prices list
Same principle: the caller can no longer retain a reference
to the input list and append prices outside the
constructor's validation path.

### `TransactionFactory` return types tightened
`createSale` and `createPurchase` returned `Transaction`
(the supertype) despite always constructing concrete `Sale`
and `Purchase` instances. Call sites had to cast back to the
concrete type. Tightened the return types to the actual
constructed types, removing the casts.

### `Sale` getter API consolidated on `*Native` suffix
SonarLint flagged identical implementations on three method
pairs:
`getCommission`/`getCommissionNative`,
`getTax`/`getTaxNative`,
`getTotal`/`getSignedTotalNative`.
A diagnostic showed the Native-suffix variants are the
abstract API declared on Transaction, that Purchase only
has the Native-suffix API, and that `TransactionStatsService`
(the most recently written code) uses the Native-suffix API
exclusively because the suffix signals the value's currency
context. Removed the three unsuffixed shortcut methods from
Sale and migrated 15 call sites. Sale is now consistent
with Purchase.

### Dead code removed from `LoanOffer` and `LoanRiskLevel`
`LoanOffer.isEligible`, `LoanOffer.minimumCollateral`, and
`LoanRiskLevel.collateralRatio` implemented a per-offer
collateral check based on risk level (10%/20%/30%) that was
never wired in. Eligibility enforcement actually uses a
flat 50% debt-ratio cap via `Player.takeLoan`. The
collateral system was a design that didn't survive
implementation. Removed the three methods; `LoanRiskLevel`
itself stays — it serves as a visual category label for
the three loan offers in the UI.
