### PR TITLE
fix: surface save and stock-CSV load errors with localized, reactive feedback

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
@@ -14,6 +14,7 @@ import edu.ntnu.idatt2003.millions.view.titlebar.TitleBarFactory;
 import java.io.File;
 import java.io.UncheckedIOException;
 import java.math.BigDecimal;
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Currency;
 import java.util.List;
@@ -232,7 +233,12 @@ public class StartController {
         try {
             new JsonGameFileHandler().loadGame(file);
             successSink.accept(() -> LanguageManager.get("start.file.uploadSuccess"));
-        } catch (GameSaveCorruptException | UncheckedIOException e) {
+        } catch (GameSaveCorruptException e) {
+            inputs.setSaveFilePath("");
+            final String key = e.getI18nKey();
+            final Object[] args = e.getArgs();
+            errorSink.accept(() -> MessageFormat.format(LanguageManager.get(key), args));
+        } catch (UncheckedIOException e) {
             inputs.setSaveFilePath("");
             errorSink.accept(e::getMessage);
         }
@@ -341,17 +347,20 @@ public class StartController {
 
     /**
      * Runs the given action and translates expected game errors to a user-facing
-     * error dialog. Catches the specific exception types that the start flow can
-     * legitimately produce: input validation failures, missing game state, and
-     * file I/O errors. Programming errors such as {@link NullPointerException}
-     * are intentionally not caught so they surface during development.
+     * error dialog. Known start-flow exceptions (input validation failures, missing
+     * game state, file I/O errors) show a specific message; unrecognized exceptions
+     * fall back to a generic error.
      *
      * @param action the start-flow action to execute
      */
     private void runOrShowError(GameAction action) {
         try {
             action.execute();
-        } catch (GameSaveCorruptException | InvalidStockDataException | IllegalArgumentException
+        } catch (GameSaveCorruptException exception) {
+            final String key = exception.getI18nKey();
+            final Object[] args = exception.getArgs();
+            errorSink.accept(() -> MessageFormat.format(LanguageManager.get(key), args));
+        } catch (InvalidStockDataException | IllegalArgumentException
                  | IllegalStateException | UncheckedIOException exception) {
             errorSink.accept(exception::getMessage);
         } catch (Exception _) {

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
@@ -211,7 +211,10 @@ public class StartController {
         try {
             new CsvStockFileHandler().readStocks(file.toPath(), currency);
             successSink.accept(() -> LanguageManager.get("start.file.uploadSuccess"));
-        } catch (InvalidStockDataException | UncheckedIOException e) {
+        } catch (InvalidStockDataException e) {
+            inputs.setStockFilePath("");
+            resolveLocalizedError(e.getI18nKey(), e.getArgs());
+        } catch (UncheckedIOException e) {
             inputs.setStockFilePath("");
             errorSink.accept(e::getMessage);
         }
@@ -235,9 +238,7 @@ public class StartController {
             successSink.accept(() -> LanguageManager.get("start.file.uploadSuccess"));
         } catch (GameSaveCorruptException e) {
             inputs.setSaveFilePath("");
-            final String key = e.getI18nKey();
-            final Object[] args = e.getArgs();
-            errorSink.accept(() -> MessageFormat.format(LanguageManager.get(key), args));
+            resolveLocalizedError(e.getI18nKey(), e.getArgs());
         } catch (UncheckedIOException e) {
             inputs.setSaveFilePath("");
             errorSink.accept(e::getMessage);
@@ -357,15 +358,18 @@ public class StartController {
         try {
             action.execute();
         } catch (GameSaveCorruptException exception) {
-            final String key = exception.getI18nKey();
-            final Object[] args = exception.getArgs();
-            errorSink.accept(() -> MessageFormat.format(LanguageManager.get(key), args));
-        } catch (InvalidStockDataException | IllegalArgumentException
-                 | IllegalStateException | UncheckedIOException exception) {
+            resolveLocalizedError(exception.getI18nKey(), exception.getArgs());
+        } catch (InvalidStockDataException exception) {
+            resolveLocalizedError(exception.getI18nKey(), exception.getArgs());
+        } catch (IllegalArgumentException | IllegalStateException | UncheckedIOException exception) {
             errorSink.accept(exception::getMessage);
         } catch (Exception _) {
             errorSink.accept(() -> LanguageManager.get("error.save.load.failed"));
         }
+    }
+
+    private void resolveLocalizedError(String key, Object[] args) {
+        errorSink.accept(() -> MessageFormat.format(LanguageManager.get(key), args));
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
@@ -354,6 +354,8 @@ public class StartController {
         } catch (GameSaveCorruptException | InvalidStockDataException | IllegalArgumentException
                  | IllegalStateException | UncheckedIOException exception) {
             errorSink.accept(exception::getMessage);
+        } catch (Exception _) {
+            errorSink.accept(() -> LanguageManager.get("error.save.load.failed"));
         }
     }
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/game/GameSaveCorruptException.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/game/GameSaveCorruptException.java
@@ -1,5 +1,7 @@
 package edu.ntnu.idatt2003.millions.file.game;
 
+import java.util.Arrays;
+
 /**
  * Thrown when a game save file cannot be deserialized because its content does not
  * conform to the expected JSON schema — for example, a required field is missing,
@@ -8,30 +10,67 @@ package edu.ntnu.idatt2003.millions.file.game;
  * <p>This is a recoverable failure. Callers should catch it, inform the player that
  * the save file is corrupt, and offer to start a new game instead.
  *
- * <p>Note: this exception class is introduced here to give future save-file loading
- * logic a specific type to throw. The wiring into {@link JsonGameFileHandler} is
- * tracked separately.
+ * <p>The exception carries an opaque {@link #i18nKey} and structured {@link #args}
+ * (typically the filename) rather than a pre-resolved string. Callers in the
+ * controller layer resolve the key at display time via {@code LanguageManager} so
+ * that the message is always shown in the user's current language, including if the
+ * locale changes while the error is visible.
+ *
+ * <p>{@link #getMessage()} returns a fallback string intended for logging and
+ * debugging only — it is not the user-facing message.
  */
 public class GameSaveCorruptException extends Exception {
 
+    private final String i18nKey;
+    private final Object[] args;
+
     /**
-     * Creates an exception with a descriptive message identifying what was corrupt.
+     * Creates an exception with an i18n key and structured arguments but no chained cause.
      *
-     * @param message a human-readable description of the schema violation
+     * @param i18nKey the resource-bundle key identifying the error message template
+     * @param args    the format arguments (e.g. the filename); may be null or empty
      */
-    public GameSaveCorruptException(String message) {
-        super(message);
+    public GameSaveCorruptException(String i18nKey, Object[] args) {
+        super(formatFallback(i18nKey, args));
+        this.i18nKey = i18nKey;
+        this.args = args != null ? args.clone() : new Object[0];
     }
 
     /**
-     * Creates an exception with a descriptive message and a chained cause.
+     * Creates an exception with an i18n key, structured arguments, and a chained cause.
      * Use this constructor when wrapping a lower-level exception such as a
-     * {@link com.google.gson.JsonSyntaxException}.
+     * {@link com.google.gson.JsonParseException}.
      *
-     * @param message a human-readable description of the schema violation
+     * @param i18nKey the resource-bundle key identifying the error message template
+     * @param args    the format arguments (e.g. the filename); may be null or empty
      * @param cause   the lower-level exception that triggered this one
      */
-    public GameSaveCorruptException(String message, Throwable cause) {
-        super(message, cause);
+    public GameSaveCorruptException(String i18nKey, Object[] args, Throwable cause) {
+        super(formatFallback(i18nKey, args), cause);
+        this.i18nKey = i18nKey;
+        this.args = args != null ? args.clone() : new Object[0];
+    }
+
+    /**
+     * Returns the resource-bundle key for the error message template.
+     * Controllers pass this to {@code LanguageManager.get(key)} at display time.
+     *
+     * @return the i18n key
+     */
+    public String getI18nKey() {
+        return i18nKey;
+    }
+
+    /**
+     * Returns a defensive copy of the format arguments for the message template.
+     *
+     * @return the format arguments; never null, may be empty
+     */
+    public Object[] getArgs() {
+        return args.clone();
+    }
+
+    private static String formatFallback(String key, Object[] args) {
+        return key + (args != null && args.length > 0 ? " " + Arrays.toString(args) : "");
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/game/JsonGameFileHandler.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/game/JsonGameFileHandler.java
@@ -11,7 +11,10 @@ import edu.ntnu.idatt2003.millions.model.transaction.Purchase;
 import edu.ntnu.idatt2003.millions.model.transaction.Sale;
 import edu.ntnu.idatt2003.millions.model.transaction.Transaction;
 
+import edu.ntnu.idatt2003.millions.util.LanguageManager;
+
 import java.io.*;
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -107,14 +110,14 @@ public class JsonGameFileHandler implements GameFileHandler {
             gameState = gson.fromJson(reader, JsonObject.class);
         } catch (JsonParseException e) {
             throw new GameSaveCorruptException(
-                    "Save file contains invalid JSON: " + label, e);
+                    MessageFormat.format(LanguageManager.get("error.save.load.invalidJson"), label), e);
         }
 
         if (gameState == null
                 || !gameState.has("player")
                 || !gameState.has("exchange")) {
             throw new GameSaveCorruptException(
-                    "Save file is missing required fields 'player' or 'exchange': " + label);
+                    MessageFormat.format(LanguageManager.get("error.save.load.missingFields"), label));
         }
 
         Exchange exchange;
@@ -124,7 +127,7 @@ public class JsonGameFileHandler implements GameFileHandler {
             player = gson.fromJson(gameState.get("player"), Player.class);
         } catch (JsonParseException e) {
             throw new GameSaveCorruptException(
-                    "Save file has an unreadable structure: " + label, e);
+                    MessageFormat.format(LanguageManager.get("error.save.load.unreadableStructure"), label), e);
         }
 
         relinkShares(player, exchange);
@@ -165,7 +168,11 @@ public class JsonGameFileHandler implements GameFileHandler {
                 @Override
                 public T read(JsonReader in) throws IOException {
                     JsonObject obj = elementAdapter.read(in).getAsJsonObject();
-                    String type = obj.get("type").getAsString();
+                    JsonElement typeEl = obj.get("type");
+                    if (typeEl == null) {
+                        throw new JsonParseException("Missing 'type' field in transaction object");
+                    }
+                    String type = typeEl.getAsString();
 
                     if ("PURCHASE".equals(type)) {
                         return (T) gson.getDelegateAdapter(
@@ -198,9 +205,7 @@ public class JsonGameFileHandler implements GameFileHandler {
         for (Transaction transaction : player.getTransactionArchive().getAll()) {
             Share oldShare = transaction.getShare();
             var canonicalStock = exchange.getStock(oldShare.getStock().getSymbol());
-            if (canonicalStock != null) {
-                transaction.relinkShare(new Share(canonicalStock, oldShare.getQuantity(), oldShare.getPurchasePrice()));
-            }
+            transaction.relinkShare(new Share(canonicalStock, oldShare.getQuantity(), oldShare.getPurchasePrice()));
         }
     }
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/game/JsonGameFileHandler.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/game/JsonGameFileHandler.java
@@ -11,10 +11,7 @@ import edu.ntnu.idatt2003.millions.model.transaction.Purchase;
 import edu.ntnu.idatt2003.millions.model.transaction.Sale;
 import edu.ntnu.idatt2003.millions.model.transaction.Transaction;
 
-import edu.ntnu.idatt2003.millions.util.LanguageManager;
-
 import java.io.*;
-import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -109,15 +106,13 @@ public class JsonGameFileHandler implements GameFileHandler {
         try {
             gameState = gson.fromJson(reader, JsonObject.class);
         } catch (JsonParseException e) {
-            throw new GameSaveCorruptException(
-                    MessageFormat.format(LanguageManager.get("error.save.load.invalidJson"), label), e);
+            throw new GameSaveCorruptException("error.save.load.invalidJson", new Object[]{label}, e);
         }
 
         if (gameState == null
                 || !gameState.has("player")
                 || !gameState.has("exchange")) {
-            throw new GameSaveCorruptException(
-                    MessageFormat.format(LanguageManager.get("error.save.load.missingFields"), label));
+            throw new GameSaveCorruptException("error.save.load.missingFields", new Object[]{label});
         }
 
         Exchange exchange;
@@ -126,8 +121,7 @@ public class JsonGameFileHandler implements GameFileHandler {
             exchange = gson.fromJson(gameState.get("exchange"), Exchange.class);
             player = gson.fromJson(gameState.get("player"), Player.class);
         } catch (JsonParseException e) {
-            throw new GameSaveCorruptException(
-                    MessageFormat.format(LanguageManager.get("error.save.load.unreadableStructure"), label), e);
+            throw new GameSaveCorruptException("error.save.load.unreadableStructure", new Object[]{label}, e);
         }
 
         relinkShares(player, exchange);

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/stock/CsvStockFileHandler.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/stock/CsvStockFileHandler.java
@@ -194,15 +194,18 @@ public class CsvStockFileHandler implements StockFileHandler {
                 }
                 String[] fields = line.split(DELIMITER);
                 if (fields.length != EXPECTED_FIELDS) {
-                    throw new InvalidStockDataException(lineNumber, line.trim());
+                    throw new InvalidStockDataException(
+                            "error.stock.csv.invalidStockData", new Object[]{lineNumber, line.trim()});
                 }
                 String symbol = fields[SYMBOL_INDEX].trim();
                 if (symbol.isBlank()) {
-                    throw new InvalidStockDataException(lineNumber, line.trim(), "blank symbol");
+                    throw new InvalidStockDataException(
+                            "error.stock.csv.blankSymbol", new Object[]{lineNumber, line.trim()});
                 }
                 String name = fields[NAME_INDEX].trim();
                 if (name.isBlank()) {
-                    throw new InvalidStockDataException(lineNumber, line.trim(), "blank name");
+                    throw new InvalidStockDataException(
+                            "error.stock.csv.blankName", new Object[]{lineNumber, line.trim()});
                 }
                 String rawPrice = fields[PRICE_INDEX].trim();
                 BigDecimal price;
@@ -210,11 +213,11 @@ public class CsvStockFileHandler implements StockFileHandler {
                     price = new BigDecimal(rawPrice);
                 } catch (NumberFormatException e) {
                     throw new InvalidStockDataException(
-                            lineNumber, line.trim(), "non-numeric price \"" + rawPrice + "\"");
+                            "error.stock.csv.nonNumericPrice", new Object[]{rawPrice, lineNumber, line.trim()});
                 }
                 if (price.compareTo(BigDecimal.ZERO) <= 0) {
                     throw new InvalidStockDataException(
-                            lineNumber, line.trim(), "non-positive price \"" + rawPrice + "\"");
+                            "error.stock.csv.nonPositivePrice", new Object[]{rawPrice, lineNumber, line.trim()});
                 }
                 result.add(new Stock(symbol, name, new ArrayList<>(List.of(price)), currency));
             }

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/stock/EmptyStockFileException.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/stock/EmptyStockFileException.java
@@ -21,6 +21,6 @@ public class EmptyStockFileException extends InvalidStockDataException {
    * @param filePath the path or name of the stock file that was empty
    */
   public EmptyStockFileException(String filePath) {
-    super("Stock file contains no valid entries: \"" + filePath + "\"", null);
+    super("error.stock.csv.emptyFile", new Object[]{filePath}, null);
   }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/stock/InvalidStockDataException.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/stock/InvalidStockDataException.java
@@ -1,5 +1,7 @@
 package edu.ntnu.idatt2003.millions.file.stock;
 
+import java.util.Arrays;
+
 /**
  * Thrown when a CSV stock file contains a line that cannot be parsed. Triggering
  * conditions include:
@@ -13,71 +15,68 @@ package edu.ntnu.idatt2003.millions.file.stock;
  * <p>Blank lines and lines beginning with {@code #} are skipped silently and
  * never trigger this exception.
  *
- * <p>Callers should report the {@link #getLineNumber() line number} and
- * {@link #getLineContent() raw content} to the user so they can locate and
- * correct the malformed entry in the file.
+ * <p>The exception carries an opaque {@link #getI18nKey() i18nKey} and structured
+ * {@link #getArgs() args} (typically line number and raw line content) rather than
+ * a pre-resolved string. Callers in the controller layer resolve the key at display
+ * time via {@code LanguageManager} so the message is shown in the user's current
+ * language.
+ *
+ * <p>{@link #getMessage()} returns a fallback string intended for logging and
+ * debugging only — it is not the user-facing message.
  *
  * <p>{@link EmptyStockFileException} is a subclass for the case where the file
  * contains no valid stock entries at all.
  */
 public class InvalidStockDataException extends Exception {
 
-    private final int lineNumber;
-    private final String lineContent;
+    private final String i18nKey;
+    private final Object[] args;
 
     /**
-     * Creates an exception identifying the malformed line by its position in
-     * the file and its raw content.
+     * Creates an exception with an i18n key and structured arguments but no chained cause.
      *
-     * @param lineNumber  the 1-based line number of the malformed entry
-     * @param lineContent the raw text of the malformed line
+     * @param i18nKey the resource-bundle key identifying the error message template
+     * @param args    the format arguments (e.g. line number and raw content); may be null or empty
      */
-    public InvalidStockDataException(int lineNumber, String lineContent) {
-        super("Invalid stock data at line " + lineNumber + ": \"" + lineContent + "\"");
-        this.lineNumber = lineNumber;
-        this.lineContent = lineContent;
-    }
-
-    /**
-     * Creates an exception identifying the malformed line by its position, raw content,
-     * and a specific reason describing why the line failed validation.
-     *
-     * <p>Use this constructor when the generic "invalid stock data" message is not
-     * descriptive enough, for example when a required field is blank or the price
-     * is non-positive.
-     *
-     * @param lineNumber  the 1-based line number of the malformed entry
-     * @param lineContent the raw text of the malformed line
-     * @param reason      a short description of why the line is invalid
-     *                    (e.g. {@code "blank symbol"} or {@code "non-positive price \"-1\""})
-     */
-    public InvalidStockDataException(int lineNumber, String lineContent, String reason) {
-        super(reason + " at line " + lineNumber + ": \"" + lineContent + "\"");
-        this.lineNumber = lineNumber;
-        this.lineContent = lineContent;
+    public InvalidStockDataException(String i18nKey, Object[] args) {
+        super(formatFallback(i18nKey, args));
+        this.i18nKey = i18nKey;
+        this.args = args != null ? args.clone() : new Object[0];
     }
 
     /**
-     * Creates an exception with a descriptive message and a chained cause.
-     * Use this constructor when wrapping a lower-level exception such as a
-     * {@link java.io.IOException}.
+     * Creates an exception with an i18n key, structured arguments, and a chained cause.
      *
-     * @param message a human-readable description of the parse failure
-     * @param cause   the lower-level exception that triggered this one
+     * @param i18nKey the resource-bundle key identifying the error message template
+     * @param args    the format arguments (e.g. line number and raw content); may be null or empty
+     * @param cause   the lower-level exception that triggered this one; may be null
      */
-    public InvalidStockDataException(String message, Throwable cause) {
-        super(message, cause);
-        this.lineNumber = -1;
-        this.lineContent = null;
+    public InvalidStockDataException(String i18nKey, Object[] args, Throwable cause) {
+        super(formatFallback(i18nKey, args), cause);
+        this.i18nKey = i18nKey;
+        this.args = args != null ? args.clone() : new Object[0];
     }
 
-    /** @return the 1-based line number of the malformed entry, or -1 if not set */
-    public int getLineNumber() {
-        return lineNumber;
+    /**
+     * Returns the resource-bundle key for the error message template.
+     * Controllers pass this to {@code LanguageManager.get(key)} at display time.
+     *
+     * @return the i18n key
+     */
+    public String getI18nKey() {
+        return i18nKey;
     }
 
-    /** @return the raw text of the malformed line, or null if not set */
-    public String getLineContent() {
-        return lineContent;
+    /**
+     * Returns a defensive copy of the format arguments for the message template.
+     *
+     * @return the format arguments; never null, may be empty
+     */
+    public Object[] getArgs() {
+        return args.clone();
+    }
+
+    private static String formatFallback(String key, Object[] args) {
+        return key + (args != null && args.length > 0 ? " " + Arrays.toString(args) : "");
     }
 }

--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -38,6 +38,12 @@ error.save.load.failed=Could not load save file — it may be corrupt or from an
 error.save.load.invalidJson=Save file contains invalid JSON: {0}
 error.save.load.missingFields=Save file is missing required fields 'player' or 'exchange': {0}
 error.save.load.unreadableStructure=Save file has an unreadable structure: {0}
+error.stock.csv.invalidStockData=Invalid stock data at line {0}: "{1}"
+error.stock.csv.blankSymbol=Blank symbol at line {0}: "{1}"
+error.stock.csv.blankName=Blank company name at line {0}: "{1}"
+error.stock.csv.nonNumericPrice=Non-numeric price "{0}" at line {1}: "{2}"
+error.stock.csv.nonPositivePrice=Negative price "{0}" at line {1}: "{2}"
+error.stock.csv.emptyFile=Stock file is empty or contains no valid entries: "{0}"
 start.chooser.stock.title=Select stock file
 start.chooser.save.title=Select saved game file
 # Navbar

--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -34,6 +34,10 @@ error.capital.zero=Starting capital must be greater than zero
 error.name.too.short=Name must be at least 3 characters
 error.name.invalid=Name is invalid
 error.save.file.missing=Please select a save file
+error.save.load.failed=Could not load save file — it may be corrupt or from an older version.
+error.save.load.invalidJson=Save file contains invalid JSON: {0}
+error.save.load.missingFields=Save file is missing required fields 'player' or 'exchange': {0}
+error.save.load.unreadableStructure=Save file has an unreadable structure: {0}
 start.chooser.stock.title=Select stock file
 start.chooser.save.title=Select saved game file
 # Navbar

--- a/src/main/resources/i18n/messages_no.properties
+++ b/src/main/resources/i18n/messages_no.properties
@@ -38,6 +38,12 @@ error.save.load.failed=Kunne ikke laste lagringsfilen \u2014 den kan v\u00E6re k
 error.save.load.invalidJson=Lagringsfilen inneholder ugyldig JSON: {0}
 error.save.load.missingFields=Lagringsfilen mangler feltene 'player' og 'exchange': {0}
 error.save.load.unreadableStructure=Lagringsfilen har en uleselig struktur: {0}
+error.stock.csv.invalidStockData=Ugyldig aksjedata på linje {0}: "{1}"
+error.stock.csv.blankSymbol=Tomt symbol på linje {0}: "{1}"
+error.stock.csv.blankName=Tomt selskapsnavn på linje {0}: "{1}"
+error.stock.csv.nonNumericPrice=Ugyldig pris "{0}" på linje {1}: "{2}"
+error.stock.csv.nonPositivePrice=Negativ pris "{0}" på linje {1}: "{2}"
+error.stock.csv.emptyFile=Aksjefilen er tom eller inneholder ingen gyldige oppføringer: "{0}"
 start.chooser.stock.title=Velg aksjedatafil
 start.chooser.save.title=Velg lagringsfil
 # Navbar

--- a/src/main/resources/i18n/messages_no.properties
+++ b/src/main/resources/i18n/messages_no.properties
@@ -34,6 +34,10 @@ error.capital.zero=Startkapital må være større enn null
 error.name.too.short=Navn må være minst 3 tegn
 error.name.invalid=Navn er ugyldig
 error.save.file.missing=Vennligst velg en lagringsfil
+error.save.load.failed=Kunne ikke laste lagringsfilen \u2014 den kan v\u00E6re korrupt eller fra en eldre versjon.
+error.save.load.invalidJson=Lagringsfilen inneholder ugyldig JSON: {0}
+error.save.load.missingFields=Lagringsfilen mangler feltene 'player' og 'exchange': {0}
+error.save.load.unreadableStructure=Lagringsfilen har en uleselig struktur: {0}
 start.chooser.stock.title=Velg aksjedatafil
 start.chooser.save.title=Velg lagringsfil
 # Navbar

--- a/src/test/java/edu/ntnu/idatt2003/millions/file/game/GameSaveCorruptExceptionTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/file/game/GameSaveCorruptExceptionTest.java
@@ -12,21 +12,29 @@ import static org.junit.jupiter.api.Assertions.*;
 class GameSaveCorruptExceptionTest {
 
     @Nested
-    @DisplayName("GameSaveCorruptException(String message)")
-    class MessageConstructor {
+    @DisplayName("GameSaveCorruptException(String i18nKey, Object[] args)")
+    class NoCauseConstructor {
 
         @Test
-        @DisplayName("getMessage() returns the supplied message")
-        void messageIsPreserved() {
+        @DisplayName("getI18nKey() returns the supplied key")
+        void keyIsPreserved() {
             GameSaveCorruptException ex =
-                    new GameSaveCorruptException("save file is missing 'player' field");
-            assertEquals("save file is missing 'player' field", ex.getMessage());
+                    new GameSaveCorruptException("error.save.load.missingFields", new Object[]{"save.json"});
+            assertEquals("error.save.load.missingFields", ex.getI18nKey());
+        }
+
+        @Test
+        @DisplayName("getArgs() returns a copy of the supplied args")
+        void argsArePreserved() {
+            Object[] args = {"save.json"};
+            GameSaveCorruptException ex = new GameSaveCorruptException("some.key", args);
+            assertArrayEquals(args, ex.getArgs());
         }
 
         @Test
         @DisplayName("getCause() is null when no cause is supplied")
         void causeIsNullByDefault() {
-            GameSaveCorruptException ex = new GameSaveCorruptException("msg");
+            GameSaveCorruptException ex = new GameSaveCorruptException("some.key", new Object[0]);
             assertNull(ex.getCause());
         }
 
@@ -39,22 +47,22 @@ class GameSaveCorruptExceptionTest {
     }
 
     @Nested
-    @DisplayName("GameSaveCorruptException(String message, Throwable cause)")
+    @DisplayName("GameSaveCorruptException(String i18nKey, Object[] args, Throwable cause)")
     class ChainingConstructor {
 
         @Test
-        @DisplayName("getMessage() returns the supplied message")
-        void messageIsPreserved() {
-            GameSaveCorruptException ex =
-                    new GameSaveCorruptException("corrupt", new RuntimeException("root"));
-            assertEquals("corrupt", ex.getMessage());
+        @DisplayName("getI18nKey() returns the supplied key")
+        void keyIsPreserved() {
+            GameSaveCorruptException ex = new GameSaveCorruptException(
+                    "error.save.load.invalidJson", new Object[]{"corrupt.json"}, new RuntimeException("root"));
+            assertEquals("error.save.load.invalidJson", ex.getI18nKey());
         }
 
         @Test
         @DisplayName("getCause() returns the supplied cause")
         void causeIsPreserved() {
             RuntimeException root = new RuntimeException("root");
-            GameSaveCorruptException ex = new GameSaveCorruptException("msg", root);
+            GameSaveCorruptException ex = new GameSaveCorruptException("some.key", new Object[0], root);
             assertSame(root, ex.getCause());
         }
     }

--- a/src/test/java/edu/ntnu/idatt2003/millions/file/stock/CsvStockFileHandlerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/file/stock/CsvStockFileHandlerTest.java
@@ -128,7 +128,7 @@ class CsvStockFileHandlerTest {
             InvalidStockDataException ex = assertThrows(InvalidStockDataException.class,
                     () -> handler.readStocks(stream));
             // Assert — line 3 in the file is the bad one
-            assertEquals(3, ex.getLineNumber());
+            assertEquals(3, ex.getArgs()[0]);
         }
 
         @Test
@@ -326,7 +326,7 @@ class CsvStockFileHandlerTest {
             InvalidStockDataException ex = assertThrows(InvalidStockDataException.class,
                     () -> handler.readStocks(stream));
             // Assert
-            assertTrue(ex.getMessage().contains("blank symbol"));
+            assertEquals("error.stock.csv.blankSymbol", ex.getI18nKey());
         }
 
         @Test
@@ -339,7 +339,7 @@ class CsvStockFileHandlerTest {
             InvalidStockDataException ex = assertThrows(InvalidStockDataException.class,
                     () -> handler.readStocks(stream));
             // Assert
-            assertTrue(ex.getMessage().contains("blank name"));
+            assertEquals("error.stock.csv.blankName", ex.getI18nKey());
         }
 
         @Test
@@ -352,7 +352,7 @@ class CsvStockFileHandlerTest {
             InvalidStockDataException ex = assertThrows(InvalidStockDataException.class,
                     () -> handler.readStocks(stream));
             // Assert
-            assertTrue(ex.getMessage().contains("non-positive price"));
+            assertEquals("error.stock.csv.nonPositivePrice", ex.getI18nKey());
         }
 
         @Test
@@ -365,7 +365,7 @@ class CsvStockFileHandlerTest {
             InvalidStockDataException ex = assertThrows(InvalidStockDataException.class,
                     () -> handler.readStocks(stream));
             // Assert
-            assertTrue(ex.getMessage().contains("non-positive price"));
+            assertEquals("error.stock.csv.nonPositivePrice", ex.getI18nKey());
         }
 
         @Test
@@ -378,7 +378,7 @@ class CsvStockFileHandlerTest {
             InvalidStockDataException ex = assertThrows(InvalidStockDataException.class,
                     () -> handler.readStocks(stream));
             // Assert
-            assertEquals(2, ex.getLineNumber());
+            assertEquals(2, ex.getArgs()[0]);
         }
 
         @Test

--- a/src/test/java/edu/ntnu/idatt2003/millions/file/stock/EmptyStockFileExceptionTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/file/stock/EmptyStockFileExceptionTest.java
@@ -90,25 +90,25 @@ class EmptyStockFileExceptionTest {
     }
 
     @Nested
-    @DisplayName("Inherited fields from InvalidStockDataException")
-    class InheritedFields {
+    @DisplayName("i18n key and args")
+    class I18nPayload {
 
         @Test
-        @DisplayName("getLineNumber() is -1 since the error is file-level, not line-level")
-        void lineNumberIsMinusOne() {
+        @DisplayName("getI18nKey() returns the empty-file key")
+        void i18nKeyIsCorrect() {
             // Arrange & Act
             EmptyStockFileException ex = new EmptyStockFileException("/data/stocks.csv");
             // Assert
-            assertEquals(-1, ex.getLineNumber());
+            assertEquals("error.stock.csv.emptyFile", ex.getI18nKey());
         }
 
         @Test
-        @DisplayName("getLineContent() is null since the error is file-level, not line-level")
-        void lineContentIsNull() {
+        @DisplayName("getArgs()[0] is the supplied file path")
+        void argsContainFilePath() {
             // Arrange & Act
             EmptyStockFileException ex = new EmptyStockFileException("/data/stocks.csv");
             // Assert
-            assertNull(ex.getLineContent());
+            assertEquals("/data/stocks.csv", ex.getArgs()[0]);
         }
     }
 }

--- a/src/test/java/edu/ntnu/idatt2003/millions/file/stock/InvalidStockDataExceptionTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/file/stock/InvalidStockDataExceptionTest.java
@@ -12,177 +12,128 @@ import static org.junit.jupiter.api.Assertions.*;
 class InvalidStockDataExceptionTest {
 
     @Nested
-    @DisplayName("InvalidStockDataException(int lineNumber, String lineContent)")
-    class PayloadConstructor {
+    @DisplayName("InvalidStockDataException(String i18nKey, Object[] args)")
+    class NoCauseConstructor {
 
         @Test
-        @DisplayName("getLineNumber() returns the supplied line number")
-        void lineNumberIsPreserved() {
-            // Arrange & Act
-            InvalidStockDataException ex = new InvalidStockDataException(5, "AAPL,Apple,abc");
-            // Assert
-            assertEquals(5, ex.getLineNumber());
+        @DisplayName("getI18nKey() returns the supplied key")
+        void i18nKeyIsPreserved() {
+            InvalidStockDataException ex =
+                    new InvalidStockDataException("error.stock.csv.invalidStockData", new Object[]{5, "AAPL,Apple,abc"});
+            assertEquals("error.stock.csv.invalidStockData", ex.getI18nKey());
         }
 
         @Test
-        @DisplayName("getLineContent() returns the supplied line content")
-        void lineContentIsPreserved() {
-            // Arrange & Act
-            InvalidStockDataException ex = new InvalidStockDataException(5, "AAPL,Apple,abc");
-            // Assert
-            assertEquals("AAPL,Apple,abc", ex.getLineContent());
+        @DisplayName("getArgs() returns a copy with the supplied arguments")
+        void argsArePreserved() {
+            InvalidStockDataException ex =
+                    new InvalidStockDataException("error.stock.csv.blankSymbol", new Object[]{3, ",Apple,100"});
+            Object[] args = ex.getArgs();
+            assertEquals(3, args[0]);
+            assertEquals(",Apple,100", args[1]);
         }
 
         @Test
-        @DisplayName("message contains the line number")
-        void messageContainsLineNumber() {
-            // Arrange & Act
-            InvalidStockDataException ex = new InvalidStockDataException(5, "AAPL,Apple,abc");
-            // Assert
-            assertTrue(ex.getMessage().contains("5"),
-                    "message should contain the line number");
+        @DisplayName("getArgs() returns a defensive copy — mutating it does not affect stored args")
+        void argsAreDefensiveCopy() {
+            InvalidStockDataException ex =
+                    new InvalidStockDataException("error.stock.csv.blankSymbol", new Object[]{3, ",Apple,100"});
+            Object[] copy = ex.getArgs();
+            copy[0] = 999;
+            assertEquals(3, ex.getArgs()[0]);
         }
 
         @Test
-        @DisplayName("message contains the line content")
-        void messageContainsLineContent() {
-            // Arrange & Act
-            InvalidStockDataException ex = new InvalidStockDataException(5, "AAPL,Apple,abc");
-            // Assert
-            assertTrue(ex.getMessage().contains("AAPL,Apple,abc"),
-                    "message should contain the raw line content");
+        @DisplayName("null args treated as empty — getArgs() returns empty array")
+        void nullArgsBecomesEmpty() {
+            InvalidStockDataException ex =
+                    new InvalidStockDataException("error.stock.csv.invalidStockData", null);
+            assertEquals(0, ex.getArgs().length);
         }
 
         @Test
-        @DisplayName("getLineNumber() returns 1 for the first line")
-        void lineNumberOneIsPreserved() {
-            // Arrange & Act
-            InvalidStockDataException ex = new InvalidStockDataException(1, "BAD");
-            // Assert
-            assertEquals(1, ex.getLineNumber());
+        @DisplayName("getMessage() contains the key when args are empty")
+        void messageContainsKeyWhenNoArgs() {
+            InvalidStockDataException ex =
+                    new InvalidStockDataException("error.stock.csv.invalidStockData", null);
+            assertTrue(ex.getMessage().contains("error.stock.csv.invalidStockData"));
+        }
+
+        @Test
+        @DisplayName("getMessage() contains key and args in fallback form")
+        void messageContainsKeyAndArgs() {
+            InvalidStockDataException ex =
+                    new InvalidStockDataException("error.stock.csv.blankSymbol", new Object[]{5, "AAPL,Apple,abc"});
+            assertTrue(ex.getMessage().contains("error.stock.csv.blankSymbol"));
+            assertTrue(ex.getMessage().contains("5"));
+            assertTrue(ex.getMessage().contains("AAPL,Apple,abc"));
+        }
+
+        @Test
+        @DisplayName("getCause() is null")
+        void causeIsNull() {
+            InvalidStockDataException ex =
+                    new InvalidStockDataException("error.stock.csv.blankName", new Object[]{1, "BAD"});
+            assertNull(ex.getCause());
         }
 
         @Test
         @DisplayName("is a checked exception")
         void isChecked() {
-            // Arrange & Act & Assert
             assertTrue(Exception.class.isAssignableFrom(InvalidStockDataException.class));
             assertFalse(RuntimeException.class.isAssignableFrom(InvalidStockDataException.class));
         }
     }
 
     @Nested
-    @DisplayName("InvalidStockDataException(int lineNumber, String lineContent, String reason)")
-    class ReasonConstructor {
+    @DisplayName("InvalidStockDataException(String i18nKey, Object[] args, Throwable cause)")
+    class CauseConstructor {
 
         @Test
-        @DisplayName("getLineNumber() returns the supplied line number")
-        void lineNumberIsPreserved() {
-            // Arrange & Act
-            InvalidStockDataException ex = new InvalidStockDataException(3, ",Apple,100", "blank symbol");
-            // Assert
-            assertEquals(3, ex.getLineNumber());
-        }
-
-        @Test
-        @DisplayName("getLineContent() returns the supplied line content")
-        void lineContentIsPreserved() {
-            // Arrange & Act
-            InvalidStockDataException ex = new InvalidStockDataException(3, ",Apple,100", "blank symbol");
-            // Assert
-            assertEquals(",Apple,100", ex.getLineContent());
-        }
-
-        @Test
-        @DisplayName("message contains the reason")
-        void messageContainsReason() {
-            // Arrange & Act
-            InvalidStockDataException ex = new InvalidStockDataException(3, ",Apple,100", "blank symbol");
-            // Assert
-            assertTrue(ex.getMessage().contains("blank symbol"));
-        }
-
-        @Test
-        @DisplayName("message contains the line number")
-        void messageContainsLineNumber() {
-            // Arrange & Act
-            InvalidStockDataException ex = new InvalidStockDataException(3, ",Apple,100", "blank symbol");
-            // Assert
-            assertTrue(ex.getMessage().contains("3"));
-        }
-
-        @Test
-        @DisplayName("message contains the line content")
-        void messageContainsLineContent() {
-            // Arrange & Act
-            InvalidStockDataException ex = new InvalidStockDataException(3, ",Apple,100", "blank symbol");
-            // Assert
-            assertTrue(ex.getMessage().contains(",Apple,100"));
-        }
-
-        @Test
-        @DisplayName("message contains reason when reason describes a non-positive price")
-        void messageContainsNonPositivePriceReason() {
-            // Arrange & Act
-            InvalidStockDataException ex = new InvalidStockDataException(
-                    7, "AAPL,Apple,-5", "non-positive price \"-5\"");
-            // Assert
-            assertTrue(ex.getMessage().contains("non-positive price"));
-        }
-
-        @Test
-        @DisplayName("message still contains line number and content when reason is empty")
-        void emptyReasonStillIncludesLineContext() {
-            // Arrange & Act
-            InvalidStockDataException ex = new InvalidStockDataException(2, "MSFT,Microsoft,0", "");
-            // Assert
-            assertTrue(ex.getMessage().contains("2"));
-            assertTrue(ex.getMessage().contains("MSFT,Microsoft,0"));
-        }
-    }
-
-    @Nested
-    @DisplayName("InvalidStockDataException(String message, Throwable cause)")
-    class ChainingConstructor {
-
-        @Test
-        @DisplayName("getMessage() returns the supplied message")
-        void messageIsPreserved() {
-            // Arrange & Act
+        @DisplayName("getI18nKey() returns the supplied key")
+        void i18nKeyIsPreserved() {
             InvalidStockDataException ex =
-                    new InvalidStockDataException("custom message", null);
-            // Assert
-            assertEquals("custom message", ex.getMessage());
+                    new InvalidStockDataException("error.stock.csv.nonPositivePrice",
+                            new Object[]{"-5", 7, "AAPL,Apple,-5"}, null);
+            assertEquals("error.stock.csv.nonPositivePrice", ex.getI18nKey());
+        }
+
+        @Test
+        @DisplayName("getArgs() returns the supplied arguments")
+        void argsArePreserved() {
+            InvalidStockDataException ex =
+                    new InvalidStockDataException("error.stock.csv.nonPositivePrice",
+                            new Object[]{"-5", 7, "AAPL,Apple,-5"}, null);
+            Object[] args = ex.getArgs();
+            assertEquals("-5", args[0]);
+            assertEquals(7, args[1]);
+            assertEquals("AAPL,Apple,-5", args[2]);
         }
 
         @Test
         @DisplayName("getCause() returns the supplied cause")
         void causeIsPreserved() {
-            // Arrange
             RuntimeException root = new RuntimeException("root");
-            // Act
-            InvalidStockDataException ex = new InvalidStockDataException("msg", root);
-            // Assert
+            InvalidStockDataException ex =
+                    new InvalidStockDataException("error.stock.csv.nonNumericPrice",
+                            new Object[]{"abc", 3, "AAPL,Apple,abc"}, root);
             assertSame(root, ex.getCause());
         }
 
         @Test
         @DisplayName("getCause() is null when no cause is supplied")
         void causeIsNullWhenNotSupplied() {
-            // Arrange & Act
-            InvalidStockDataException ex = new InvalidStockDataException("msg", null);
-            // Assert
+            InvalidStockDataException ex =
+                    new InvalidStockDataException("error.stock.csv.blankSymbol", new Object[]{1, "BAD"}, null);
             assertNull(ex.getCause());
         }
 
         @Test
-        @DisplayName("getLineNumber() is -1 and getLineContent() is null for chaining constructor")
-        void payloadIsDefaultForChainingConstructor() {
-            // Arrange & Act
-            InvalidStockDataException ex = new InvalidStockDataException("msg", null);
-            // Assert
-            assertEquals(-1, ex.getLineNumber());
-            assertNull(ex.getLineContent());
+        @DisplayName("null args treated as empty")
+        void nullArgsBecomesEmpty() {
+            InvalidStockDataException ex =
+                    new InvalidStockDataException("error.stock.csv.emptyFile", null, null);
+            assertEquals(0, ex.getArgs().length);
         }
     }
 }


### PR DESCRIPTION
Three connected commits fixing file-load error handling
end-to-end: errors now surface to the user instead of
failing silently, messages appear in the correct language,
and the displayed message updates live if the user
switches language.

## What this PR changes

### 1. Surface silent load failures
Loading an incompatible save file could fail silently
because TransactionAdapterFactory.read() threw NullPointer
Exception when a transaction's "type" field was missing.
Gson doesn't wrap NPEs from TypeAdapters in JsonParse
Exception, so the NPE escaped parsing and was not caught
by StartController's typed-exception catch list. The user
saw no error at all.

- TransactionAdapterFactory now throws JsonParseException
  for missing "type", letting the existing GameSaveCorrupt
  Exception wrapping take effect.
- StartController.runOrShowError gains a fallback catch
  for any unanticipated Exception so the user always
  gets feedback.
- Dead null-check in relinkArchive removed (Exchange.
  getStock never returns null — it throws).

### 2. Localize save-load error messages
GameSaveCorruptException's hardcoded English message was
displayed even in Norwegian UI. The exception was thrown
with a pre-resolved string, which violated SoC
(JsonGameFileHandler is the file/infrastructure layer and
shouldn't know about presentation) and froze the message
in the language it was thrown in.

- GameSaveCorruptException now carries (i18nKey, args[])
  instead of a resolved String.
- JsonGameFileHandler no longer references
  LanguageManager.
- StartController resolves at display time via the
  Supplier-based reactive mechanism already in FileDropTab.
  Switching language updates a visible error message live.

### 3. Localize stock-CSV error messages
The same problem existed on the Nytt-spill tab for CSV
upload errors. Migrated identically:

- InvalidStockDataException and EmptyStockFileException
  now carry (i18nKey, args[]).
- CsvStockFileHandler no longer references
  LanguageManager.
- StartController catches each exception separately and
  resolves through the same shared mechanism.

Six new i18n keys cover the five throw sites in
InvalidStockDataException plus the empty-file case. Tests
that asserted on English substring matches were rewritten
to assert on getI18nKey() and getArgs() directly — they
are now contract-checks rather than string-substring-
checks.

The lineNumber and lineContent fields on
InvalidStockDataException were removed; all payload lives
in args[] for consistency with GameSaveCorruptException.

## What is NOT in this PR (deferred)

- A common LocalizedException base class or interface
  shared by both exception types. Two parallel
  implementations now; we'll extract if time.
- A fix for the deferred-wrapping animation bug where
  feedbackLabel shows ellipsis on first render until the
  user moves the mouse or switches language, triggering a
  scene layout pass. The error IS displayed; it just
  truncates on first render.
