### PR TITLE
fix: stale header focus after top-level navigation

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/millions/keyboard/PageFocusProvider.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/keyboard/PageFocusProvider.java
@@ -1,0 +1,15 @@
+package edu.ntnu.idatt2003.millions.keyboard;
+
+/**
+ * Implemented by top-level views that expose a keyboard focus entry point.
+ *
+ * <p>Allows the view coordinator to move focus into whichever page has just
+ * become visible without knowing that page's internal controls.</p>
+ */
+public interface PageFocusProvider {
+
+    /**
+     * Requests focus on the most appropriate entry control in this page.
+     */
+    void focusPageEntry();
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/MainView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/MainView.java
@@ -4,6 +4,7 @@ import edu.ntnu.idatt2003.millions.controller.LoanController;
 import edu.ntnu.idatt2003.millions.controller.MainController;
 import edu.ntnu.idatt2003.millions.controller.TradeController;
 import edu.ntnu.idatt2003.millions.keyboard.PageArrowDispatcher;
+import edu.ntnu.idatt2003.millions.keyboard.PageFocusProvider;
 import edu.ntnu.idatt2003.millions.keyboard.SearchFocusRegistry;
 import edu.ntnu.idatt2003.millions.keyboard.TabNavigationRegistry;
 import edu.ntnu.idatt2003.millions.service.GameService;
@@ -16,6 +17,7 @@ import edu.ntnu.idatt2003.millions.view.titlebar.TitleBar;
 import edu.ntnu.idatt2003.millions.view.dashboard.DashboardView;
 import edu.ntnu.idatt2003.millions.view.exchange.ExchangeView;
 import edu.ntnu.idatt2003.millions.view.leaderboard.LeaderboardView;
+import javafx.application.Platform;
 import javafx.beans.binding.Bindings;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
@@ -157,7 +159,7 @@ public class MainView {
             outerRoot.getChildren().add(overlay);
         }
 
-        showDashboard();
+        showDashboard(false);
     }
 
     /**
@@ -175,6 +177,15 @@ public class MainView {
      * so sub-view state (active tab, scroll position) survives navigation.
      */
     public void showDashboard() {
+        showDashboard(true);
+    }
+
+    /**
+     * Switches to the dashboard and optionally moves keyboard focus into it.
+     *
+     * @param focusPage whether to focus the page entry point after it is shown
+     */
+    private void showDashboard(boolean focusPage) {
         if (dashboardScrollable == null) {
             dashboardView = new DashboardView(
                     gameService, tradeController, loanController, createWeekBar(), this::showExchangeOnStocksTab);
@@ -184,6 +195,9 @@ public class MainView {
         tabNavigationRegistry.setActive(dashboardView::showTab);
         activeScrollable = dashboardScrollable;
         content.setCenter(dashboardScrollable);
+        if (focusPage) {
+            requestPageFocus(dashboardView);
+        }
     }
 
     /**
@@ -197,6 +211,7 @@ public class MainView {
         tabNavigationRegistry.setActive(exchangeView::showTab);
         activeScrollable = exchangeScrollable;
         content.setCenter(exchangeScrollable);
+        requestPageFocus(exchangeView);
     }
 
     /**
@@ -213,6 +228,7 @@ public class MainView {
         tabNavigationRegistry.setActive(null);
         activeScrollable = leaderboardScrollable;
         content.setCenter(leaderboardScrollable);
+        requestPageFocus(leaderboardView);
     }
 
     /**
@@ -226,6 +242,16 @@ public class MainView {
         tabNavigationRegistry.setActive(exchangeView::showTab);
         activeScrollable = exchangeScrollable;
         content.setCenter(exchangeScrollable);
+        requestPageFocus(exchangeView);
+    }
+
+    /**
+     * Requests focus after the selected page has been attached to the scene graph.
+     *
+     * @param page the newly displayed page and its focus entry policy
+     */
+    private void requestPageFocus(PageFocusProvider page) {
+        Platform.runLater(page::focusPageEntry);
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/ViewHeader.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/ViewHeader.java
@@ -93,6 +93,15 @@ public class ViewHeader extends VBox {
     }
 
     /**
+     * Requests keyboard focus on the currently active tab button, if present.
+     */
+    public void focusActiveTab() {
+        if (activeButton != null) {
+            activeButton.requestFocus();
+        }
+    }
+
+    /**
      * Updates all text elements to the current language.
      * Called automatically when the language changes.
      */

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/DashboardView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/DashboardView.java
@@ -2,9 +2,10 @@ package edu.ntnu.idatt2003.millions.view.dashboard;
 
 import edu.ntnu.idatt2003.millions.controller.LoanController;
 import edu.ntnu.idatt2003.millions.controller.TradeController;
+import edu.ntnu.idatt2003.millions.keyboard.PageFocusProvider;
+import edu.ntnu.idatt2003.millions.keyboard.SearchFocusProvider;
 import edu.ntnu.idatt2003.millions.keyboard.TabNavigationRegistry;
 import edu.ntnu.idatt2003.millions.service.GameService;
-import edu.ntnu.idatt2003.millions.keyboard.SearchFocusProvider;
 import edu.ntnu.idatt2003.millions.view.component.ViewHeader;
 import edu.ntnu.idatt2003.millions.view.component.WeekBar;
 import edu.ntnu.idatt2003.millions.view.dashboard.loans.LoansView;
@@ -26,7 +27,7 @@ import java.util.List;
  * indicator in {@link ViewHeader} directly, ensuring the highlight is correct
  * whether the tab was activated by click or by keyboard shortcut.</p>
  */
-public class DashboardView extends VBox implements SearchFocusProvider {
+public class DashboardView extends VBox implements SearchFocusProvider, PageFocusProvider {
 
     private final GameService gameService;
     private final TradeController tradeController;
@@ -161,5 +162,13 @@ public class DashboardView extends VBox implements SearchFocusProvider {
         if (activeSubview != null) {
             activeSubview.focusSearch();
         }
+    }
+
+    /**
+     * Focuses the active dashboard tab as the keyboard entry point for this page.
+     */
+    @Override
+    public void focusPageEntry() {
+        viewHeader.focusActiveTab();
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/exchange/ExchangeView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/exchange/ExchangeView.java
@@ -1,9 +1,10 @@
 package edu.ntnu.idatt2003.millions.view.exchange;
 
 import edu.ntnu.idatt2003.millions.controller.TradeController;
+import edu.ntnu.idatt2003.millions.keyboard.PageFocusProvider;
+import edu.ntnu.idatt2003.millions.keyboard.SearchFocusProvider;
 import edu.ntnu.idatt2003.millions.keyboard.TabNavigationRegistry;
 import edu.ntnu.idatt2003.millions.service.GameService;
-import edu.ntnu.idatt2003.millions.keyboard.SearchFocusProvider;
 import edu.ntnu.idatt2003.millions.view.component.ViewHeader;
 import edu.ntnu.idatt2003.millions.view.component.WeekBar;
 import edu.ntnu.idatt2003.millions.view.exchange.overview.ExchangeOverview;
@@ -18,7 +19,7 @@ import java.util.List;
  * Contains a tab bar for navigating between overview and stocks.
  * Tab navigation is purely visual state and handled internally by this view.
  */
-public class ExchangeView extends VBox implements SearchFocusProvider {
+public class ExchangeView extends VBox implements SearchFocusProvider, PageFocusProvider {
 
     private final GameService gameService;
     private final TradeController controller;
@@ -92,6 +93,14 @@ public class ExchangeView extends VBox implements SearchFocusProvider {
         if (activeTabProvider != null) {
             activeTabProvider.focusSearch();
         }
+    }
+
+    /**
+     * Focuses the active exchange tab as the keyboard entry point for this page.
+     */
+    @Override
+    public void focusPageEntry() {
+        viewHeader.focusActiveTab();
     }
 
     private void showOverview() {

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/leaderboard/LeaderboardView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/leaderboard/LeaderboardView.java
@@ -1,9 +1,10 @@
 package edu.ntnu.idatt2003.millions.view.leaderboard;
 
+import edu.ntnu.idatt2003.millions.keyboard.PageFocusProvider;
+import edu.ntnu.idatt2003.millions.keyboard.SearchFocusProvider;
 import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.service.toast.ToastService;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
-import edu.ntnu.idatt2003.millions.keyboard.SearchFocusProvider;
 import edu.ntnu.idatt2003.millions.view.component.StyledText;
 import edu.ntnu.idatt2003.millions.view.component.WeekBar;
 import edu.ntnu.idatt2003.millions.view.leaderboard.card.LeaderboardCard;
@@ -21,7 +22,7 @@ import javafx.scene.layout.VBox;
  * via {@link edu.ntnu.idatt2003.millions.observer.GameObserver} callbacks wired
  * inside the card.</p>
  */
-public class LeaderboardView extends VBox implements SearchFocusProvider {
+public class LeaderboardView extends VBox implements SearchFocusProvider, PageFocusProvider {
 
     private final LeaderboardCard card;
 
@@ -57,5 +58,13 @@ public class LeaderboardView extends VBox implements SearchFocusProvider {
     @Override
     public void focusSearch() {
         card.focusSearch();
+    }
+
+    /**
+     * Focuses the search field as the keyboard entry point for this page.
+     */
+    @Override
+    public void focusPageEntry() {
+        focusSearch();
     }
 }

--- a/src/main/resources/css/navbar.css
+++ b/src/main/resources/css/navbar.css
@@ -18,6 +18,12 @@
     -fx-background-color: transparent;
     -fx-cursor: hand;
     -fx-padding: 50 0 8 0;
+    -fx-border-color: transparent;
+    -fx-border-width: 0 0 2 0;
+}
+
+.navbar-link:focused {
+    -fx-border-color: white;
 }
 
 .navbar-action {

--- a/src/main/resources/css/navbar.css
+++ b/src/main/resources/css/navbar.css
@@ -32,11 +32,24 @@
     -fx-background-color: transparent;
     -fx-cursor: hand;
     -fx-padding: 16 0 0 0;
+    -fx-border-color: transparent;
+    -fx-border-width: 0 0 2 0;
+}
+
+.navbar-action:focused {
+    -fx-border-color: white;
 }
 
 .navbar-icon {
     -fx-background-color: transparent;
     -fx-cursor: hand;
+    -fx-border-color: transparent;
+    -fx-border-width: 1;
+    -fx-border-radius: 4;
+}
+
+.navbar-icon:focused {
+    -fx-border-color: white;
 }
 
 .navbar-bell-icon {
@@ -52,11 +65,18 @@
 
 .language-picker-btn {
     -fx-background-color: transparent;
-    -fx-border-width: 0;
+    -fx-border-color: transparent;
+    -fx-border-width: 1;
+    -fx-border-radius: 4;
     -fx-cursor: hand;
     -fx-padding: 3 5 3 5;
     -fx-background-radius: 4;
     -fx-opacity: 0.35;
+}
+
+.language-picker-btn:focused {
+    -fx-border-color: white;
+    -fx-opacity: 1.0;
 }
 
 .language-picker-btn:hover {


### PR DESCRIPTION
## Summary

This PR fixes an issue where pressing Enter after navigating to another top-level page could unexpectedly return the user to Dashboard. It also improves keyboard focus visibility across the persistent header controls.

## Background

The application supports keyboard activation of focused buttons through Enter. When a user navigated away from Dashboard, focus could remain on the persistent header button for Dashboard even though a different page was visible. Pressing Enter would then activate the stale focused button and navigate back to Dashboard.

The underlying issue was not the Enter shortcut itself, but missing focus handoff when switching between top-level views.

## Changes

Introduced a small page-focus contract that allows each top-level view to expose its natural keyboard entry point without making the main view aware of internal control details.

Dashboard and Exchange now expose their currently active tab as their entry focus target, while Leaderboard exposes its search field. After user-initiated navigation, the main view requests focus on the newly displayed page once it has been attached to the JavaFX scene graph.

Initial Dashboard display remains unchanged and does not force a focus indicator when the application first opens.

Improved focus visibility in the black application header:
- Main navigation links receive an underline when focused.
- Text actions such as New Game, Save Game and Exit Game receive the same underline focus indication.
- The notification bell and language controls receive a compact focus border suited to icon-based controls.
- Language selection styling remains separate from keyboard focus styling.

## Design Rationale

The fix preserves the existing Enter behaviour for intentionally focused buttons and addresses the actual stale-focus cause instead of disabling keyboard activation.

The page-focus contract keeps responsibilities separated:
- Each page owns the knowledge of its most appropriate focus entry point.
- The main view owns navigation timing and focus handoff after page changes.
- CSS owns the presentation of keyboard focus in the header.

This avoids coupling the view coordinator to internal buttons or search fields and keeps keyboard focus feedback consistent with the control type.