### PR TITLE
Feat/open detail from row and chevron

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/card/DetailTableCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/card/DetailTableCard.java
@@ -1,0 +1,68 @@
+package edu.ntnu.idatt2003.millions.view.component.card;
+
+import edu.ntnu.idatt2003.millions.controller.TradeController;
+import edu.ntnu.idatt2003.millions.service.GameService;
+
+/**
+ * Abstract base for sortable table cards that open a detail view when a row is activated.
+ *
+ * <p>Extends {@link SortableTableCard} and adds a {@link TradeController} field shared by
+ * all concrete subclasses.</p>
+ *
+ * <p>Concrete subclasses:</p>
+ * <ul>
+ *   <li>{@code HoldingsCard} opens the share detail modal for a {@code Share}</li>
+ *   <li>{@code StocksCard} opens the stock detail modal for a {@code Stock}</li>
+ *   <li>{@code WatchlistCard}opens the stock detail modal for a {@code WatchlistItem}</li>
+ * </ul>
+ *
+ * @param <T>      the item type displayed in the table rows
+ * @param <Column> the sort-column enum type
+ */
+public abstract class DetailTableCard<T, Column> extends SortableTableCard<T, Column> {
+
+    /**
+     * The controller used to open detail and trade dialogs.
+     * Accessible to subclasses for wiring chevron buttons and action callbacks.
+     */
+    protected final TradeController controller;
+
+    /**
+     * Constructs a detail table card.
+     *
+     * @param gameService   the game service to observe
+     * @param controller    the controller used to open detail and trade dialogs
+     * @param pageSize      the number of items shown per page
+     * @param statusKey     i18n key for the metadata-row status pattern;
+     *                      must accept two positional arguments (filtered count, total count)
+     * @param emptyStateKey i18n key for the default empty-state message
+     */
+    protected DetailTableCard(
+            GameService gameService,
+            TradeController controller,
+            int pageSize,
+            String statusKey,
+            String emptyStateKey) {
+        super(gameService, pageSize, statusKey, emptyStateKey);
+        this.controller = controller;
+    }
+
+    /**
+     * Sealed activation hook: always delegates to {@link #openDetail(Object)}.
+     * Subclasses must not override this method; override {@link #openDetail(Object)} instead.
+     *
+     * @param item the item whose row was confirmed by keyboard or mouse
+     */
+    @Override
+    protected final void onRowEnter(T item) {
+        openDetail(item);
+    }
+
+    /**
+     * Opens the detail view for the given item.
+     * Called whenever the user activates a row (Enter, Space, or click on a data cell).
+     *
+     * @param item the item to show details for
+     */
+    protected abstract void openDetail(T item);
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/card/DetailTableCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/card/DetailTableCard.java
@@ -2,6 +2,7 @@ package edu.ntnu.idatt2003.millions.view.component.card;
 
 import edu.ntnu.idatt2003.millions.controller.TradeController;
 import edu.ntnu.idatt2003.millions.service.GameService;
+import edu.ntnu.idatt2003.millions.view.component.ChevronButton;
 
 /**
  * Abstract base for sortable table cards that open a detail view when a row is activated.
@@ -65,4 +66,28 @@ public abstract class DetailTableCard<T, Column> extends SortableTableCard<T, Co
      * @param item the item to show details for
      */
     protected abstract void openDetail(T item);
+
+    /**
+     * Returns the i18n key for the chevron button tooltip.
+     *
+     * @return the tooltip i18n key
+     */
+    protected String chevronTooltipKey() {
+        return "tooltip.stocks.chevron";
+    }
+
+    /**
+     * Builds a {@link ChevronButton} that opens the detail view for the given item.
+     *
+     * <p>The button delegates to {@link #openDetail(Object)} and uses the tooltip key
+     * returned by {@link #chevronTooltipKey()}. Intended to be placed in the
+     * {@code DETAILS} column of {@link edu.ntnu.idatt2003.millions.view.component.table.RowCells}
+     * by concrete subclasses.</p>
+     *
+     * @param item the item to open the detail view for
+     * @return a configured {@link ChevronButton}
+     */
+    protected final ChevronButton buildDetailChevron(T item) {
+        return new ChevronButton(() -> openDetail(item), chevronTooltipKey());
+    }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/card/PaginatedCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/card/PaginatedCard.java
@@ -1,6 +1,7 @@
 package edu.ntnu.idatt2003.millions.view.component.card;
 
 import edu.ntnu.idatt2003.millions.service.GameService;
+import edu.ntnu.idatt2003.millions.view.component.Pagination;
 
 /**
  * Abstract base class for paginated card components.
@@ -36,8 +37,7 @@ public abstract class PaginatedCard extends Card {
 
     /**
      * Navigates to the given page and refreshes the table.
-     * Called by {@link edu.ntnu.idatt2003.millions.view.component.Pagination}
-     * when the user clicks Prev or Next.
+     * Called by {@link Pagination} when the user clicks Prev or Next.
      *
      * @param page the zero-based page index to navigate to
      */

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/card/SortableTableCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/card/SortableTableCard.java
@@ -26,12 +26,6 @@ import java.util.function.Consumer;
  * Template Method. Row rendering is a second Template Method so
  * subclasses describe only what a row contains, not how it is inserted or navigated.</p>
  *
- * <p>{@link #table}, {@link #pagination} and {@link #sortProvider} must be assigned
- * by the subclass constructor after {@code super()}, since all three depend on a sort
- * object that cannot exist earlier. The {@code statusKey} and {@code emptyStateKey}
- * i18n keys are supplied at construction; override {@link #emptyStateMessage} when a
- * plain key lookup is not enough.</p>
- *
  * @param <T>      the item type displayed in the table rows
  * @param <Column> the sort-column enum type
  */

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/table/RowCells.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/table/RowCells.java
@@ -1,6 +1,8 @@
 package edu.ntnu.idatt2003.millions.view.component.table;
 
 import javafx.scene.Node;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -56,6 +58,20 @@ public final class RowCells<Column> {
      */
     Node get(Column column) {
         return cells.get(column);
+    }
+
+    /**
+     * Returns an unmodifiable view of all nodes in insertion order.
+     *
+     * <p>Used by {@link SortColumnTable} to wire {@code MOUSE_CLICKED} handlers
+     * on non-{@link javafx.scene.control.ButtonBase} nodes so that clicking anywhere
+     * on a data row activates the row's action without conflicting with interactive
+     * cell controls.</p>
+     *
+     * @return an unmodifiable collection of all nodes in this row, in insertion order
+     */
+    Collection<Node> nodes() {
+        return Collections.unmodifiableCollection(cells.values());
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/component/table/SortColumnTable.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/component/table/SortColumnTable.java
@@ -7,8 +7,10 @@ import edu.ntnu.idatt2003.millions.util.SortState;
 import edu.ntnu.idatt2003.millions.util.TableCells;
 import javafx.scene.Node;
 import javafx.scene.control.Button;
+import javafx.scene.control.ButtonBase;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
+import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
 import javafx.geometry.VPos;
 import javafx.scene.layout.ColumnConstraints;
@@ -168,16 +170,33 @@ public class SortColumnTable<Column> {
     }
 
     /**
-     * Adds a {@link RowCells}-based data row and makes it keyboard-reachable.
+     * Adds a {@link RowCells}-based data row and makes it keyboard- and mouse-reachable.
+     *
+     * <p>After inserting the row and wiring the keyboard handlers, iterates all nodes
+     * in {@code cells} and attaches a {@code MOUSE_CLICKED} handler to every node that
+     * is not a {@link ButtonBase}. This lets the user open the detail view by clicking
+     * anywhere on a data cell, while interactive controls (buttons, checkboxes) keep their
+     * own click behaviour unchanged — {@link ButtonBase} already consumes
+     * {@code MOUSE_CLICKED} before it bubbles, so no double-firing occurs on those.</p>
      *
      * @param gridRow     the grid row to write to (row 0 is reserved for the header)
      * @param focusAnchor the node focused when this row is reached
-     * @param onEnter     action invoked on Enter or Space
+     * @param onEnter     action invoked on Enter, Space, or a primary click on a data cell
      * @param cells       the column-keyed cells from {@link RowCells#builder()}
      */
     public void addSelectableRow(int gridRow, Node focusAnchor, Runnable onEnter, RowCells<Column> cells) {
         addRow(gridRow, cells);
         registerSelectableRow(gridRow, focusAnchor, onEnter);
+        for (Node node : cells.nodes()) {
+            if (!(node instanceof ButtonBase)) {
+                node.addEventHandler(MouseEvent.MOUSE_CLICKED, e -> {
+                    if (e.getButton() == MouseButton.PRIMARY) {
+                        onEnter.run();
+                        e.consume();
+                    }
+                });
+            }
+        }
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/HoldingsCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/HoldingsCard.java
@@ -12,7 +12,7 @@ import edu.ntnu.idatt2003.millions.util.TableCells;
 import edu.ntnu.idatt2003.millions.view.component.ChevronButton;
 import edu.ntnu.idatt2003.millions.view.component.Pagination;
 import edu.ntnu.idatt2003.millions.view.component.StyledText;
-import edu.ntnu.idatt2003.millions.view.component.card.SortableTableCard;
+import edu.ntnu.idatt2003.millions.view.component.card.DetailTableCard;
 import edu.ntnu.idatt2003.millions.view.component.table.RowCells;
 import edu.ntnu.idatt2003.millions.view.component.table.SortColumnTable;
 import edu.ntnu.idatt2003.millions.view.component.table.TableTotalRow;
@@ -34,19 +34,19 @@ import java.util.List;
  * headers, search, pagination, action buttons for buy / sell / sell all / details,
  * and a persistent total row below the pagination.
  *
- * <p>Extends {@link SortableTableCard} for shared pagination, search, sort state,
- * and the common refresh Template Method. The total row is a {@link TableTotalRow}
+ * <p>Extends {@link DetailTableCard} for shared pagination, search, sort state,
+ * the common refresh Template Method, and row-activation routing to
+ * {@link #openDetail(Share)}. The total row is a {@link TableTotalRow}
  * sharing the table's column constraints, so values align regardless of which page is
  * active. The {@link #afterFilter} hook is overridden to update the total row's
  * visibility and values after each filter pass.</p>
  */
-public class HoldingsCard extends SortableTableCard<Share, HoldingsSort.SortColumn> {
+public class HoldingsCard extends DetailTableCard<Share, HoldingsSort.SortColumn> {
 
     private static final int PAGE_SIZE = 9;
 
     private final GameService gameService;
     private final PortfolioService portfolioService;
-    private final TradeController controller;
     private final HoldingsSort sort;
     private final TableTotalRow<HoldingsSort.SortColumn> totalRow;
 
@@ -59,10 +59,9 @@ public class HoldingsCard extends SortableTableCard<Share, HoldingsSort.SortColu
      */
     public HoldingsCard(GameService gameService, TradeController controller,
                         PortfolioService portfolioService) {
-        super(gameService, PAGE_SIZE,
+        super(gameService, controller, PAGE_SIZE,
                 "dashboard.portfolio.holdings.status", "dashboard.portfolio.empty");
         this.gameService = gameService;
-        this.controller = controller;
         this.portfolioService = portfolioService;
         this.sort = new HoldingsSort(portfolioService, gameService.getCurrencyConverter());
         this.sortProvider = sort;
@@ -138,12 +137,13 @@ public class HoldingsCard extends SortableTableCard<Share, HoldingsSort.SortColu
     }
 
     /**
-     * Opens the share details modal when the user presses Enter on a row.
+     * Opens the share details modal for the given share position. Whenever the user
+     * activates a row via keyboard or mouse click on a data cell.
      *
-     * @param item the share whose row was confirmed
+     * @param item the share to show details for
      */
     @Override
-    protected void onRowEnter(Share item) {
+    protected void openDetail(Share item) {
         controller.openDetailsModal(item);
     }
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/HoldingsCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/portfolio/card/HoldingsCard.java
@@ -9,7 +9,6 @@ import edu.ntnu.idatt2003.millions.util.ChangeFormatter;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
 import edu.ntnu.idatt2003.millions.util.MoneyFormatter;
 import edu.ntnu.idatt2003.millions.util.TableCells;
-import edu.ntnu.idatt2003.millions.view.component.ChevronButton;
 import edu.ntnu.idatt2003.millions.view.component.Pagination;
 import edu.ntnu.idatt2003.millions.view.component.StyledText;
 import edu.ntnu.idatt2003.millions.view.component.card.DetailTableCard;
@@ -118,7 +117,7 @@ public class HoldingsCard extends DetailTableCard<Share, HoldingsSort.SortColumn
     protected RowCells<HoldingsSort.SortColumn> buildRowCells(Share item, int rowIndex) {
         Stock stock = item.getStock();
         return RowCells.<HoldingsSort.SortColumn>builder()
-                .put(HoldingsSort.SortColumn.DETAILS, buildDetailsButton(item))
+                .put(HoldingsSort.SortColumn.DETAILS, buildDetailChevron(item))
                 .put(HoldingsSort.SortColumn.ACTIONS, buildActionButtons(item))
                 .put(HoldingsSort.SortColumn.COMPANY,
                         TableCells.data(stock.getSymbol() + ", " + stock.getCompany()))
@@ -229,13 +228,13 @@ public class HoldingsCard extends DetailTableCard<Share, HoldingsSort.SortColumn
     }
 
     /**
-     * Builds the details navigation button for a share row.
+     * Returns the i18n key for the holdings chevron tooltip.
      *
-     * @param share the share to open details for
-     * @return a styled {@link ChevronButton} that opens the share detail modal
+     * @return {@code "tooltip.holdings.chevron"}
      */
-    private ChevronButton buildDetailsButton(Share share) {
-        return new ChevronButton(() -> controller.openDetailsModal(share), "tooltip.holdings.chevron");
+    @Override
+    protected String chevronTooltipKey() {
+        return "tooltip.holdings.chevron";
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/watchlist/WatchlistCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/watchlist/WatchlistCard.java
@@ -2,12 +2,11 @@ package edu.ntnu.idatt2003.millions.view.dashboard.watchlist;
 
 import edu.ntnu.idatt2003.millions.controller.TradeController;
 import edu.ntnu.idatt2003.millions.model.stock.Stock;
-import edu.ntnu.idatt2003.millions.model.watchlist.WatchlistEntry;
 import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
 import edu.ntnu.idatt2003.millions.view.component.Pagination;
 import edu.ntnu.idatt2003.millions.view.component.StyledText;
-import edu.ntnu.idatt2003.millions.view.component.card.SortableTableCard;
+import edu.ntnu.idatt2003.millions.view.component.card.DetailTableCard;
 import edu.ntnu.idatt2003.millions.view.component.table.RowCells;
 import edu.ntnu.idatt2003.millions.view.component.table.SortColumnTable;
 import javafx.geometry.Pos;
@@ -23,12 +22,10 @@ import java.util.stream.Collectors;
 /**
  * Card displaying the player's watchlist as a sortable, searchable, paginated table.
  *
- * <p>Extends {@link SortableTableCard} for shared pagination, search, sort state,
- * and the common refresh Template Method. Row rendering is delegated to
- * {@link WatchlistRowRenderer}. The header row contains the section title on the
- * left and an explore-stocks button on the right.</p>
+ * <p>Extends {@link DetailTableCard} for shared pagination, search, sort state,
+ * the common refresh Template Method, and row-activation. </p>
  */
-public class WatchlistCard extends SortableTableCard<WatchlistItem, WatchlistSort.SortColumn> {
+public class WatchlistCard extends DetailTableCard<WatchlistItem, WatchlistSort.SortColumn> {
 
     private static final int PAGE_SIZE = 8;
     private static final double COL_GAP = 8;
@@ -41,17 +38,17 @@ public class WatchlistCard extends SortableTableCard<WatchlistItem, WatchlistSor
      * Constructs a new WatchlistCard.
      *
      * @param gameService     the game service containing player and exchange state
-     * @param tradeController the controller used to open buy dialogs
+     * @param tradeController the controller used to open buy and detail dialogs
      */
     public WatchlistCard(GameService gameService,
                          TradeController tradeController) {
-        super(gameService, PAGE_SIZE, "watchlist.status", "watchlist.empty");
+        super(gameService, tradeController, PAGE_SIZE, "watchlist.status", "watchlist.empty");
         this.gameService = gameService;
 
         WatchlistSort sort = new WatchlistSort(gameService.getCurrencyConverter());
         this.sortProvider = sort;
         this.rowRenderer = new WatchlistRowRenderer(
-                gameService, tradeController,
+                gameService, controller,
                 gameService::removeFromWatchlist,
                 this::openNoteDialog);
         this.table = new SortColumnTable<>(sort::getColumnDefs, COL_GAP);
@@ -98,7 +95,8 @@ public class WatchlistCard extends SortableTableCard<WatchlistItem, WatchlistSor
 
     @Override
     protected RowCells<WatchlistSort.SortColumn> buildRowCells(WatchlistItem item, int rowIndex) {
-        return rowRenderer.buildRow(item);
+        return rowRenderer.buildRow(item)
+                .put(WatchlistSort.SortColumn.DETAILS, buildDetailChevron(item));
     }
 
     @Override
@@ -107,6 +105,17 @@ public class WatchlistCard extends SortableTableCard<WatchlistItem, WatchlistSor
             return MessageFormat.format(LanguageManager.get("watchlist.empty.search"), term);
         }
         return LanguageManager.get("watchlist.empty");
+    }
+
+    /**
+     * Opens the stock detail modal for the given watchlist item. Whenever the user
+     * activates a row via keyboard or mouse click on a data cell.
+     *
+     * @param item the watchlist item whose stock to show details for
+     */
+    @Override
+    protected void openDetail(WatchlistItem item) {
+        controller.openStockDetail(item.stock());
     }
 
     @Override

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/watchlist/WatchlistRowRenderer.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/watchlist/WatchlistRowRenderer.java
@@ -27,8 +27,9 @@ import java.util.function.Consumer;
  *
  * <p>Each call to {@link #buildRow(WatchlistItem)} produces a {@link RowCells} map with
  * ticker, company, price in NOK, price in the stock's native currency, weekly change
- * (NOK and %), 4-week high/low, a sparkline trend, a buy button, a note button, and a
- * remove button. The owning card inserts the cells and registers the row for navigation.</p>
+ * (NOK and %), 4-week high/low, a sparkline trend, a buy button, a note button, a
+ * chevron button detail link, and a remove button.
+ * The owning card inserts the cells and registers the row for navigation.</p>
  *
  * <p>This class is stateless and may be reused across refreshes.</p>
  */
@@ -44,6 +45,8 @@ class WatchlistRowRenderer extends RowRenderer {
     private final Consumer<WatchlistItem> onNote;
 
     /**
+     * Constructs a new WatchlistRowRenderer.
+     *
      * @param gameService     the game service used to read converter and game-over state
      * @param tradeController the controller used to open the buy dialog
      * @param onRemove        callback invoked with the stock symbol when the player clicks ×
@@ -61,10 +64,6 @@ class WatchlistRowRenderer extends RowRenderer {
 
     /**
      * Builds the column-keyed cells for the given watchlist item.
-     *
-     * <p>The note button is inserted first so it serves as the row's default
-     * keyboard-focus anchor (see {@link RowCells#firstNode()}); unlike the buy
-     * button it is never disabled when the game is over.</p>
      *
      * @param item the watchlist item to render
      * @return the column-keyed cells for this item, keyed by {@link WatchlistSort.SortColumn}

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/watchlist/WatchlistSort.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/dashboard/watchlist/WatchlistSort.java
@@ -25,14 +25,10 @@ class WatchlistSort extends SortProvider<WatchlistItem, WatchlistSort.SortColumn
 
     /**
      * All columns in the watchlist table.
-     * TICKER, COMPANY, CURRENCY, PRICE_ALT, PRICE_NOK, CHANGE_NOK, CHANGE_PCT and
-     * HIGH_LOW are sortable; TREND, TRADE, NOTE and REMOVE are non-sortable and
-     * exist only as structural keys for
-     * {@link edu.ntnu.idatt2003.millions.view.component.table.RowCells}.
      */
     enum SortColumn {
         TICKER, COMPANY, CURRENCY, PRICE_ALT, PRICE_NOK, CHANGE_NOK, CHANGE_PCT, HIGH_LOW,
-        TREND, TRADE, NOTE, REMOVE
+        TREND, TRADE, NOTE, DETAILS, REMOVE
     }
 
     private final StockStatsService statsService = new StockStatsService();
@@ -77,16 +73,13 @@ class WatchlistSort extends SortProvider<WatchlistItem, WatchlistSort.SortColumn
                         "tooltip.shared.trend", 12, HPos.CENTER),
                 TableColumnDef.nonSortable(SortColumn.TRADE, "col.trade", 7, HPos.CENTER),
                 TableColumnDef.nonSortable(SortColumn.NOTE, "col.note", 7, HPos.CENTER),
+                TableColumnDef.nonSortable(SortColumn.DETAILS, "col.details", 5, HPos.CENTER),
                 TableColumnDef.spacer(SortColumn.REMOVE, 3, HPos.CENTER)
         );
     }
 
     /**
      * Builds a {@link Comparator} for the given sort column.
-     * {@link SortColumn#TREND}, {@link SortColumn#TRADE}, {@link SortColumn#NOTE}
-     * and {@link SortColumn#REMOVE} are non-sortable structural columns and are
-     * excluded from sortable column definitions in {@link #getColumnDefs()}, so
-     * they should never reach this method.
      *
      * @param column the column to build a comparator for
      * @return a comparator for the given column
@@ -103,7 +96,7 @@ class WatchlistSort extends SortProvider<WatchlistItem, WatchlistSort.SortColumn
             case CHANGE_NOK -> Comparator.comparing(i -> statsService.changeInNok(i.stock(), converter));
             case CHANGE_PCT -> Comparator.comparing(i -> i.stock().getWeeklyChangePercent());
             case HIGH_LOW -> Comparator.comparing(i -> statsService.highLowRangeInNok(i.stock(), converter, HIGH_LOW_WEEKS));
-            case TREND, TRADE, NOTE, REMOVE ->
+            case TREND, TRADE, NOTE, DETAILS, REMOVE ->
                     throw new IllegalStateException(column + " is not sortable");
         };
     }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/exchange/stocks/card/StocksCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/exchange/stocks/card/StocksCard.java
@@ -51,8 +51,7 @@ public class StocksCard extends DetailTableCard<Stock, StocksSort.SortColumn> {
                     } else {
                         gameService.addToWatchlist(symbol);
                     }
-                },
-                controller::openStockDetail);
+                });
         this.table = new SortColumnTable<>(sort::getColumnDefs, 10);
         this.pagination = new Pagination(PAGE_SIZE, this::setPage);
         this.title = StyledText.sectionTitle(LanguageManager.get("exchange.stocks.market"));
@@ -82,7 +81,8 @@ public class StocksCard extends DetailTableCard<Stock, StocksSort.SortColumn> {
 
     @Override
     protected RowCells<StocksSort.SortColumn> buildRowCells(Stock item, int rowIndex) {
-        return rowRenderer.buildRow(item);
+        return rowRenderer.buildRow(item)
+                .put(StocksSort.SortColumn.DETAILS, buildDetailChevron(item));
     }
 
     @Override

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/exchange/stocks/card/StocksCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/exchange/stocks/card/StocksCard.java
@@ -6,7 +6,7 @@ import edu.ntnu.idatt2003.millions.service.GameService;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
 import edu.ntnu.idatt2003.millions.view.component.Pagination;
 import edu.ntnu.idatt2003.millions.view.component.StyledText;
-import edu.ntnu.idatt2003.millions.view.component.card.SortableTableCard;
+import edu.ntnu.idatt2003.millions.view.component.card.DetailTableCard;
 import edu.ntnu.idatt2003.millions.view.component.table.RowCells;
 import edu.ntnu.idatt2003.millions.view.component.table.SortColumnTable;
 import edu.ntnu.idatt2003.millions.view.exchange.stocks.StocksSort;
@@ -18,13 +18,10 @@ import java.util.List;
 
 /**
  * Market card with controls for searching, sorting, and paginating stocks listed on the exchange.
- * Extends {@link SortableTableCard} for shared pagination, search, sort state, and refresh algorithm.
- *
- * <p>Column structure and sort state are owned by {@link SortColumnTable};
- * domain-specific sort logic is delegated to {@link StocksSort};
- * row rendering is delegated to {@link StocksRowRenderer}.</p>
+ * Extends {@link DetailTableCard} for shared pagination, search, sort state, refresh algorithm,
+ * and row-activation routing to {@link #openDetail(Stock)}.
  */
-public class StocksCard extends SortableTableCard<Stock, StocksSort.SortColumn> {
+public class StocksCard extends DetailTableCard<Stock, StocksSort.SortColumn> {
 
     private static final int PAGE_SIZE = 20;
     private static final double ROW_HEIGHT = 34.0;
@@ -41,7 +38,7 @@ public class StocksCard extends SortableTableCard<Stock, StocksSort.SortColumn> 
      * @param controller  the controller used to open buy/sell dialogs
      */
     public StocksCard(GameService gameService, TradeController controller) {
-        super(gameService, PAGE_SIZE, "exchange.stocks.status", "exchange.stocks.empty");
+        super(gameService, controller, PAGE_SIZE, "exchange.stocks.status", "exchange.stocks.empty");
         this.gameService = gameService;
         this.sort = new StocksSort(
                 gameService.getCurrencyConverter(),
@@ -94,6 +91,17 @@ public class StocksCard extends SortableTableCard<Stock, StocksSort.SortColumn> 
             return LanguageManager.get("exchange.stocks.empty");
         }
         return MessageFormat.format(LanguageManager.get("exchange.stocks.empty.search"), term);
+    }
+
+    /**
+     * Opens the stock detail modal for the given stock. Whenever the user
+     * activates a row via keyboard or mouse click on a data cell.
+     *
+     * @param item the stock to show details for
+     */
+    @Override
+    protected void openDetail(Stock item) {
+        controller.openStockDetail(item);
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/exchange/stocks/card/StocksRowRenderer.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/exchange/stocks/card/StocksRowRenderer.java
@@ -9,11 +9,11 @@ import edu.ntnu.idatt2003.millions.service.StockStatsService;
 import edu.ntnu.idatt2003.millions.util.ChangeFormatter;
 import edu.ntnu.idatt2003.millions.util.LanguageManager;
 import edu.ntnu.idatt2003.millions.util.TableCells;
-import edu.ntnu.idatt2003.millions.view.component.ChevronButton;
 import edu.ntnu.idatt2003.millions.view.component.RowRenderer;
 import edu.ntnu.idatt2003.millions.view.component.chart.SparklineChart;
 import edu.ntnu.idatt2003.millions.view.component.table.RowCells;
 import edu.ntnu.idatt2003.millions.view.exchange.stocks.StocksSort;
+import java.util.function.Consumer;
 import javafx.geometry.Pos;
 import javafx.scene.layout.Priority;
 import javafx.scene.control.Button;
@@ -22,7 +22,6 @@ import javafx.scene.layout.HBox;
 
 import java.math.BigDecimal;
 import java.util.List;
-import java.util.function.Consumer;
 
 import static edu.ntnu.idatt2003.millions.view.exchange.stocks.StocksSort.SortColumn.*;
 
@@ -31,7 +30,7 @@ import static edu.ntnu.idatt2003.millions.view.exchange.stocks.StocksSort.SortCo
  *
  * <p>Each call to {@link #buildRow(Stock)} produces a {@link RowCells} map with
  * a watchlist star toggle, ticker, company, NOK price, weekly change,
- * a {@link SparklineChart} trend, a {@link ChevronButton} detail link, and trade actions.
+ * sparkline chart trend, a chevron button detail link, and trade actions.
  * The owning card inserts the cells and registers the row for navigation.</p>
  *
  * <p>This class is stateless and may be reused across refreshes.
@@ -44,7 +43,6 @@ class StocksRowRenderer extends RowRenderer {
     private final StockStatsService statsService = new StockStatsService();
     private final TradeController controller;
     private final Consumer<String> onWatchlistToggle;
-    private final Consumer<Stock> onDetailClick;
 
     /**
      * Constructs a new StocksRowRenderer.
@@ -53,28 +51,20 @@ class StocksRowRenderer extends RowRenderer {
      * @param controller        the controller used to open buy dialogs
      * @param onWatchlistToggle callback invoked with the stock symbol when the player
      *                          clicks the watchlist star button
-     * @param onDetailClick     callback invoked with the {@link Stock} when the player
-     *                          clicks the details chevron button
      */
     StocksRowRenderer(GameService gameService,
                       TradeController controller,
-                      Consumer<String> onWatchlistToggle,
-                      Consumer<Stock> onDetailClick) {
+                      Consumer<String> onWatchlistToggle) {
         this.gameService = gameService;
         this.controller = controller;
         this.onWatchlistToggle = onWatchlistToggle;
-        this.onDetailClick = onDetailClick;
     }
 
     /**
      * Builds the column-keyed cells for the given stock.
      * Produces a watchlist star toggle, ticker (with optional owner badge), company name,
-     * NOK price, weekly change in NOK and percent, a {@link SparklineChart} trend,
-     * a {@link ChevronButton} that fires {@link #onDetailClick}, and trade buttons.
-     *
-     * <p>The watchlist star is inserted first so it serves as the row's default
-     * keyboard-focus anchor (see {@link RowCells#firstNode()}). Row insertion and
-     * navigation registration are handled by the owning card's base class.</p>
+     * NOK price, weekly change in NOK and percent, a {@link SparklineChart} trend, trade buttons
+     * and chevron.
      *
      * @param stock the stock to render
      * @return the column-keyed cells for this stock, keyed by {@link StocksSort.SortColumn}
@@ -112,8 +102,6 @@ class StocksRowRenderer extends RowRenderer {
         Label changePctLabel = ChangeFormatter.styledPercent(stock.getWeeklyChangePercent(), "table-cell");
         SparklineChart sparkline = buildSparkline(stock, MAX_SPARKLINE_WEEKS);
         Button tradeButton = buildBuyButton(stock);
-        ChevronButton detailsButton = new ChevronButton(
-                () -> onDetailClick.accept(stock), "tooltip.stocks.chevron");
 
         return RowCells.<StocksSort.SortColumn>builder()
                 .put(WATCHLIST, starButton)
@@ -123,8 +111,7 @@ class StocksRowRenderer extends RowRenderer {
                 .put(CHANGE_KR, changeKrLabel)
                 .put(CHANGE_PCT, changePctLabel)
                 .put(TREND, sparkline)
-                .put(TRADE, tradeButton)
-                .put(DETAILS, detailsButton);
+                .put(TRADE, tradeButton);
     }
 
     /**


### PR DESCRIPTION
## Summary

Introduces consistent row-activation behaviour across all three sortable table cards: clicking any data cell or pressing Enter/Space now opens the detail view. Chevron button construction is moved out of individual renderers and centralised in a new abstract base class, eliminating duplication and enforcing a single point of control.

## Background

Previously, the three table cards, HoldingsCard, StocksCard, and WatchlistCard, each wired their own ChevronButton independently inside their row renderers, passing a Consumer<T> callback through the constructor. Row activation (Enter/Space) was handled by onRowEnter in SortableTableCard, but clicking a data cell did nothing.

### This meant:

Chevron construction logic was duplicated across StocksRowRenderer and WatchlistRowRenderer
Each renderer needed an extra constructor parameter solely to carry the detail-open callback
There was no shared abstraction for the pattern of "this card opens a detail view on row activation"
Mouse clicks on data cells were dead — only keyboard and the chevron button worked


## Changes

**New: DetailTableCard**
Abstract base class sitting between SortableTableCard and the three concrete cards. Holds the shared TradeController field and seals onRowEnter to always delegate to the abstract openDetail(T) method. Provides buildDetailChevron(T) (final) and the overridable chevronTooltipKey() so subclasses can customise the tooltip without duplicating chevron construction.
HoldingsCard, StocksCard, WatchlistCard

All three now extend DetailTableCard instead of SortableTableCard. Each implements openDetail(T) with its own routing logic. HoldingsCard overrides chevronTooltipKey() to return "tooltip.holdings.chevron"; the other two use the default "tooltip.stocks.chevron". The DETAILS chevron is added in each card's buildRowCells via buildDetailChevron(item).

**StocksRowRenderer, WatchlistRowRenderer**
onDetailClick callback field and constructor parameter removed from both. ChevronButton construction and the .put(DETAILS, ...) call removed from buildRow. Constructors are now simpler and have one fewer responsibility.

**WatchlistSort**
Added DETAILS to the SortColumn enum and inserted a non-sortable column definition for it between NOTE and REMOVE.

**RowCells**
Added package-private nodes() returning an unmodifiable collection of all cell values in insertion order. Used by SortColumnTable to attach click handlers without exposing the backing map.

**SortColumnTable**
addSelectableRow now iterates cells.nodes() after inserting the row, and attaches a MOUSE_CLICKED (primary button) handler to every node that is not a ButtonBase. This opens the detail view on a plain cell click. ButtonBase nodes are skipped because they already consume MOUSE_CLICKED naturally, preventing double-firing on interactive controls.