### PR TITLE
fix: cache exchangeview to prevent repeated observer registration

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/millions/view/exchange/ExchangeView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/exchange/ExchangeView.java
@@ -26,6 +26,8 @@ public class ExchangeView extends VBox implements SearchFocusProvider, PageFocus
     private final ViewHeader viewHeader;
     private final VBox contentArea;
     private SearchFocusProvider activeTabProvider;
+    private ExchangeOverview overviewView;
+    private StocksView stocksView;
 
     /**
      * Constructs a new ExchangeView with the overview tab active.
@@ -104,12 +106,17 @@ public class ExchangeView extends VBox implements SearchFocusProvider, PageFocus
     }
 
     private void showOverview() {
+        if (overviewView == null) {
+            overviewView = new ExchangeOverview(gameService);
+        }
         activeTabProvider = null;
-        contentArea.getChildren().setAll(new ExchangeOverview(gameService));
+        contentArea.getChildren().setAll(overviewView);
     }
 
     private void showStocks() {
-        StocksView stocksView = new StocksView(gameService, controller);
+        if (stocksView == null) {
+            stocksView = new StocksView(gameService, controller);
+        }
         activeTabProvider = stocksView;
         contentArea.getChildren().setAll(stocksView);
     }


### PR DESCRIPTION
ExchangeView was creating a new ExchangeOverview and StocksView instance on every tab switch. Both classes register as GameObserver in their constructor and never deregister, causing observers to accumulate in GameService with each tab navigation. Fixed by introducing lazy initialisation with caching, matching the pattern already used in DashboardView.