### PR TITLE
refactor: keyboard cleanup

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/millions/keyboard/ActiveRegistry.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/keyboard/ActiveRegistry.java
@@ -1,0 +1,41 @@
+package edu.ntnu.idatt2003.millions.keyboard;
+
+import java.util.function.Consumer;
+
+/**
+ * Generic single-active-provider registry.
+ *
+ * <p>Holds at most one active provider of type {@code T} at a time.
+ * Callers set the active provider via {@link #setActive(Object)} and
+ * trigger behaviour on it via {@link #ifActive(Consumer)}.
+ * Passing {@code null} to {@link #setActive} clears the active provider.</p>
+ *
+ * @param <T> the type of provider this registry holds
+ */
+public final class ActiveRegistry<T> {
+
+    private T active;
+
+    /**
+     * Registers the given provider as the currently active one,
+     * replacing any previous registration.
+     * Pass {@code null} to clear the active provider.
+     *
+     * @param provider the provider to activate, or {@code null}
+     */
+    public void setActive(T provider) {
+        this.active = provider;
+    }
+
+    /**
+     * Runs {@code action} on the active provider if one is registered.
+     * Does nothing when no provider is active.
+     *
+     * @param action the operation to perform on the active provider
+     */
+    public void ifActive(Consumer<T> action) {
+        if (active != null) {
+            action.accept(active);
+        }
+    }
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/keyboard/KeyboardNavigationService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/keyboard/KeyboardNavigationService.java
@@ -18,9 +18,8 @@ import java.util.Objects;
  * <p>Dispatch order on each key event:</p>
  * <ol>
  *   <li>The universal {@link ShortcutRegistry}, for shortcuts that must fire
- *       regardless of context (e.g. Enter > fire focused button).</li>
- *   <li>If the universal registry did not handle the event, the global
- *       {@link ShortcutRegistry} is consulted.</li>
+ *       regardless of context (e.g. Enter to fire the focused button).</li>
+ *   <li>The global {@link ShortcutRegistry}, for application-wide shortcuts.</li>
  * </ol>
  *
  * <p>Modal dialogs are isolated naturally: each is its own

--- a/src/main/java/edu/ntnu/idatt2003/millions/keyboard/PageScroller.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/keyboard/PageScroller.java
@@ -9,7 +9,11 @@ import javafx.scene.input.KeyCode;
  * so the dispatcher (in the {@code keyboard} package) can scroll the active page
  * without depending on the concrete view component. This keeps the dependency
  * direction one-way: the view depends on {@code keyboard}, not the reverse.</p>
+ *
+ * <p>Marked as {@link FunctionalInterface} because it has a single abstract method,
+ * allowing implementations to be expressed as lambdas where convenient.</p>
  */
+@FunctionalInterface
 public interface PageScroller {
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/keyboard/SearchFocusRegistry.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/keyboard/SearchFocusRegistry.java
@@ -1,8 +1,12 @@
 package edu.ntnu.idatt2003.millions.keyboard;
 
+/**
+ * Tracks the currently active {@link SearchFocusProvider} and delegates
+ * search-focus requests to it.
+ */
 public final class SearchFocusRegistry {
 
-    private SearchFocusProvider active;
+    private final ActiveRegistry<SearchFocusProvider> registry = new ActiveRegistry<>();
 
     /**
      * Registers the given provider as the active search target.
@@ -11,7 +15,7 @@ public final class SearchFocusRegistry {
      * @param provider the provider to activate, or {@code null}
      */
     public void setActive(SearchFocusProvider provider) {
-        this.active = provider;
+        registry.setActive(provider);
     }
 
     /**
@@ -19,8 +23,6 @@ public final class SearchFocusRegistry {
      * Does nothing if no provider is currently active.
      */
     public void focusActive() {
-        if (active != null) {
-            active.focusSearch();
-        }
+        registry.ifActive(SearchFocusProvider::focusSearch);
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/keyboard/ShortcutRegistry.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/keyboard/ShortcutRegistry.java
@@ -43,7 +43,7 @@ public final class ShortcutRegistry {
     /**
      * Registers a conditional action for the given combination, replacing any previous mapping.
      * The event is consumed only if {@code action} returns {@code true}, allowing the action
-     * to decline handling (e.g. when the focused node is a text input rather than a button).
+     * to decline handling and let the event propagate.
      *
      * @param combination the key combination
      * @param action      the action; return {@code true} if the event was handled,

--- a/src/main/java/edu/ntnu/idatt2003/millions/keyboard/TabNavigationRegistry.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/keyboard/TabNavigationRegistry.java
@@ -8,7 +8,7 @@ import java.util.function.IntConsumer;
  */
 public final class TabNavigationRegistry {
 
-    private IntConsumer active;
+    private final ActiveRegistry<IntConsumer> registry = new ActiveRegistry<>();
 
     /**
      * Registers the given navigator as the active tab handler.
@@ -18,7 +18,7 @@ public final class TabNavigationRegistry {
      *                  zero-based index, or {@code null}
      */
     public void setActive(IntConsumer navigator) {
-        this.active = navigator;
+        registry.setActive(navigator);
     }
 
     /**
@@ -28,8 +28,6 @@ public final class TabNavigationRegistry {
      * @param index the zero-based index of the tab to select
      */
     public void selectTab(int index) {
-        if (active != null) {
-            active.accept(index);
-        }
+        registry.ifActive(navigator -> navigator.accept(index));
     }
 }


### PR DESCRIPTION
## Summary

Three targeted cleanups to the keyboard package: a missing @FunctionalInterface annotation, a generic extraction to eliminate a duplicated single-active-provider pattern, and two tightened Javadoc comments that were over-explaining implied behaviour.

## Background
A review of the keyboard package identified three minor but concrete issues:

PageScroller had a single abstract method and was already used as a lambda in tests, but lacked the @FunctionalInterface annotation. Without it, the compiler cannot enforce the contract, and the intent is invisible to readers.

SearchFocusRegistry and TabNavigationRegistry were structurally identical, both held one active provider of a given type, offered a setActive() mutator, and delegated to the provider on demand. The only difference was the type parameter and the delegation method name. This violated DRY with no architectural justification.

In KeyboardNavigationService, the dispatch-order list described step 2 as "If the universal registry did not handle the event, the global registry is consulted", the conditional was implicit in a numbered list and added no information. In ShortcutRegistry.register(KeyCombination, BooleanSupplier), the @param description cited a concrete application-specific example ("when the focused node is a text input rather than a button") inside a general-purpose API, coupling library-level documentation to one caller's context.

## Changes
PageScroller.java Added @FunctionalInterface annotation and a corresponding Javadoc sentence explaining why, making the single-method contract compiler-enforced and explicit.

ActiveRegistry.java (new) Generic single-active-provider registry with setActive(T) and ifActive(Consumer<T>). Extracted from the duplicated logic shared by SearchFocusRegistry and TabNavigationRegistry.

SearchFocusRegistry: Replaced the inlined active-provider logic with delegation to ActiveRegistry<SearchFocusProvider>. Public API (setActive, focusActive) is unchanged; all call sites are unaffected.

TabNavigationRegistry: Replaced the inlined active-provider logic with delegation to ActiveRegistry<IntConsumer>. Public API (setActive, selectTab) is unchanged; all call sites are unaffected.

KeyboardNavigationService: Removed the redundant conditional phrase from step 2 of the dispatch-order list. The numbered list structure already implies sequencing.

ShortcutRegistry: Replaced the application-specific example in the register(KeyCombination, BooleanSupplier) @param description with a general-purpose formulation that does not reference any particular caller.