### PR TITLE
docs: javadoc pass and quality fixes across the service layer

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/millions/factory/TransactionFactory.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/factory/TransactionFactory.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.factory;
 
 import edu.ntnu.idatt2003.millions.model.stock.Share;
@@ -7,18 +8,9 @@ import edu.ntnu.idatt2003.millions.model.transaction.Sale;
 import java.math.BigDecimal;
 
 /**
- * Factory for creating financial transactions.
- *
- * <p>Use this class to create {@link Purchase} and {@link Sale} transactions.
+ * Factory for creating {@link Purchase} and {@link Sale} transactions.
  * A purchase can either use its calculated share-currency cost or an explicit
- * settlement amount prepared by a coordinating service. To execute a transaction,
- * call <code>commit(player)</code> on the returned object.</p>
- *
- * <p>Example usage:</p>
- * <pre>
- *   Transaction t = TransactionFactory.createPurchase(share, week);
- *   t.commit(player);
- * </pre>
+ * settlement amount prepared by a coordinating service.
  */
 public class TransactionFactory {
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/observer/GameObserver.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/observer/GameObserver.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.observer;
 
 /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/GameService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/GameService.java
@@ -348,11 +348,13 @@
          *
          * @param shares      the shares the player has chosen to sell
          * @param currentWeek the game week being processed (the week after the current one)
+         * @throws NullPointerException              if shares is null
          * @throws InsufficientSaleProceedsException if the net sale total is less than total obligations
          * @throws IllegalStateException             if the game is over
          */
         public void executeForcedSale(List<Share> shares, int currentWeek)
                 throws InsufficientSaleProceedsException {
+            Objects.requireNonNull(shares, "Shares cannot be null");
             if (gameOver) throw new IllegalStateException("Game is over");
             CurrencyConverter converter = exchange.getCurrencyConverter();
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/GameService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/GameService.java
@@ -272,6 +272,8 @@ public class GameService {
      * @throws IllegalStateException if the game is over
      */
     public Transaction buy(String symbol, BigDecimal quantity) {
+        Objects.requireNonNull(symbol, "Symbol cannot be null");
+        Objects.requireNonNull(quantity, "Quantity cannot be null");
         if (gameOver) throw new IllegalStateException("Game is over");
         Transaction transaction = exchange.buy(symbol, quantity, player);
         notifyObservers();
@@ -302,6 +304,8 @@ public class GameService {
      * @throws IllegalStateException if the game is over
      */
     public Transaction sell(Share share, BigDecimal quantity) {
+        Objects.requireNonNull(share, "Share cannot be null");
+        Objects.requireNonNull(quantity, "Quantity cannot be null");
         if (gameOver) throw new IllegalStateException("Game is over");
         Transaction transaction = exchange.sell(share, quantity, player);
         notifyObservers();
@@ -391,10 +395,12 @@ public class GameService {
     }
 
     /**
-     * Returns the currency converter from the active exchange.
-     * Convenience shortcut for {@code getExchange().getCurrencyConverter()}.
+     * Returns the currency converter for the active game.
      *
-     * @return the active currency converter
+     * @return the currency converter
+     * @throws NullPointerException if no game is currently
+     *     active. Callers must ensure createNewGame() or
+     *     loadGame() has succeeded before invoking this method.
      */
     public CurrencyConverter getCurrencyConverter() {
         return exchange.getCurrencyConverter();

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/GameService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/GameService.java
@@ -1,554 +1,582 @@
-// Javadoc generated with AI assistance - reviewed and approved by author.
-package edu.ntnu.idatt2003.millions.service;
+    // Javadoc generated with AI assistance - reviewed and approved by author.
+    package edu.ntnu.idatt2003.millions.service;
 
-import edu.ntnu.idatt2003.millions.file.game.GameFileHandler;
-import edu.ntnu.idatt2003.millions.file.game.GameSaveCorruptException;
-import edu.ntnu.idatt2003.millions.file.game.GameState;
-import edu.ntnu.idatt2003.millions.file.game.JsonGameFileHandler;
-import edu.ntnu.idatt2003.millions.file.stock.CsvStockFileHandler;
-import edu.ntnu.idatt2003.millions.file.stock.InvalidStockDataException;
-import edu.ntnu.idatt2003.millions.file.stock.StockFileHandler;
-import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
-import edu.ntnu.idatt2003.millions.model.currency.FixedRateCurrencyConverter;
-import edu.ntnu.idatt2003.millions.model.exchange.Exchange;
-import edu.ntnu.idatt2003.millions.model.watchlist.WatchlistEntry;
-import edu.ntnu.idatt2003.millions.model.calculator.SalesCalculator;
-import edu.ntnu.idatt2003.millions.model.loan.ExcessiveDebtException;
-import edu.ntnu.idatt2003.millions.model.loan.InsufficientSaleProceedsException;
-import edu.ntnu.idatt2003.millions.model.loan.Loan;
-import edu.ntnu.idatt2003.millions.model.loan.LoanOffer;
-import edu.ntnu.idatt2003.millions.model.player.Player;
-import edu.ntnu.idatt2003.millions.model.stock.Share;
-import edu.ntnu.idatt2003.millions.model.stock.Stock;
-import edu.ntnu.idatt2003.millions.model.transaction.Transaction;
-import edu.ntnu.idatt2003.millions.observer.GameObserver;
-import edu.ntnu.idatt2003.millions.model.leaderboard.Outcome;
-import edu.ntnu.idatt2003.millions.service.notification.NotificationService;
+    import edu.ntnu.idatt2003.millions.file.game.GameFileHandler;
+    import edu.ntnu.idatt2003.millions.file.game.GameSaveCorruptException;
+    import edu.ntnu.idatt2003.millions.file.game.GameState;
+    import edu.ntnu.idatt2003.millions.file.game.JsonGameFileHandler;
+    import edu.ntnu.idatt2003.millions.file.stock.CsvStockFileHandler;
+    import edu.ntnu.idatt2003.millions.file.stock.InvalidStockDataException;
+    import edu.ntnu.idatt2003.millions.file.stock.StockFileHandler;
+    import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
+    import edu.ntnu.idatt2003.millions.model.currency.FixedRateCurrencyConverter;
+    import edu.ntnu.idatt2003.millions.model.exchange.Exchange;
+    import edu.ntnu.idatt2003.millions.model.watchlist.WatchlistEntry;
+    import edu.ntnu.idatt2003.millions.model.calculator.SalesCalculator;
+    import edu.ntnu.idatt2003.millions.model.loan.ExcessiveDebtException;
+    import edu.ntnu.idatt2003.millions.model.loan.InsufficientSaleProceedsException;
+    import edu.ntnu.idatt2003.millions.model.loan.Loan;
+    import edu.ntnu.idatt2003.millions.model.loan.LoanOffer;
+    import edu.ntnu.idatt2003.millions.model.player.Player;
+    import edu.ntnu.idatt2003.millions.model.stock.Share;
+    import edu.ntnu.idatt2003.millions.model.stock.Stock;
+    import edu.ntnu.idatt2003.millions.model.transaction.Transaction;
+    import edu.ntnu.idatt2003.millions.observer.GameObserver;
+    import edu.ntnu.idatt2003.millions.model.leaderboard.Outcome;
+    import edu.ntnu.idatt2003.millions.service.notification.NotificationService;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.UncheckedIOException;
-import java.math.BigDecimal;
-import java.util.*;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-/**
- * Service-layer manager for the game lifecycle: creates new games, loads and
- * saves game state, and advances the game week. Owns the active {@link Player}
- * and {@link Exchange}, and notifies registered {@link GameObserver}s after
- * every state-changing operation. Delegates persistence to {@link GameFileHandler}.
- *
- * <p>{@code createNewGame} validates player input before performing any file I/O
- * and only swaps in the new state once the player and exchange are fully
- * constructed, so failures leave the previous game intact.</p>
- */
-public class GameService {
-
-    private static final Logger LOGGER = Logger.getLogger(GameService.class.getName());
-
-    private static final String DEFAULT_EXCHANGE_NAME = "MainExchange";
-    private static final String DEFAULT_STOCK_RESOURCE = "/data/sp500.csv";
-    private static final Currency DEFAULT_STOCK_CURRENCY = Currency.getInstance("USD");
-
-    private Player player;
-    private Exchange exchange;
-    private boolean gameOver = false;
-    private File currentSaveFile = null;
-    private final GameFileHandler gameFileHandler;
-    private final List<GameObserver> observers = new ArrayList<>();
-    private final NotificationService notificationService = new NotificationService();
-    private final LeaderboardService leaderboardService;
+    import java.io.File;
+    import java.io.IOException;
+    import java.io.InputStream;
+    import java.io.UncheckedIOException;
+    import java.math.BigDecimal;
+    import java.util.*;
+    import java.util.logging.Level;
+    import java.util.logging.Logger;
 
     /**
-     * Default constructor — uses production {@link LeaderboardService}
-     * that reads and writes {@code leaderboard.json} in the project root.
-     */
-    public GameService() {
-        this(new LeaderboardService());
-    }
-
-    /**
-     * Test-friendly constructor — accepts an injected
-     * {@link LeaderboardService} so tests can redirect leaderboard
-     * persistence to a temporary file.
+     * Service-layer manager for the game lifecycle: creates new games, loads and
+     * saves game state, and advances the game week. Owns the active {@link Player}
+     * and {@link Exchange}, and notifies registered {@link GameObserver}s after
+     * every state-changing operation. Delegates persistence to {@link GameFileHandler}.
      *
-     * @param leaderboardService the leaderboard service to use
-     * @throws NullPointerException if {@code leaderboardService} is null
+     * <p>{@code createNewGame} validates player input before performing any file I/O
+     * and only swaps in the new state once the player and exchange are fully
+     * constructed, so failures leave the previous game intact.</p>
      */
-    public GameService(LeaderboardService leaderboardService) {
-        this.leaderboardService = Objects.requireNonNull(
-                leaderboardService, "leaderboardService cannot be null");
-        this.gameFileHandler = new JsonGameFileHandler();
-    }
+    public class GameService {
 
-    /**
-     * Registers an observer to be notified when the game state changes.
-     *
-     * @param observer the observer to register
-     * @throws NullPointerException if observer is null
-     */
-    public void addObserver(GameObserver observer) {
-        Objects.requireNonNull(observer, "Observer cannot be null");
-        observers.add(observer);
-    }
+        private static final Logger LOGGER = Logger.getLogger(GameService.class.getName());
 
-    public boolean isGameOver() {
-        return gameOver;
-    }
+        private static final String DEFAULT_EXCHANGE_NAME = "MainExchange";
+        private static final String DEFAULT_STOCK_RESOURCE = "/data/sp500.csv";
+        private static final Currency DEFAULT_STOCK_CURRENCY = Currency.getInstance("USD");
 
-    /**
-     * Marks the game as over and notifies observers. After this call, all trading
-     * and week-advance operations throw {@link IllegalStateException}.
-     */
-    public void declareGameOver() {
-        this.gameOver = true;
-        if (player != null && exchange != null) {
+        private Player player;
+        private Exchange exchange;
+        private boolean gameOver = false;
+        private File currentSaveFile = null;
+        private final GameFileHandler gameFileHandler;
+        private final List<GameObserver> observers = new ArrayList<>();
+        private final NotificationService notificationService = new NotificationService();
+        private final LeaderboardService leaderboardService;
+
+        /**
+         * Default constructor — uses production {@link LeaderboardService}
+         * that reads and writes {@code leaderboard.json} in the project root.
+         */
+        public GameService() {
+            this(new LeaderboardService());
+        }
+
+        /**
+         * Test-friendly constructor — accepts an injected
+         * {@link LeaderboardService} so tests can redirect leaderboard
+         * persistence to a temporary file.
+         *
+         * @param leaderboardService the leaderboard service to use
+         * @throws NullPointerException if {@code leaderboardService} is null
+         */
+        public GameService(LeaderboardService leaderboardService) {
+            this.leaderboardService = Objects.requireNonNull(
+                    leaderboardService, "leaderboardService cannot be null");
+            this.gameFileHandler = new JsonGameFileHandler();
+        }
+
+        /**
+         * Registers an observer to be notified when the game state changes.
+         *
+         * @param observer the observer to register
+         * @throws NullPointerException if observer is null
+         */
+        public void addObserver(GameObserver observer) {
+            Objects.requireNonNull(observer, "Observer cannot be null");
+            observers.add(observer);
+        }
+
+        public boolean isGameOver() {
+            return gameOver;
+        }
+
+        /**
+         * Marks the game as over and notifies observers. After this call, all trading
+         * and week-advance operations throw {@link IllegalStateException}.
+         *
+         * <p>No-op for the persistence and leaderboard side effects
+         * if no game is currently active; the gameOver flag is set
+         * regardless and observers are notified.</p>
+         */
+        public void declareGameOver() {
+            this.gameOver = true;
+            if (player != null && exchange != null) {
+                leaderboardService.recordOrUpdate(
+                        player, exchange, exchange.getCurrencyConverter(), Outcome.BANKRUPTCY);
+                if (currentSaveFile != null) {
+                    try {
+                        gameFileHandler.saveGame(player, exchange, gameOver, currentSaveFile);
+                    } catch (UncheckedIOException e) {
+                        LOGGER.log(Level.WARNING, "Could not write save file on bankruptcy", e);
+                    } catch (RuntimeException e) {
+                        LOGGER.log(Level.SEVERE, "Unexpected error writing save file on bankruptcy", e);
+                    }
+                }
+            }
+            notifyObservers();
+        }
+
+        /**
+         * Saves the current game state to a JSON file.
+         *
+         * @param file the file to save the game state to
+         * @throws NullPointerException  if the file is null
+         * @throws IllegalStateException if no active game exists
+         */
+        public void saveGame(File file) {
+            Objects.requireNonNull(file, "File cannot be null");
+            if (player == null || exchange == null) {
+                throw new IllegalStateException("No active game to save");
+            }
+            gameFileHandler.saveGame(player, exchange, gameOver, file);
+            this.currentSaveFile = file;
+            try {
+                leaderboardService.recordOrUpdate(player, exchange, exchange.getCurrencyConverter(),
+                        gameOver ? Outcome.BANKRUPTCY : Outcome.ACTIVE);
+            } catch (RuntimeException e) {
+                LOGGER.log(Level.WARNING, "Could not update leaderboard after save", e);
+            }
+        }
+
+        /**
+         * Returns the file used for the most recent save or load in this session,
+         * or empty if no save has been made and no game has been loaded yet.
+         *
+         * @return an Optional containing the current save file, or empty if none
+         */
+        public Optional<File> getCurrentSaveFile() {
+            return Optional.ofNullable(currentSaveFile);
+        }
+
+        /**
+         * Clears the stored save path so the next save will prompt for a location.
+         */
+        public void clearCurrentSaveFile() {
+            this.currentSaveFile = null;
+        }
+
+        /**
+         * Creates a new game with the given player name and starting capital.
+         *
+         * <p>Validates the player input first by constructing a {@link Player},
+         * then loads default stock data from {@link #DEFAULT_STOCK_RESOURCE} and
+         * instantiates an {@link Exchange}. The active game state is only mutated
+         * once both steps succeed, leaving any previous game intact on failure.
+         * Observers are notified once the new game state is active.</p>
+         *
+         * @param name    the name of the player
+         * @param capital the starting capital for the player, in NOK
+         * @throws NullPointerException     if name or capital is null
+         * @throws IllegalArgumentException if name is blank, capital is negative,
+         *                                  or the default stock file contains no stocks
+         * @throws IllegalStateException    if the default stock data cannot be found
+         * @throws UncheckedIOException     if the default stock data cannot be read
+         */
+        public void createNewGame(String name, BigDecimal capital) {
+            Player newPlayer = new Player(name, capital);
+            List<Stock> stocks = loadDefaultStocks();
+            activate(newPlayer, stocks);
+        }
+
+        /**
+         * Convenience overload of {@link #createNewGame(String, BigDecimal, File, Currency)}
+         * that defaults the stock currency to USD.
+         *
+         * @param name      the player name
+         * @param capital   the starting capital, in NOK
+         * @param stockFile the CSV file with stock data
+         * @throws NullPointerException      if any argument is null
+         * @throws IllegalArgumentException  if name is blank, capital is negative,
+         *                                   or the file contains no stocks
+         * @throws InvalidStockDataException if the stock file contains malformed or no valid entries
+         */
+        public void createNewGame(String name, BigDecimal capital, File stockFile)
+                throws InvalidStockDataException {
+            createNewGame(name, capital, stockFile, DEFAULT_STOCK_CURRENCY);
+        }
+
+        /**
+         * Creates a new game from the given stock file, tagging every parsed
+         * {@link Stock} with {@code currency} so the {@link Exchange} converts
+         * prices to NOK on every trade.
+         *
+         * @param name      the player name
+         * @param capital   the starting capital, in NOK
+         * @param stockFile the CSV file with stock data
+         * @param currency  the currency the stock prices are quoted in
+         * @throws NullPointerException      if any argument is null
+         * @throws IllegalArgumentException  if name is blank, capital is negative,
+         *                                   or the file contains no stocks
+         * @throws InvalidStockDataException if the stock file contains malformed or no valid entries
+         */
+        public void createNewGame(String name, BigDecimal capital, File stockFile, Currency currency)
+                throws InvalidStockDataException {
+            Objects.requireNonNull(stockFile, "Stock file cannot be null");
+            Objects.requireNonNull(currency, "Currency cannot be null");
+            Player newPlayer = new Player(name, capital);
+            StockFileHandler stockFileHandler = new CsvStockFileHandler();
+            List<Stock> stocks = stockFileHandler.readStocks(stockFile.toPath(), currency);
+            activate(newPlayer, stocks);
+        }
+
+        private void activate(Player newPlayer, List<Stock> stocks) {
+            this.player = newPlayer;
+            this.exchange = new Exchange(DEFAULT_EXCHANGE_NAME, stocks, new FixedRateCurrencyConverter());
+            this.gameOver = false;
+            this.currentSaveFile = null;
+            notifyObservers();
+        }
+
+        private List<Stock> loadDefaultStocks() {
+            StockFileHandler stockFileHandler = new CsvStockFileHandler();
+            try (InputStream inputStream = GameService.class.getResourceAsStream(DEFAULT_STOCK_RESOURCE)) {
+                if (inputStream == null) {
+                    throw new IllegalStateException("Default stock data not found: " + DEFAULT_STOCK_RESOURCE);
+                }
+                return stockFileHandler.readStocks(inputStream, DEFAULT_STOCK_CURRENCY);
+            } catch (IOException e) {
+                throw new UncheckedIOException("Could not read default stock data", e);
+            } catch (InvalidStockDataException e) {
+                throw new IllegalStateException("Default stock data is malformed: " + e.getMessage(), e);
+            }
+        }
+
+        /**
+         * Loads a saved game state from a JSON file and notifies observers.
+         *
+         * @param file the file to load the game state from
+         * @throws NullPointerException     if the file is null
+         * @throws GameSaveCorruptException if the save file is corrupt or has missing fields
+         */
+        public void loadGame(File file) throws GameSaveCorruptException {
+            Objects.requireNonNull(file, "File cannot be null");
+            GameState state = gameFileHandler.loadGame(file);
+            this.player = state.player();
+            this.exchange = state.exchange();
+            this.exchange.reinitialize(new FixedRateCurrencyConverter());
+            this.gameOver = state.gameOver();
+            this.currentSaveFile = file;
+            notifyObservers();
+        }
+
+        /**
+         * Buys the given quantity of a stock for the current player.
+         *
+         * @param symbol   the symbol of the stock to buy
+         * @param quantity the quantity to buy
+         * @return the completed purchase transaction
+         * @throws IllegalStateException if the game is over
+         */
+        public Transaction buy(String symbol, BigDecimal quantity) {
+            Objects.requireNonNull(symbol, "Symbol cannot be null");
+            Objects.requireNonNull(quantity, "Quantity cannot be null");
+            if (gameOver) throw new IllegalStateException("Game is over");
+            Transaction transaction = exchange.buy(symbol, quantity, player);
+            notifyObservers();
+            return transaction;
+        }
+
+        /**
+         * Sells the full quantity of a share for the current player.
+         *
+         * @param share the share to sell
+         * @return the completed sale transaction
+         * @throws NullPointerException  if share is null
+         * @throws IllegalStateException if the game is over
+         */
+        public Transaction sell(Share share) {
+            Objects.requireNonNull(share, "Share cannot be null");
+            return sell(share, share.getQuantity());
+        }
+
+        /**
+         * Sells the given quantity of a share for the current player. When the
+         * quantity is less than the share's full position, the remainder stays
+         * in the player's portfolio with the original purchase price preserved.
+         *
+         * @param share    the share to sell from
+         * @param quantity the quantity to sell
+         * @return the completed sale transaction
+         * @throws IllegalStateException if the game is over
+         */
+        public Transaction sell(Share share, BigDecimal quantity) {
+            Objects.requireNonNull(share, "Share cannot be null");
+            Objects.requireNonNull(quantity, "Quantity cannot be null");
+            if (gameOver) throw new IllegalStateException("Game is over");
+            Transaction transaction = exchange.sell(share, quantity, player);
+            notifyObservers();
+            return transaction;
+        }
+
+        /**
+         * Advances the game by one week and notifies all registered observers.
+         * Assumes the player has enough cash to cover all obligations (interest +
+         * any maturing loan principals); use {@link #executeForcedSale} instead
+         * when they cannot.
+         *
+         * @throws IllegalStateException if the game is over
+         */
+        public void advanceWeek() {
+            if (gameOver) throw new IllegalStateException("Game is over");
+            CurrencyConverter converter = exchange.getCurrencyConverter();
+            player.setPreviousNetWorth(player.getNetWorth(converter));
+            exchange.advance();
+            int week = exchange.getWeek();
+            player.collectWeeklyInterest(week);
+            for (Loan loan : player.getLoansDueThisWeek(week)) {
+                player.repayLoan(loan, week);
+            }
+            finishWeekAdvance();
+        }
+
+        /**
+         * Sells the given shares, deducts all weekly obligations (interest plus any
+         * maturing loan principals) from the player's cash, advances the week, and
+         * notifies observers.
+         *
+         * <p>All-or-nothing: if the combined net sale value (after commission and tax,
+         * converted to NOK) is less than the total obligations for {@code currentWeek},
+         * an {@link InsufficientSaleProceedsException} is thrown and no state is mutated.
+         *
+         * @param shares      the shares the player has chosen to sell
+         * @param currentWeek the game week being processed (the week after the current one)
+         * @throws InsufficientSaleProceedsException if the net sale total is less than total obligations
+         * @throws IllegalStateException             if the game is over
+         */
+        public void executeForcedSale(List<Share> shares, int currentWeek)
+                throws InsufficientSaleProceedsException {
+            if (gameOver) throw new IllegalStateException("Game is over");
+            CurrencyConverter converter = exchange.getCurrencyConverter();
+
+            List<Loan> maturingLoans = player.getLoansDueThisWeek(currentWeek);
+            BigDecimal totalObligations = player.getTotalObligationsThisWeek(currentWeek);
+
+            BigDecimal netTotal = shares.stream()
+                    .map(s -> SalesCalculator.calculateNetNok(s, converter))
+                    .reduce(BigDecimal.ZERO, BigDecimal::add);
+            if (netTotal.compareTo(totalObligations) < 0) {
+                throw new InsufficientSaleProceedsException(totalObligations.subtract(netTotal));
+            }
+
+            player.setPreviousNetWorth(player.getNetWorth(converter));
+
+            for (Share share : shares) {
+                exchange.sell(share, player);
+            }
+            player.withdrawMoney(totalObligations);
+
+            exchange.advance();
+            int week = exchange.getWeek();
+            player.writeInterestLedgerEntries(week);
+            for (Loan loan : maturingLoans) {
+                player.settleMatureLoan(loan, week);
+            }
+            finishWeekAdvance();
+        }
+
+        private void finishWeekAdvance() {
+            CurrencyConverter converter = exchange.getCurrencyConverter();
+            player.recordNetWorth(converter);
+            player.recordTotalDebt();
+            notificationService.onWeekAdvanced(player, exchange, converter);
+            notifyObservers();
+        }
+
+        /**
+         * Returns the player for the active game.
+         *
+         * @return the current player
+         * @throws NullPointerException if no game is currently
+         *     active. Callers must ensure createNewGame() or
+         *     loadGame() has succeeded before invoking this method.
+         */
+        public Player getPlayer() {
+            return player;
+        }
+
+        /**
+         * Returns the exchange for the active game.
+         *
+         * @return the current exchange
+         * @throws NullPointerException if no game is currently
+         *     active. Callers must ensure createNewGame() or
+         *     loadGame() has succeeded before invoking this method.
+         */
+        public Exchange getExchange() {
+            return exchange;
+        }
+
+        /**
+         * Returns the currency converter for the active game.
+         *
+         * @return the currency converter
+         * @throws NullPointerException if no game is currently
+         *     active. Callers must ensure createNewGame() or
+         *     loadGame() has succeeded before invoking this method.
+         */
+        public CurrencyConverter getCurrencyConverter() {
+            return exchange.getCurrencyConverter();
+        }
+
+        /**
+         * Returns the player's net worth from before the last week advance.
+         * Returns null if the week has not been advanced yet in this game.
+         *
+         * @return the previous net worth, or null if no week has yet advanced
+         * @throws NullPointerException if no game is currently
+         *     active. Callers must ensure createNewGame() or
+         *     loadGame() has succeeded before invoking this method.
+         */
+        public BigDecimal getPreviousNetWorth() {
+            return player.getPreviousNetWorth();
+        }
+
+        /**
+         * Creates a loan against the given offer and disburses the principal to the player.
+         *
+         * @param offer  the loan offer the player is accepting
+         * @param amount the principal to disburse; must be positive and within offer limits
+         * @return the created {@link Loan}
+         * @throws NullPointerException     if either argument is null
+         * @throws IllegalArgumentException if amount exceeds the offer's maximum principal
+         * @throws IllegalStateException    if the game is over
+         * @throws edu.ntnu.idatt2003.millions.model.loan.ExcessiveDebtException
+         *         if the loan would breach the player's debt-to-net-worth limit
+         */
+        public Loan takeLoan(LoanOffer offer, BigDecimal amount) throws ExcessiveDebtException {
+            if (gameOver) throw new IllegalStateException("Game is over");
+            Objects.requireNonNull(offer, "Offer cannot be null");
+            Objects.requireNonNull(amount, "Amount cannot be null");
+            Loan loan = new Loan(offer, amount, exchange.getWeek());
+            player.takeLoan(loan, exchange.getCurrencyConverter());
+            notificationService.onLoanTaken(player, exchange.getWeek(), exchange.getCurrencyConverter());
+            notifyObservers();
+            return loan;
+        }
+
+        /**
+         * Repays the given loan in full, withdrawing the principal from the player's
+         * cash balance and removing the loan from their active list.
+         *
+         * @param loan the loan to repay
+         * @throws NullPointerException     if loan is null
+         * @throws IllegalArgumentException if the player cannot afford the repayment
+         * @throws IllegalStateException    if the game is over
+         */
+        public void repayLoan(Loan loan) {
+            if (gameOver) throw new IllegalStateException("Game is over");
+            Objects.requireNonNull(loan, "Loan cannot be null");
+            player.repayLoan(loan, exchange.getWeek());
+            notifyObservers();
+        }
+
+        /**
+         * Liquidates the entire portfolio at current market prices, records a
+         * {@link Outcome#RETIRED} leaderboard entry, and persists the final state
+         * to the current save file if one exists. The caller is responsible for
+         * closing the application after this returns.
+         *
+         * <p>Unlike other trading methods, this does not check the {@code gameOver}
+         * flag. Retirement must remain available after bankruptcy or game-over so
+         * the player can always complete and exit the game.</p>
+         *
+         * <p>Requires an active game. Behaviour is undefined and
+         * will throw NullPointerException if invoked before
+         * createNewGame() or loadGame() has succeeded.</p>
+         */
+        public void sellAllAndExit() {
+            for (Share share : new ArrayList<>(player.getPortfolio().getShares())) {
+                exchange.sell(share, player);
+            }
             leaderboardService.recordOrUpdate(
-                    player, exchange, exchange.getCurrencyConverter(), Outcome.BANKRUPTCY);
+                    player, exchange, exchange.getCurrencyConverter(),
+                    gameOver ? Outcome.BANKRUPTCY : Outcome.RETIRED);
             if (currentSaveFile != null) {
                 try {
                     gameFileHandler.saveGame(player, exchange, gameOver, currentSaveFile);
                 } catch (UncheckedIOException e) {
-                    LOGGER.log(Level.WARNING, "Could not write save file on bankruptcy", e);
+                    LOGGER.log(Level.WARNING, "Could not write save file on retire", e);
                 } catch (RuntimeException e) {
-                    LOGGER.log(Level.SEVERE, "Unexpected error writing save file on bankruptcy", e);
+                    LOGGER.log(Level.SEVERE, "Unexpected error writing save file on retire", e);
                 }
             }
-        }
-        notifyObservers();
-    }
-
-    /**
-     * Saves the current game state to a JSON file.
-     *
-     * @param file the file to save the game state to
-     * @throws NullPointerException  if the file is null
-     * @throws IllegalStateException if no active game exists
-     */
-    public void saveGame(File file) {
-        Objects.requireNonNull(file, "File cannot be null");
-        if (player == null || exchange == null) {
-            throw new IllegalStateException("No active game to save");
-        }
-        gameFileHandler.saveGame(player, exchange, gameOver, file);
-        this.currentSaveFile = file;
-        try {
-            leaderboardService.recordOrUpdate(player, exchange, exchange.getCurrencyConverter(),
-                    gameOver ? Outcome.BANKRUPTCY : Outcome.ACTIVE);
-        } catch (RuntimeException e) {
-            LOGGER.log(Level.WARNING, "Could not update leaderboard after save", e);
-        }
-    }
-
-    /**
-     * Returns the file used for the most recent save or load in this session,
-     * or empty if no save has been made and no game has been loaded yet.
-     *
-     * @return an Optional containing the current save file, or empty if none
-     */
-    public Optional<File> getCurrentSaveFile() {
-        return Optional.ofNullable(currentSaveFile);
-    }
-
-    /**
-     * Clears the stored save path so the next save will prompt for a location.
-     */
-    public void clearCurrentSaveFile() {
-        this.currentSaveFile = null;
-    }
-
-    /**
-     * Creates a new game with the given player name and starting capital.
-     *
-     * <p>Validates the player input first by constructing a {@link Player},
-     * then loads default stock data from {@link #DEFAULT_STOCK_RESOURCE} and
-     * instantiates an {@link Exchange}. The active game state is only mutated
-     * once both steps succeed, leaving any previous game intact on failure.
-     * Observers are notified once the new game state is active.</p>
-     *
-     * @param name    the name of the player
-     * @param capital the starting capital for the player, in NOK
-     * @throws NullPointerException     if name or capital is null
-     * @throws IllegalArgumentException if name is blank, capital is negative,
-     *                                  or the default stock file contains no stocks
-     * @throws IllegalStateException    if the default stock data cannot be found
-     * @throws UncheckedIOException     if the default stock data cannot be read
-     */
-    public void createNewGame(String name, BigDecimal capital) {
-        Player newPlayer = new Player(name, capital);
-        List<Stock> stocks = loadDefaultStocks();
-        activate(newPlayer, stocks);
-    }
-
-    /**
-     * Convenience overload of {@link #createNewGame(String, BigDecimal, File, Currency)}
-     * that defaults the stock currency to USD.
-     *
-     * @param name      the player name
-     * @param capital   the starting capital, in NOK
-     * @param stockFile the CSV file with stock data
-     * @throws NullPointerException      if any argument is null
-     * @throws IllegalArgumentException  if name is blank, capital is negative,
-     *                                   or the file contains no stocks
-     * @throws InvalidStockDataException if the stock file contains malformed or no valid entries
-     */
-    public void createNewGame(String name, BigDecimal capital, File stockFile)
-            throws InvalidStockDataException {
-        createNewGame(name, capital, stockFile, DEFAULT_STOCK_CURRENCY);
-    }
-
-    /**
-     * Creates a new game from the given stock file, tagging every parsed
-     * {@link Stock} with {@code currency} so the {@link Exchange} converts
-     * prices to NOK on every trade.
-     *
-     * @param name      the player name
-     * @param capital   the starting capital, in NOK
-     * @param stockFile the CSV file with stock data
-     * @param currency  the currency the stock prices are quoted in
-     * @throws NullPointerException      if any argument is null
-     * @throws IllegalArgumentException  if name is blank, capital is negative,
-     *                                   or the file contains no stocks
-     * @throws InvalidStockDataException if the stock file contains malformed or no valid entries
-     */
-    public void createNewGame(String name, BigDecimal capital, File stockFile, Currency currency)
-            throws InvalidStockDataException {
-        Objects.requireNonNull(stockFile, "Stock file cannot be null");
-        Objects.requireNonNull(currency, "Currency cannot be null");
-        Player newPlayer = new Player(name, capital);
-        StockFileHandler stockFileHandler = new CsvStockFileHandler();
-        List<Stock> stocks = stockFileHandler.readStocks(stockFile.toPath(), currency);
-        activate(newPlayer, stocks);
-    }
-
-    private void activate(Player newPlayer, List<Stock> stocks) {
-        this.player = newPlayer;
-        this.exchange = new Exchange(DEFAULT_EXCHANGE_NAME, stocks, new FixedRateCurrencyConverter());
-        this.gameOver = false;
-        this.currentSaveFile = null;
-        notifyObservers();
-    }
-
-    private List<Stock> loadDefaultStocks() {
-        StockFileHandler stockFileHandler = new CsvStockFileHandler();
-        try (InputStream inputStream = GameService.class.getResourceAsStream(DEFAULT_STOCK_RESOURCE)) {
-            if (inputStream == null) {
-                throw new IllegalStateException("Default stock data not found: " + DEFAULT_STOCK_RESOURCE);
-            }
-            return stockFileHandler.readStocks(inputStream, DEFAULT_STOCK_CURRENCY);
-        } catch (IOException e) {
-            throw new UncheckedIOException("Could not read default stock data", e);
-        } catch (InvalidStockDataException e) {
-            throw new IllegalStateException("Default stock data is malformed: " + e.getMessage(), e);
-        }
-    }
-
-    /**
-     * Loads a saved game state from a JSON file and notifies observers.
-     *
-     * @param file the file to load the game state from
-     * @throws NullPointerException     if the file is null
-     * @throws GameSaveCorruptException if the save file is corrupt or has missing fields
-     */
-    public void loadGame(File file) throws GameSaveCorruptException {
-        Objects.requireNonNull(file, "File cannot be null");
-        GameState state = gameFileHandler.loadGame(file);
-        this.player = state.player();
-        this.exchange = state.exchange();
-        this.exchange.reinitialize(new FixedRateCurrencyConverter());
-        this.gameOver = state.gameOver();
-        this.currentSaveFile = file;
-        notifyObservers();
-    }
-
-    /**
-     * Buys the given quantity of a stock for the current player.
-     *
-     * @param symbol   the symbol of the stock to buy
-     * @param quantity the quantity to buy
-     * @return the completed purchase transaction
-     * @throws IllegalStateException if the game is over
-     */
-    public Transaction buy(String symbol, BigDecimal quantity) {
-        Objects.requireNonNull(symbol, "Symbol cannot be null");
-        Objects.requireNonNull(quantity, "Quantity cannot be null");
-        if (gameOver) throw new IllegalStateException("Game is over");
-        Transaction transaction = exchange.buy(symbol, quantity, player);
-        notifyObservers();
-        return transaction;
-    }
-
-    /**
-     * Sells the full quantity of a share for the current player.
-     *
-     * @param share the share to sell
-     * @return the completed sale transaction
-     * @throws NullPointerException  if share is null
-     * @throws IllegalStateException if the game is over
-     */
-    public Transaction sell(Share share) {
-        Objects.requireNonNull(share, "Share cannot be null");
-        return sell(share, share.getQuantity());
-    }
-
-    /**
-     * Sells the given quantity of a share for the current player. When the
-     * quantity is less than the share's full position, the remainder stays
-     * in the player's portfolio with the original purchase price preserved.
-     *
-     * @param share    the share to sell from
-     * @param quantity the quantity to sell
-     * @return the completed sale transaction
-     * @throws IllegalStateException if the game is over
-     */
-    public Transaction sell(Share share, BigDecimal quantity) {
-        Objects.requireNonNull(share, "Share cannot be null");
-        Objects.requireNonNull(quantity, "Quantity cannot be null");
-        if (gameOver) throw new IllegalStateException("Game is over");
-        Transaction transaction = exchange.sell(share, quantity, player);
-        notifyObservers();
-        return transaction;
-    }
-
-    /**
-     * Advances the game by one week and notifies all registered observers.
-     * Assumes the player has enough cash to cover all obligations (interest +
-     * any maturing loan principals); use {@link #executeForcedSale} instead
-     * when they cannot.
-     *
-     * @throws IllegalStateException if the game is over
-     */
-    public void advanceWeek() {
-        if (gameOver) throw new IllegalStateException("Game is over");
-        CurrencyConverter converter = exchange.getCurrencyConverter();
-        player.setPreviousNetWorth(player.getNetWorth(converter));
-        exchange.advance();
-        int week = exchange.getWeek();
-        player.collectWeeklyInterest(week);
-        for (Loan loan : player.getLoansDueThisWeek(week)) {
-            player.repayLoan(loan, week);
-        }
-        finishWeekAdvance();
-    }
-
-    /**
-     * Sells the given shares, deducts all weekly obligations (interest plus any
-     * maturing loan principals) from the player's cash, advances the week, and
-     * notifies observers.
-     *
-     * <p>All-or-nothing: if the combined net sale value (after commission and tax,
-     * converted to NOK) is less than the total obligations for {@code currentWeek},
-     * an {@link InsufficientSaleProceedsException} is thrown and no state is mutated.
-     *
-     * @param shares      the shares the player has chosen to sell
-     * @param currentWeek the game week being processed (the week after the current one)
-     * @throws InsufficientSaleProceedsException if the net sale total is less than total obligations
-     * @throws IllegalStateException             if the game is over
-     */
-    public void executeForcedSale(List<Share> shares, int currentWeek)
-            throws InsufficientSaleProceedsException {
-        if (gameOver) throw new IllegalStateException("Game is over");
-        CurrencyConverter converter = exchange.getCurrencyConverter();
-
-        List<Loan> maturingLoans = player.getLoansDueThisWeek(currentWeek);
-        BigDecimal totalObligations = player.getTotalObligationsThisWeek(currentWeek);
-
-        BigDecimal netTotal = shares.stream()
-                .map(s -> SalesCalculator.calculateNetNok(s, converter))
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
-        if (netTotal.compareTo(totalObligations) < 0) {
-            throw new InsufficientSaleProceedsException(totalObligations.subtract(netTotal));
+            notifyObservers();
         }
 
-        player.setPreviousNetWorth(player.getNetWorth(converter));
-
-        for (Share share : shares) {
-            exchange.sell(share, player);
-        }
-        player.withdrawMoney(totalObligations);
-
-        exchange.advance();
-        int week = exchange.getWeek();
-        player.writeInterestLedgerEntries(week);
-        for (Loan loan : maturingLoans) {
-            player.settleMatureLoan(loan, week);
-        }
-        finishWeekAdvance();
-    }
-
-    private void finishWeekAdvance() {
-        CurrencyConverter converter = exchange.getCurrencyConverter();
-        player.recordNetWorth(converter);
-        player.recordTotalDebt();
-        notificationService.onWeekAdvanced(player, exchange, converter);
-        notifyObservers();
-    }
-
-    public Player getPlayer() {
-        return player;
-    }
-
-    public Exchange getExchange() {
-        return exchange;
-    }
-
-    /**
-     * Returns the currency converter for the active game.
-     *
-     * @return the currency converter
-     * @throws NullPointerException if no game is currently
-     *     active. Callers must ensure createNewGame() or
-     *     loadGame() has succeeded before invoking this method.
-     */
-    public CurrencyConverter getCurrencyConverter() {
-        return exchange.getCurrencyConverter();
-    }
-
-    /**
-     * Returns the player's net worth from before the last week advance.
-     * Returns null if the week has not been advanced yet.
-     *
-     * @return the previous net worth, or null if not yet available
-     */
-    public BigDecimal getPreviousNetWorth() {
-        return player.getPreviousNetWorth();
-    }
-
-    /**
-     * Creates a loan against the given offer and disburses the principal to the player.
-     *
-     * @param offer  the loan offer the player is accepting
-     * @param amount the principal to disburse; must be positive and within offer limits
-     * @return the created {@link Loan}
-     * @throws NullPointerException     if either argument is null
-     * @throws IllegalArgumentException if amount exceeds the offer's maximum principal
-     * @throws IllegalStateException    if the game is over
-     * @throws edu.ntnu.idatt2003.millions.model.loan.ExcessiveDebtException
-     *         if the loan would breach the player's debt-to-net-worth limit
-     */
-    public Loan takeLoan(LoanOffer offer, BigDecimal amount) throws ExcessiveDebtException {
-        if (gameOver) throw new IllegalStateException("Game is over");
-        Objects.requireNonNull(offer, "Offer cannot be null");
-        Objects.requireNonNull(amount, "Amount cannot be null");
-        Loan loan = new Loan(offer, amount, exchange.getWeek());
-        player.takeLoan(loan, exchange.getCurrencyConverter());
-        notificationService.onLoanTaken(player, exchange.getWeek(), exchange.getCurrencyConverter());
-        notifyObservers();
-        return loan;
-    }
-
-    /**
-     * Repays the given loan in full, withdrawing the principal from the player's
-     * cash balance and removing the loan from their active list.
-     *
-     * @param loan the loan to repay
-     * @throws NullPointerException     if loan is null
-     * @throws IllegalArgumentException if the player cannot afford the repayment
-     * @throws IllegalStateException    if the game is over
-     */
-    public void repayLoan(Loan loan) {
-        if (gameOver) throw new IllegalStateException("Game is over");
-        Objects.requireNonNull(loan, "Loan cannot be null");
-        player.repayLoan(loan, exchange.getWeek());
-        notifyObservers();
-    }
-
-    /**
-     * Liquidates the entire portfolio at current market prices, records a
-     * {@link Outcome#RETIRED} leaderboard entry, and persists the final state
-     * to the current save file if one exists. The caller is responsible for
-     * closing the application after this returns.
-     *
-     * <p>Unlike other trading methods, this does not check the {@code gameOver}
-     * flag. Retirement must remain available after bankruptcy or game-over so
-     * the player can always complete and exit the game.</p>
-     */
-    public void sellAllAndExit() {
-        for (Share share : new ArrayList<>(player.getPortfolio().getShares())) {
-            exchange.sell(share, player);
-        }
-        leaderboardService.recordOrUpdate(
-                player, exchange, exchange.getCurrencyConverter(),
-                gameOver ? Outcome.BANKRUPTCY : Outcome.RETIRED);
-        if (currentSaveFile != null) {
-            try {
-                gameFileHandler.saveGame(player, exchange, gameOver, currentSaveFile);
-            } catch (UncheckedIOException e) {
-                LOGGER.log(Level.WARNING, "Could not write save file on retire", e);
-            } catch (RuntimeException e) {
-                LOGGER.log(Level.SEVERE, "Unexpected error writing save file on retire", e);
+        /**
+         * Records the player's current standing to the leaderboard as an active game.
+         * No-op if no game is currently active.
+         */
+        public void recordLeaderboardEntry() {
+            if (player != null && exchange != null) {
+                leaderboardService.recordOrUpdate(player, exchange, exchange.getCurrencyConverter(),
+                        gameOver ? Outcome.BANKRUPTCY : Outcome.ACTIVE);
             }
         }
-        notifyObservers();
-    }
 
-    /**
-     * Records the player's current standing to the leaderboard as an active game.
-     * No-op if no game is currently active.
-     */
-    public void recordLeaderboardEntry() {
-        if (player != null && exchange != null) {
-            leaderboardService.recordOrUpdate(player, exchange, exchange.getCurrencyConverter(),
-                    gameOver ? Outcome.BANKRUPTCY : Outcome.ACTIVE);
+        /**
+         * Clears all notifications from the current player and notifies observers.
+         * No-op if no game is active.
+         */
+        public void clearAllNotifications() {
+            if (player == null) return;
+            player.clearAllNotifications();
+            notifyObservers();
+        }
+
+        /**
+         * Adds the given stock symbol to the player's watchlist at the current week.
+         * No-op if no game is active, the symbol is already on the watchlist, or the symbol
+         * does not exist on the {@link Exchange}.
+         *
+         * @param symbol the ticker symbol to add
+         * @throws NullPointerException if symbol is null
+         */
+        public void addToWatchlist(String symbol) {
+            Objects.requireNonNull(symbol, "Symbol cannot be null");
+            if (player == null || !exchange.hasStock(symbol)) return;
+            player.addToWatchlist(new WatchlistEntry(symbol, exchange.getWeek(), ""));
+            notifyObservers();
+        }
+
+        /**
+         * Removes the given stock symbol from the player's watchlist.
+         * No-op if no game is active or the symbol is not on the watchlist.
+         *
+         * @param symbol the ticker symbol to remove
+         * @throws NullPointerException if symbol is null
+         */
+        public void removeFromWatchlist(String symbol) {
+            Objects.requireNonNull(symbol, "Symbol cannot be null");
+            if (player == null) return;
+            player.removeFromWatchlist(symbol);
+            notifyObservers();
+        }
+
+        /**
+         * Updates the note for the given symbol in the player's watchlist.
+         * No-op if no game is active or the symbol is not on the watchlist.
+         *
+         * @param symbol  the ticker symbol of the entry to update
+         * @param newNote the new note text
+         * @throws NullPointerException if symbol is null
+         */
+        public void updateWatchlistNote(String symbol, String newNote) {
+            Objects.requireNonNull(symbol, "Symbol cannot be null");
+            if (player == null) return;
+            player.updateWatchlistNote(symbol, newNote);
+            notifyObservers();
+        }
+
+        private void notifyObservers() {
+            observers.forEach(GameObserver::onGameUpdated);
         }
     }
-
-    /**
-     * Clears all notifications from the current player and notifies observers.
-     * No-op if no game is active.
-     */
-    public void clearAllNotifications() {
-        if (player == null) return;
-        player.clearAllNotifications();
-        notifyObservers();
-    }
-
-    /**
-     * Adds the given stock symbol to the player's watchlist at the current week.
-     * No-op if the symbol is already on the watchlist or does not exist on the {@link Exchange}.
-     *
-     * @param symbol the ticker symbol to add
-     * @throws NullPointerException if symbol is null
-     */
-    public void addToWatchlist(String symbol) {
-        Objects.requireNonNull(symbol, "Symbol cannot be null");
-        if (player == null || !exchange.hasStock(symbol)) return;
-        player.addToWatchlist(new WatchlistEntry(symbol, exchange.getWeek(), ""));
-        notifyObservers();
-    }
-
-    /**
-     * Removes the given stock symbol from the player's watchlist.
-     * No-op if the symbol is not on the watchlist.
-     *
-     * @param symbol the ticker symbol to remove
-     * @throws NullPointerException if symbol is null
-     */
-    public void removeFromWatchlist(String symbol) {
-        Objects.requireNonNull(symbol, "Symbol cannot be null");
-        if (player == null) return;
-        player.removeFromWatchlist(symbol);
-        notifyObservers();
-    }
-
-    /**
-     * Updates the note for the given symbol in the player's watchlist.
-     * No-op if the symbol is not on the watchlist.
-     *
-     * @param symbol  the ticker symbol of the entry to update
-     * @param newNote the new note text
-     * @throws NullPointerException if symbol is null
-     */
-    public void updateWatchlistNote(String symbol, String newNote) {
-        Objects.requireNonNull(symbol, "Symbol cannot be null");
-        if (player == null) return;
-        player.updateWatchlistNote(symbol, newNote);
-        notifyObservers();
-    }
-
-    private void notifyObservers() {
-        observers.forEach(GameObserver::onGameUpdated);
-    }
-}

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/GameService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/GameService.java
@@ -23,7 +23,6 @@ import edu.ntnu.idatt2003.millions.model.stock.Stock;
 import edu.ntnu.idatt2003.millions.model.transaction.Transaction;
 import edu.ntnu.idatt2003.millions.observer.GameObserver;
 import edu.ntnu.idatt2003.millions.model.leaderboard.Outcome;
-import edu.ntnu.idatt2003.millions.service.LeaderboardService;
 import edu.ntnu.idatt2003.millions.service.notification.NotificationService;
 
 import java.io.File;

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/GameService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/GameService.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.service;
 
 import edu.ntnu.idatt2003.millions.file.game.GameFileHandler;
@@ -42,11 +43,7 @@ import java.util.logging.Logger;
  *
  * <p>{@code createNewGame} validates player input before performing any file I/O
  * and only swaps in the new state once the player and exchange are fully
- * constructed, so failures leave the previous game intact. The four-argument
- * overload accepts the {@link Currency} of the stock prices so the
- * {@link Exchange} can convert to NOK through its {@link CurrencyConverter};
- * the three-argument overload defaults to USD.</p>
- *
+ * constructed, so failures leave the previous game intact.</p>
  */
 public class GameService {
 
@@ -98,20 +95,13 @@ public class GameService {
         observers.add(observer);
     }
 
-    /**
-     * Returns whether the game has ended.
-     *
-     * @return true if the game is over; false otherwise
-     */
     public boolean isGameOver() {
         return gameOver;
     }
 
     /**
-     * Marks the game as over and notifies observers.
-     * Call this when the player cannot cover obligations even through full liquidation.
-     * After this call, all trading and week-advance operations will throw
-     * {@link IllegalStateException}.
+     * Marks the game as over and notifies observers. After this call, all trading
+     * and week-advance operations throw {@link IllegalStateException}.
      */
     public void declareGameOver() {
         this.gameOver = true;
@@ -133,7 +123,6 @@ public class GameService {
 
     /**
      * Saves the current game state to a JSON file.
-     * Delegates the file operation to the game file handler.
      *
      * @param file the file to save the game state to
      * @throws NullPointerException  if the file is null
@@ -166,7 +155,6 @@ public class GameService {
 
     /**
      * Clears the stored save path so the next save will prompt for a location.
-     * Called when a write to the stored path fails.
      */
     public void clearCurrentSaveFile() {
         this.currentSaveFile = null;
@@ -202,9 +190,10 @@ public class GameService {
      * @param name      the player name
      * @param capital   the starting capital, in NOK
      * @param stockFile the CSV file with stock data
-     * @throws NullPointerException     if any argument is null
-     * @throws IllegalArgumentException if name is blank, capital is negative,
-     *                                  or the file contains no stocks
+     * @throws NullPointerException      if any argument is null
+     * @throws IllegalArgumentException  if name is blank, capital is negative,
+     *                                   or the file contains no stocks
+     * @throws InvalidStockDataException if the stock file contains malformed or no valid entries
      */
     public void createNewGame(String name, BigDecimal capital, File stockFile)
             throws InvalidStockDataException {
@@ -214,16 +203,16 @@ public class GameService {
     /**
      * Creates a new game from the given stock file, tagging every parsed
      * {@link Stock} with {@code currency} so the {@link Exchange} converts
-     * prices to NOK on every trade. See class-level Javadoc for validation
-     * order and observer semantics.
+     * prices to NOK on every trade.
      *
      * @param name      the player name
      * @param capital   the starting capital, in NOK
      * @param stockFile the CSV file with stock data
      * @param currency  the currency the stock prices are quoted in
-     * @throws NullPointerException     if any argument is null
-     * @throws IllegalArgumentException if name is blank, capital is negative,
-     *                                  or the file contains no stocks
+     * @throws NullPointerException      if any argument is null
+     * @throws IllegalArgumentException  if name is blank, capital is negative,
+     *                                   or the file contains no stocks
+     * @throws InvalidStockDataException if the stock file contains malformed or no valid entries
      */
     public void createNewGame(String name, BigDecimal capital, File stockFile, Currency currency)
             throws InvalidStockDataException {
@@ -235,14 +224,6 @@ public class GameService {
         activate(newPlayer, stocks);
     }
 
-    /**
-     * Activates a new game state once the player and stocks have been
-     * successfully constructed and loaded. Replaces the active player and
-     * exchange atomically and notifies observers.
-     *
-     * @param newPlayer the validated player instance
-     * @param stocks    the stocks to list on the exchange
-     */
     private void activate(Player newPlayer, List<Stock> stocks) {
         this.player = newPlayer;
         this.exchange = new Exchange(DEFAULT_EXCHANGE_NAME, stocks, new FixedRateCurrencyConverter());
@@ -251,15 +232,6 @@ public class GameService {
         notifyObservers();
     }
 
-    /**
-     * Loads default stock data from the application resources.
-     * Streams the resource directly through the {@link StockFileHandler}
-     * so no intermediate file is written to disk.
-     *
-     * @return the default stocks for a new game
-     * @throws IllegalStateException if the default stock data cannot be found
-     * @throws UncheckedIOException  if the default stock data cannot be read
-     */
     private List<Stock> loadDefaultStocks() {
         StockFileHandler stockFileHandler = new CsvStockFileHandler();
         try (InputStream inputStream = GameService.class.getResourceAsStream(DEFAULT_STOCK_RESOURCE)) {
@@ -275,11 +247,7 @@ public class GameService {
     }
 
     /**
-     * Loads a saved game state from a JSON file.
-     * Delegates the file operation to the game file handler and reinitializes
-     * the exchange with a {@link FixedRateCurrencyConverter}, since the
-     * converter is transient and not restored by Gson. Notifies observers
-     * once the loaded state is in place.
+     * Loads a saved game state from a JSON file and notifies observers.
      *
      * @param file the file to load the game state from
      * @throws NullPointerException     if the file is null
@@ -298,12 +266,11 @@ public class GameService {
 
     /**
      * Buys the given quantity of a stock for the current player.
-     * Delegates the actual transaction to {@link Exchange} and notifies
-     * observers on success.
      *
      * @param symbol   the symbol of the stock to buy
      * @param quantity the quantity to buy
      * @return the completed purchase transaction
+     * @throws IllegalStateException if the game is over
      */
     public Transaction buy(String symbol, BigDecimal quantity) {
         if (gameOver) throw new IllegalStateException("Game is over");
@@ -313,12 +280,12 @@ public class GameService {
     }
 
     /**
-     * Sells the full quantity of a share for the current player. Convenience
-     * overload that delegates to {@link #sell(Share, BigDecimal)} with the
-     * share's full quantity.
+     * Sells the full quantity of a share for the current player.
      *
      * @param share the share to sell
      * @return the completed sale transaction
+     * @throws NullPointerException  if share is null
+     * @throws IllegalStateException if the game is over
      */
     public Transaction sell(Share share) {
         Objects.requireNonNull(share, "Share cannot be null");
@@ -329,12 +296,11 @@ public class GameService {
      * Sells the given quantity of a share for the current player. When the
      * quantity is less than the share's full position, the remainder stays
      * in the player's portfolio with the original purchase price preserved.
-     * Delegates the actual transaction to {@link Exchange} and notifies
-     * observers on success.
      *
      * @param share    the share to sell from
      * @param quantity the quantity to sell
      * @return the completed sale transaction
+     * @throws IllegalStateException if the game is over
      */
     public Transaction sell(Share share, BigDecimal quantity) {
         if (gameOver) throw new IllegalStateException("Game is over");
@@ -348,6 +314,8 @@ public class GameService {
      * Assumes the player has enough cash to cover all obligations (interest +
      * any maturing loan principals); use {@link #executeForcedSale} instead
      * when they cannot.
+     *
+     * @throws IllegalStateException if the game is over
      */
     public void advanceWeek() {
         if (gameOver) throw new IllegalStateException("Game is over");
@@ -374,6 +342,7 @@ public class GameService {
      * @param shares      the shares the player has chosen to sell
      * @param currentWeek the game week being processed (the week after the current one)
      * @throws InsufficientSaleProceedsException if the net sale total is less than total obligations
+     * @throws IllegalStateException             if the game is over
      */
     public void executeForcedSale(List<Share> shares, int currentWeek)
             throws InsufficientSaleProceedsException {
@@ -414,20 +383,10 @@ public class GameService {
         notifyObservers();
     }
 
-    /**
-     * Returns the current player.
-     *
-     * @return the player
-     */
     public Player getPlayer() {
         return player;
     }
 
-    /**
-     * Returns the current exchange.
-     *
-     * @return the exchange
-     */
     public Exchange getExchange() {
         return exchange;
     }
@@ -453,15 +412,14 @@ public class GameService {
     }
 
     /**
-     * Creates a loan against the given offer, disburses the principal to the player,
-     * and notifies observers. Delegates all capacity and limit validation to
-     * {@link edu.ntnu.idatt2003.millions.model.player.Player#takeLoan}.
+     * Creates a loan against the given offer and disburses the principal to the player.
      *
      * @param offer  the loan offer the player is accepting
      * @param amount the principal to disburse; must be positive and within offer limits
      * @return the created {@link Loan}
-     * @throws NullPointerException    if either argument is null
+     * @throws NullPointerException     if either argument is null
      * @throws IllegalArgumentException if amount exceeds the offer's maximum principal
+     * @throws IllegalStateException    if the game is over
      * @throws edu.ntnu.idatt2003.millions.model.loan.ExcessiveDebtException
      *         if the loan would breach the player's debt-to-net-worth limit
      */
@@ -483,6 +441,7 @@ public class GameService {
      * @param loan the loan to repay
      * @throws NullPointerException     if loan is null
      * @throws IllegalArgumentException if the player cannot afford the repayment
+     * @throws IllegalStateException    if the game is over
      */
     public void repayLoan(Loan loan) {
         if (gameOver) throw new IllegalStateException("Game is over");
@@ -527,6 +486,10 @@ public class GameService {
         }
     }
 
+    /**
+     * Clears all notifications from the current player and notifies observers.
+     * No-op if no game is active.
+     */
     public void clearAllNotifications() {
         if (player == null) return;
         player.clearAllNotifications();
@@ -562,8 +525,7 @@ public class GameService {
     }
 
     /**
-     * Updates the note for the given symbol in the player's watchlist via
-     * {@link WatchlistEntry}.
+     * Updates the note for the given symbol in the player's watchlist.
      * No-op if the symbol is not on the watchlist.
      *
      * @param symbol  the ticker symbol of the entry to update
@@ -577,9 +539,6 @@ public class GameService {
         notifyObservers();
     }
 
-    /**
-     * Notifies all registered observers that the game state has changed.
-     */
     private void notifyObservers() {
         observers.forEach(GameObserver::onGameUpdated);
     }

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/GameService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/GameService.java
@@ -454,6 +454,10 @@ public class GameService {
      * {@link Outcome#RETIRED} leaderboard entry, and persists the final state
      * to the current save file if one exists. The caller is responsible for
      * closing the application after this returns.
+     *
+     * <p>Unlike other trading methods, this does not check the {@code gameOver}
+     * flag. Retirement must remain available after bankruptcy or game-over so
+     * the player can always complete and exit the game.</p>
      */
     public void sellAllAndExit() {
         for (Share share : new ArrayList<>(player.getPortfolio().getShares())) {

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/LeaderboardService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/LeaderboardService.java
@@ -147,7 +147,7 @@ public class LeaderboardService {
         List<LeaderboardEntry> entries;
         try {
             entries = readMutable();
-        } catch (LeaderboardCorruptException | IllegalStateException e) {
+        } catch (LeaderboardCorruptException | IllegalStateException | UncheckedIOException e) {
             LOGGER.log(Level.WARNING, "Could not read leaderboard", e);
             return List.of();
         }

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/LeaderboardService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/LeaderboardService.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.service;
 
 import edu.ntnu.idatt2003.millions.file.leaderboard.JsonLeaderboardFileHandler;
@@ -40,6 +41,7 @@ import java.util.logging.Logger;
  * to see others' results, play, commit and push to share yours. The path is
  * configurable via the DI constructor so tests can use a temp file.
  */
+@SuppressWarnings("ClassCanBeRecord")
 public class LeaderboardService {
 
     private static final Logger LOGGER = Logger.getLogger(LeaderboardService.class.getName());
@@ -155,18 +157,10 @@ public class LeaderboardService {
         return entries;
     }
 
-    /**
-     * Reads the leaderboard file into a fresh mutable list so callers can
-     * upsert without affecting any internal cache.
-     */
     private List<LeaderboardEntry> readMutable() throws LeaderboardCorruptException {
         return new ArrayList<>(fileHandler.readAll(file));
     }
 
-    /**
-     * Finds the index of an entry with the given session id, or {@code -1}
-     * if none exists.
-     */
     private int indexOfSession(List<LeaderboardEntry> entries, String sessionId) {
         for (int i = 0; i < entries.size(); i++) {
             if (entries.get(i).sessionId().equals(sessionId)) {
@@ -176,11 +170,6 @@ public class LeaderboardService {
         return -1;
     }
 
-    /**
-     * Builds a fresh entry from the player's current state. Uses
-     * {@link Player#getNetWorthChangePercentSinceStart} so returnPercent matches
-     * how the rest of the app computes growth.
-     */
     private LeaderboardEntry snapshot(Player player, Exchange exchange,
                                       CurrencyConverter converter, Outcome outcome) {
         return new LeaderboardEntry(

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/LoanPreviewService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/LoanPreviewService.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.service;
 
 import edu.ntnu.idatt2003.millions.model.loan.LoanOffer;

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/PlayerStatsService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/PlayerStatsService.java
@@ -120,7 +120,7 @@ public class PlayerStatsService {
             int growthPart = Math.clamp((long) Math.floor(growthPercent / 2), 0, 10);
             return (weeksPart + growthPart) / 20.0;
         } else {
-            int weeksPart = Math.clamp(weeksTraded, 0, 10);
+            int weeksPart = Math.clamp((long) weeksTraded - 10, 0, 10);
             int growthPart = Math.clamp((long) Math.floor((growthPercent - 20) / 2), 0, 40);
             return (weeksPart + growthPart) / 50.0;
         }

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/PlayerStatsService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/PlayerStatsService.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.service;
 
 import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
@@ -10,29 +11,48 @@ import java.util.Objects;
 
 /**
  * Stateless read service for player net-worth and status queries.
- * All methods accept {@link Player} and {@link CurrencyConverter} as parameters
- * so this service holds no state and can be shared freely.
  */
 public class PlayerStatsService {
 
-    /** Returns the player's current net worth in NOK. */
+    /**
+     * Returns the player's current net worth in NOK.
+     *
+     * @param player    the active player
+     * @param converter the currency converter used to value portfolio positions
+     * @return net worth in NOK
+     */
     public BigDecimal getNetWorth(Player player, CurrencyConverter converter) {
         return player.getNetWorth(converter);
     }
 
-    /** Returns the absolute change in net worth since the start of the game, in NOK. */
+    /**
+     * Returns the absolute change in net worth since the start of the game, in NOK.
+     *
+     * @param player    the active player
+     * @param converter the currency converter used to value portfolio positions
+     * @return net worth change in NOK; negative if the player has lost money
+     */
     public BigDecimal getNetWorthChangeSinceStart(Player player, CurrencyConverter converter) {
         return player.getNetWorthChangeSinceStart(converter);
     }
 
-    /** Returns the percentage change in net worth since the start of the game. */
+    /**
+     * Returns the percentage change in net worth since the start of the game.
+     *
+     * @param player    the active player
+     * @param converter the currency converter used to value portfolio positions
+     * @return percentage change; negative if the player has lost money
+     */
     public BigDecimal getNetWorthChangePercentSinceStart(Player player, CurrencyConverter converter) {
         return player.getNetWorthChangePercentSinceStart(converter);
     }
 
     /**
      * Returns the absolute change in net worth since the previous week, in NOK.
-     * Returns null if no week has been advanced yet.
+     *
+     * @param player    the active player
+     * @param converter the currency converter used to value portfolio positions
+     * @return net worth change in NOK; null if no week has been advanced yet
      */
     public BigDecimal getWeeklyNetWorthChange(Player player, CurrencyConverter converter) {
         return player.getWeeklyNetWorthChange(converter);
@@ -40,13 +60,22 @@ public class PlayerStatsService {
 
     /**
      * Returns the percentage change in net worth since the previous week.
-     * Returns null if no week has been advanced yet.
+     *
+     * @param player    the active player
+     * @param converter the currency converter used to value portfolio positions
+     * @return percentage change; null if no week has been advanced yet
      */
     public BigDecimal getWeeklyNetWorthChangePercent(Player player, CurrencyConverter converter) {
         return player.getWeeklyNetWorthChangePercent(converter);
     }
 
-    /** Returns the player's current status level. */
+    /**
+     * Returns the player's current status level.
+     *
+     * @param player    the active player
+     * @param converter the currency converter used to compute net worth
+     * @return the current {@link PlayerStatusLevel}
+     */
     public PlayerStatusLevel getStatus(Player player, CurrencyConverter converter) {
         return player.getStatus(converter);
     }
@@ -88,19 +117,23 @@ public class PlayerStatsService {
 
         if (status == PlayerStatusLevel.NOVICE) {
             int weeksPart  = Math.min(10, weeksTraded);
-            int growthPart = Math.min(10, Math.max(0, (int) Math.floor(growthPercent / 2)));
+            int growthPart = Math.clamp((long) Math.floor(growthPercent / 2), 0, 10);
             return (weeksPart + growthPart) / 20.0;
         } else {
-            int weeksPart  = Math.min(10, Math.max(0, weeksTraded - 10));
-            int growthPart = Math.min(40, Math.max(0, (int) Math.floor((growthPercent - 20) / 2)));
+            int weeksPart = Math.clamp(weeksTraded, 0, 10);
+            int growthPart = Math.clamp((long) Math.floor((growthPercent - 20) / 2), 0, 40);
             return (weeksPart + growthPart) / 50.0;
         }
     }
 
     /**
      * Returns the player's recorded net-worth history — one entry per game week,
-     * in order from week 1 to the current week. The returned list is a defensive
-     * copy and does not reflect later mutations of the player.
+     * in chronological order from week 1 to the current week. The returned list
+     * is a defensive copy and does not reflect later mutations of the player.
+     *
+     * @param player the active player
+     * @return immutable snapshot of the net-worth history; never null
+     * @throws NullPointerException if player is null
      */
     public List<BigDecimal> getNetWorthHistory(Player player) {
         Objects.requireNonNull(player, "Player cannot be null");

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/PortfolioService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/PortfolioService.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.service;
 
 import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
@@ -10,8 +11,6 @@ import java.util.Currency;
 
 /**
  * Stateless read service for portfolio value queries.
- * All methods accept domain objects as parameters so this service holds no state.
- * Provides both per-share and aggregate queries used by portfolio and stocks views.
  */
 public class PortfolioService {
 
@@ -20,6 +19,10 @@ public class PortfolioService {
     /**
      * Returns the total market value of the player's portfolio in NOK
      * ({@code salesPrice × quantity} per share, converted to NOK, no fees deducted).
+     *
+     * @param player    the player whose portfolio to inspect
+     * @param converter the currency converter used to translate values to NOK
+     * @return total portfolio market value in NOK
      */
     public BigDecimal getValue(Player player, CurrencyConverter converter) {
         return player.getPortfolio().getNetWorth(converter);
@@ -27,7 +30,11 @@ public class PortfolioService {
 
     /**
      * Returns the current market value of a share position in NOK
-     * (salesPrice × quantity × exchange rate, no fees deducted).
+     * ({@code salesPrice × quantity × exchange rate}, no fees deducted).
+     *
+     * @param share     the share position to evaluate
+     * @param converter the currency converter used to translate to NOK
+     * @return market value of the position in NOK
      */
     public BigDecimal getShareValueInNok(Share share, CurrencyConverter converter) {
         return converter.convert(share.getCurrentValue(), share.getStock().getCurrency(), NOK);
@@ -35,34 +42,52 @@ public class PortfolioService {
 
     /**
      * Returns the unrealized return on a share position in NOK
-     * (currentValue − cost, converted to NOK at the current rate).
+     * ({@code currentValue − cost}, converted to NOK at the current rate).
+     *
+     * @param share     the share position to evaluate
+     * @param converter the currency converter used to translate to NOK
+     * @return unrealized gain or loss in NOK; negative if the position is at a loss
      */
     public BigDecimal getShareReturnInNok(Share share, CurrencyConverter converter) {
         return converter.convert(share.getReturnNative(), share.getStock().getCurrency(), NOK);
     }
 
     /**
-     * Returns the liquidation value of a share position in NOK: what the player
-     * would actually receive after commission and tax if the entire position were
-     * sold now, converted to NOK at the current exchange rate.
+     * Returns the liquidation value of a share position in NOK: the net proceeds
+     * after commission and tax if the entire position were sold now.
+     *
+     * @param share     the share position to evaluate
+     * @param converter the currency converter used to translate to NOK
+     * @return net sale proceeds in NOK
      */
     public BigDecimal getLiquidationValueInNok(Share share, CurrencyConverter converter) {
         return converter.convert(share.getLiquidationValue(), share.getStock().getCurrency(), NOK);
     }
 
-    /** Returns the total unrealized return across all portfolio positions in NOK. */
+    /**
+     * Returns the total unrealized return across all portfolio positions in NOK.
+     *
+     * @param player    the player whose portfolio to inspect
+     * @param converter the currency converter used to translate values to NOK
+     * @return total unrealized gain or loss in NOK; negative if the portfolio is at a loss
+     */
     public BigDecimal getTotalReturnInNok(Player player, CurrencyConverter converter) {
         return player.getPortfolio().getTotalReturnInNok(converter);
     }
 
-    /** Returns the total portfolio return as a percentage of total cost in NOK. */
+    /**
+     * Returns the total portfolio return as a percentage of total cost in NOK.
+     *
+     * @param player    the player whose portfolio to inspect
+     * @param converter the currency converter used to translate values to NOK
+     * @return return percentage; negative if the portfolio is at a loss
+     */
     public BigDecimal getTotalReturnPercent(Player player, CurrencyConverter converter) {
         return player.getPortfolio().getTotalReturnPercent(converter);
     }
 
     /**
      * Returns the total cost basis of all portfolio positions in NOK.
-     * Computed as current market value minus total unrealized return.
      * Returns zero when the portfolio is empty.
      *
      * @param player    the player whose portfolio to inspect
@@ -76,13 +101,9 @@ public class PortfolioService {
     /**
      * Returns the total portfolio value change for the current week in NOK.
      *
-     * <p>Computed as the sum of {@code latestPriceChange × quantity} for every
-     * {@link Share} in the portfolio, with each stock's price change converted
-     * from its native currency to NOK using the given converter.
-     *
      * @param player    the player whose portfolio to inspect
      * @param converter the currency converter used to translate values to NOK
-     * @return total weekly return in NOK, negative when the portfolio lost value
+     * @return total weekly return in NOK; negative when the portfolio lost value
      */
     public BigDecimal getWeeklyReturnInNok(Player player, CurrencyConverter converter) {
         return player.getPortfolio().getShares().stream()
@@ -96,8 +117,7 @@ public class PortfolioService {
     /**
      * Returns the portfolio's weekly return as a percentage of the total cost basis in NOK.
      *
-     * <p>Returns zero when the portfolio is empty or the invested amount is zero
-     * to avoid division by zero.
+     * <p>Returns zero when the portfolio is empty or the invested amount is zero.
      *
      * @param player    the player whose portfolio to inspect
      * @param converter the currency converter used to translate values to NOK

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/RealizedReturnsService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/RealizedReturnsService.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.service;
 
 import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
@@ -9,7 +10,6 @@ import java.util.Map;
 
 /**
  * Stateless read service for realized-return queries (gains, losses, tax, commission).
- * All methods accept domain objects as parameters so this service holds no state.
  */
 public class RealizedReturnsService {
 
@@ -18,6 +18,8 @@ public class RealizedReturnsService {
     /**
      * Returns the total realized gain across all profitable sales, converted to NOK.
      *
+     * @param player    the active player
+     * @param converter the currency converter used to translate values to NOK
      * @return total realized gain in NOK; zero if no profitable sales exist
      */
     public BigDecimal getGainsInNok(Player player, CurrencyConverter converter) {
@@ -26,9 +28,11 @@ public class RealizedReturnsService {
 
     /**
      * Returns the total realized loss across all losing sales, converted to NOK.
-     * The value is non-negative — losses are returned as a positive number for display purposes.
+     * Losses are returned as a positive number for display purposes.
      *
-     * @return total realized loss in NOK as a non-negative value
+     * @param player    the active player
+     * @param converter the currency converter used to translate values to NOK
+     * @return total realized loss in NOK as a non-negative value; zero if no losing sales exist
      */
     public BigDecimal getLossesInNok(Player player, CurrencyConverter converter) {
         return sumToNok(player.getTransactionArchive().getRealizedLossesByCurrency(), converter);
@@ -36,23 +40,43 @@ public class RealizedReturnsService {
 
     /**
      * Returns the net realized result: gains minus losses, in NOK.
-     * Can be negative if losses exceed gains.
+     *
+     * @param player    the active player
+     * @param converter the currency converter used to translate values to NOK
+     * @return net realized result in NOK; negative if losses exceed gains
      */
     public BigDecimal getNetRealizedInNok(Player player, CurrencyConverter converter) {
         return getGainsInNok(player, converter).subtract(getLossesInNok(player, converter));
     }
 
-    /** Returns the total tax paid across all sales, converted to NOK. */
+    /**
+     * Returns the total tax paid across all sales, converted to NOK.
+     *
+     * @param player    the active player
+     * @param converter the currency converter used to translate values to NOK
+     * @return total tax paid in NOK; zero if no taxable sales exist
+     */
     public BigDecimal getTotalTaxPaidInNok(Player player, CurrencyConverter converter) {
         return sumToNok(player.getTransactionArchive().getTotalSaleTaxByCurrency(), converter);
     }
 
-    /** Returns the total commission paid across all sales, converted to NOK. */
+    /**
+     * Returns the total commission paid across all sales, converted to NOK.
+     *
+     * @param player    the active player
+     * @param converter the currency converter used to translate values to NOK
+     * @return total commission paid in NOK; zero if no sales have been made
+     */
     public BigDecimal getTotalSaleCommissionInNok(Player player, CurrencyConverter converter) {
         return sumToNok(player.getTransactionArchive().getTotalSaleCommissionByCurrency(), converter);
     }
 
-    /** Returns the total number of completed sales. */
+    /**
+     * Returns the total number of completed sales.
+     *
+     * @param player the active player
+     * @return number of sales recorded in the transaction archive
+     */
     public int getSalesCount(Player player) {
         return player.getTransactionArchive().getSalesCount();
     }

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/StockHistoryService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/StockHistoryService.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.service;
 
 import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
@@ -12,11 +13,6 @@ import java.util.Objects;
 
 /**
  * Stateless read service computing derived price-history values for a {@link Stock}.
- *
- * <p>Holds no state and reads freely from the domain without mutating it, in line with
- * the application's read-service layer ({@link PlayerStatsService}, {@link PortfolioService}).
- * Views call it directly and render the returned rows: all numeric derivation lives here
- * rather than in the view, keeping presentation free of business logic.</p>
  */
 public final class StockHistoryService {
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/StockStatsService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/StockStatsService.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.service;
 
 import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
@@ -9,8 +10,6 @@ import java.util.Objects;
 
 /**
  * Stateless read service computing a stock's current key figures expressed in NOK.
- *
- * <p>Provides point-in-time values.</p>
  *
  * <p>Complements {@link StockHistoryService}, which derives time-series values (weekly change
  * rows) across the price history; this service returns single scalar figures instead.</p>

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/TransactionPreviewService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/TransactionPreviewService.java
@@ -11,6 +11,7 @@ import edu.ntnu.idatt2003.millions.model.transaction.TransactionPreview;
 
 import java.math.BigDecimal;
 import java.util.Currency;
+import java.util.Objects;
 
 /**
  * Produces {@link TransactionPreview} snapshots for a prospective purchase or sale
@@ -30,9 +31,14 @@ public class TransactionPreviewService {
      * @param player    the player who would perform the purchase
      * @param converter used to convert the native-currency total to NOK
      * @return a preview with gross/commission/total in native currency and balanceAfter in NOK
+     * @throws NullPointerException if any argument is null
      */
     public TransactionPreview previewPurchase(
             Stock stock, BigDecimal quantity, Player player, CurrencyConverter converter) {
+        Objects.requireNonNull(stock, "Stock cannot be null");
+        Objects.requireNonNull(quantity, "Quantity cannot be null");
+        Objects.requireNonNull(player, "Player cannot be null");
+        Objects.requireNonNull(converter, "Converter cannot be null");
 
         Share hypothetical = new Share(stock, quantity, stock.getSalesPrice());
         PurchaseCalculator calc = new PurchaseCalculator(hypothetical);
@@ -59,10 +65,15 @@ public class TransactionPreviewService {
      * @param converter used to convert the native-currency payout to NOK
      * @return a preview with gross/commission/tax/total/profit in native currency
      *         and balanceAfter in NOK
+     * @throws NullPointerException     if any argument is null
      * @throws IllegalArgumentException if {@code quantity} exceeds the position held in {@code share}
      */
     public TransactionPreview previewSale(
             Share share, BigDecimal quantity, Player player, CurrencyConverter converter) {
+        Objects.requireNonNull(share, "Share cannot be null");
+        Objects.requireNonNull(quantity, "Quantity cannot be null");
+        Objects.requireNonNull(player, "Player cannot be null");
+        Objects.requireNonNull(converter, "Converter cannot be null");
 
         if (quantity.compareTo(share.getQuantity()) > 0) {
             throw new IllegalArgumentException(

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/TransactionPreviewService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/TransactionPreviewService.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.service;
 
 import edu.ntnu.idatt2003.millions.model.calculator.PurchaseCalculator;
@@ -12,22 +13,17 @@ import java.math.BigDecimal;
 import java.util.Currency;
 
 /**
- * Domain Service that produces transaction previews without mutating state.
- *
- * <p>Coordinates calculations across {@link Stock}, {@link Share},
- * {@link Player} and the calculator classes to answer questions like
- * "what would this purchase cost?" or "what would I receive from this
- * sale?". Used by controllers to feed dialogs and other view components.</p>
+ * Produces {@link TransactionPreview} snapshots for a prospective purchase or sale
+ * without mutating any model state.
  */
 public class TransactionPreviewService {
 
     private static final Currency NOK = Currency.getInstance("NOK");
 
     /**
-     * Computes a preview of buying the given quantity of a stock for the given
-     * player. Gross, commission, and total are in the stock's native currency.
-     * {@code balanceAfter} is in NOK — the converter is used to translate the
-     * total cost before subtracting from the player's NOK balance.
+     * Returns a preview of buying the given quantity of a stock for the given player.
+     * Gross, commission, and total are in the stock's native currency;
+     * {@code balanceAfter} is in NOK.
      *
      * @param stock     the stock to buy
      * @param quantity  the quantity to buy
@@ -53,17 +49,17 @@ public class TransactionPreviewService {
     }
 
     /**
-     * Computes a preview of selling the given quantity of an owned share for the
-     * given player. Gross, commission, tax, total, and profit are in the stock's
-     * native currency. {@code balanceAfter} is in NOK — the converter is used to
-     * translate the net payout before adding it to the player's NOK balance.
+     * Returns a preview of selling the given quantity of an owned share for the given player.
+     * Gross, commission, tax, total, and profit are in the stock's native currency;
+     * {@code balanceAfter} is in NOK.
      *
      * @param share     the share to sell from
-     * @param quantity  the quantity to sell (may be less than the full share)
+     * @param quantity  the quantity to sell; may be less than the full position
      * @param player    the player who would perform the sale
      * @param converter used to convert the native-currency payout to NOK
      * @return a preview with gross/commission/tax/total/profit in native currency
      *         and balanceAfter in NOK
+     * @throws IllegalArgumentException if {@code quantity} exceeds the position held in {@code share}
      */
     public TransactionPreview previewSale(
             Share share, BigDecimal quantity, Player player, CurrencyConverter converter) {

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/TransactionStatsService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/TransactionStatsService.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.service;
 
 import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
@@ -13,24 +14,12 @@ import java.util.List;
  * transactions tab — both per-transaction figures for the history
  * table and aggregated totals for the summary card.
  *
- * <p>Sits alongside {@code PlayerStatsService}, {@code PortfolioService}
- * and {@code RealizedReturnsService}: like them, it holds no state, takes
- * the model objects it needs as method arguments, and returns plain values
- * the view can render. This is the pattern SoC.md prescribes for derived
- * values that don't naturally live on a single domain object — the
- * computation crosses {@link Transaction}, {@link Share}, the calculator
- * tied to its subclass, and the active {@link CurrencyConverter}.</p>
- *
  * <p>Native-currency values are converted to NOK so the table stays denominated
  * in one currency. Both native and NOK figures are returned so views can show
- * NOK in the cell and the native amount in a tooltip without recomputing.
- * Subtype-specific financial values (commission, tax, signed total, price per
- * share) are accessed through polymorphic methods on {@link Transaction}, keeping
- * this service free of {@code instanceof} dispatch.</p>
+ * NOK in the cell and the native amount in a tooltip without recomputing.</p>
  */
 public class TransactionStatsService {
 
-    /** Currency every NOK-denominated value is converted to. */
     private static final Currency NOK = Currency.getInstance("NOK");
 
     /**
@@ -65,13 +54,10 @@ public class TransactionStatsService {
      * Aggregates a list of transactions into Kjøp / Salg / Total figures
      * in NOK, ready to be rendered in the summary card.
      *
-     * <p>The aggregation reuses {@link #getStats} per transaction so the
-     * summary stays consistent with the table: a transaction's
-     * {@code amountNok} is already negative for purchases and positive
-     * for sales. The summary therefore exposes {@code purchasesNok} as
-     * a non-positive sum of outflows, {@code salesNok} as a non-negative
-     * sum of inflows, and {@code totalNok} as their sum — i.e. the net
-     * cash flow over the range.</p>
+     * <p>{@code amountNok} is negative for purchases and positive for sales.
+     * The summary therefore exposes {@code purchasesNok} as a non-positive
+     * sum of outflows, {@code salesNok} as a non-negative sum of inflows,
+     * and {@code totalNok} as their sum — the net cash flow over the range.</p>
      *
      * <p>If the input list is empty all three values are zero. Filtering
      * by week range is the caller's responsibility; this service holds

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/notification/NotificationService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/notification/NotificationService.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.service.notification;
 
 import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
@@ -17,12 +18,29 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+/**
+ * Evaluates game events and pushes the resulting {@link Notification} objects to the player.
+ * Called after each week advances and after a loan is taken.
+ */
 public class NotificationService {
 
+    /** Debt-to-capacity ratio at or above which a high-debt warning notification is generated. */
     public static final BigDecimal DEBT_RATIO_WARNING_THRESHOLD = new BigDecimal("0.85");
+
+    /** Minimum absolute price change (as a fraction) that triggers a stock-movement notification. */
     public static final BigDecimal STOCK_MOVEMENT_THRESHOLD = new BigDecimal("0.09");
+
+    /** Number of weeks before loan maturity at which a near-maturity warning is generated. */
     public static final int LOAN_NEAR_MATURITY_WEEKS = 3;
 
+    /**
+     * Runs all notification checks for the current week and pushes any triggered
+     * notifications to {@code player}.
+     *
+     * @param player    the player to check and push notifications to
+     * @param exchange  the exchange providing the current week number and stock data
+     * @param converter currency converter used for debt-ratio and status checks
+     */
     public void onWeekAdvanced(Player player, Exchange exchange, CurrencyConverter converter) {
         int currentWeek = exchange.getWeek();
         checkLoanRepayments(player, currentWeek);
@@ -33,6 +51,14 @@ public class NotificationService {
         checkStatusChange(player, currentWeek, converter);
     }
 
+    /**
+     * Re-evaluates the debt-ratio check immediately after a loan is taken and pushes
+     * a warning to {@code player} if the threshold is exceeded.
+     *
+     * @param player      the player who took the loan
+     * @param currentWeek the week in which the loan was taken
+     * @param converter   currency converter used to compute loan capacity
+     */
     public void onLoanTaken(Player player, int currentWeek, CurrencyConverter converter) {
         checkDebtRatio(player, currentWeek, converter);
     }

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/toast/Toast.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/toast/Toast.java
@@ -1,3 +1,11 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.service.toast;
 
+/**
+ * A brief user-facing notification displayed as a transient overlay.
+ *
+ * @param id      unique identifier for this toast
+ * @param type    severity category of the notification
+ * @param message text to display to the user
+ */
 public record Toast(long id, ToastType type, String message) {}

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/toast/ToastService.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/toast/ToastService.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.service.toast;
 
 
@@ -16,15 +17,31 @@ public class ToastService {
     private final List<Consumer<Toast>> listeners = new ArrayList<>();
     private long nextId = 1;
 
+    /**
+     * Creates a {@link Toast} with an auto-assigned ID and delivers it to all registered listeners.
+     *
+     * @param message the already-translated text to display
+     * @param type    severity category of the notification
+     */
     public void show(String message, ToastType type) {
         Toast toast = new Toast(nextId++, type, message);
         listeners.forEach(l -> l.accept(toast));
     }
 
+    /**
+     * Registers a listener to receive future toasts.
+     *
+     * @param listener the consumer to invoke when a toast is published
+     */
     public void addListener(Consumer<Toast> listener) {
         listeners.add(listener);
     }
 
+    /**
+     * Removes a previously registered listener; no-op if not registered.
+     *
+     * @param listener the consumer to remove
+     */
     public void removeListener(Consumer<Toast> listener) {
         listeners.remove(listener);
     }

--- a/src/main/java/edu/ntnu/idatt2003/millions/service/toast/ToastType.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/service/toast/ToastType.java
@@ -1,6 +1,12 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.service.toast;
 
+/**
+ * Severity category of a {@link Toast} notification.
+ */
 public enum ToastType {
+    /** Operation completed successfully. */
     SUCCESS,
+    /** Operation failed or an error was encountered. */
     ERROR
 }

--- a/src/test/java/edu/ntnu/idatt2003/millions/service/GameServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/service/GameServiceTest.java
@@ -372,6 +372,20 @@ class GameServiceTest {
                     .subtract(PURCHASE_COMMISSION)
                     .compareTo(gameService.getPlayer().getCash()));
         }
+
+        @Test
+        @DisplayName("Should throw NullPointerException when symbol is null")
+        void throwsWhenSymbolIsNull() {
+            assertThrows(NullPointerException.class, () ->
+                    gameService.buy(null, BigDecimal.ONE));
+        }
+
+        @Test
+        @DisplayName("Should throw NullPointerException when quantity is null")
+        void throwsWhenQuantityIsNull() {
+            assertThrows(NullPointerException.class, () ->
+                    gameService.buy("EQNR", null));
+        }
     }
 
     @Nested
@@ -395,6 +409,29 @@ class GameServiceTest {
             assertEquals(0, STARTING_MONEY.subtract(PURCHASE_COMMISSION)
                     .subtract(SALE_COMMISSION)
                     .compareTo(gameService.getPlayer().getCash()));
+        }
+
+        @Test
+        @DisplayName("Should throw NullPointerException when share is null")
+        void throwsWhenShareIsNull() {
+            assertThrows(NullPointerException.class, () ->
+                    gameService.sell((Share) null));
+        }
+
+        @Test
+        @DisplayName("Should throw NullPointerException when share is null (two-arg overload)")
+        void throwsWhenShareIsNullTwoArg() {
+            assertThrows(NullPointerException.class, () ->
+                    gameService.sell(null, BigDecimal.ONE));
+        }
+
+        @Test
+        @DisplayName("Should throw NullPointerException when quantity is null")
+        void throwsWhenQuantityIsNull() {
+            gameService.buy("EQNR", QUANTITY);
+            Share share = gameService.getPlayer().getPortfolio().getShares("EQNR").getFirst();
+            assertThrows(NullPointerException.class, () ->
+                    gameService.sell(share, null));
         }
     }
 


### PR DESCRIPTION
25 commits covering every class in service.* with Javadoc
audit, plus quality fixes that surfaced during the audit.
Mirrors the approach used in the earlier model-layer
Javadoc PR.

## Documentation

Class-level and public-method Javadoc updated for:
GameService, LeaderboardService, LoanPreviewService,
NotificationService, PlayerStatsService, PortfolioService,
RealizedReturnsService, StockHistoryService,
StockStatsService, Toast, ToastService, ToastType,
TransactionPreviewService, TransactionStatsService,
GameObserver, TransactionFactory.

AI-assistance markers added on files where Javadoc was
substantively reworked.

## Substantive code changes (not just docs)

Each was driven by an observation surfaced during the
Javadoc audit, diagnosed before changing anything, and
landed as its own commit.

### GameService — active-game preconditions documented systematically
A walk-through found six public methods with implicit
"requires active game" preconditions that were not
documented (getPlayer, getExchange, getPreviousNetWorth,
declareGameOver, sellAllAndExit, addToWatchlist plus the
two watchlist siblings). Javadoc now makes the contract
explicit on all of them. The two unguarded getters were
verified to be safe — every call site lives in MainView,
which only mounts after createNewGame/loadGame succeeds.
No runtime guards added; the precondition lives in the
Javadoc.

### GameService — null-checks on buy/sell overloads
buy(String, BigDecimal) and sell(Share, BigDecimal)
lacked `Objects.requireNonNull` despite every other
public method in the class guarding non-primitives. Added
the missing checks to match the established convention.

### GameService — null-check on executeForcedSale.shares
Same convention applied to the forced-sale path.

### GameService — sellAllAndExit gameOver gap documented
The method intentionally has no gameOver guard
(retirement must remain available after bankruptcy) but
this wasn't documented. Added a Javadoc note to flag the
deliberate divergence from sibling methods.

### PlayerStatsService — INVESTOR-to-SPECULATOR progress formula corrected
Two tests in PlayerStatsServiceTest were failing because
the getProgressToNextStatus INVESTOR branch used
`Math.clamp(weeksTraded, 0, 10)` instead of
`Math.clamp(weeksTraded - 10, 0, 10)`. The first 10 weeks
were already counted toward reaching INVESTOR; the bar
should only fill based on weeks beyond 10. The tests
already encoded the correct contract — they were
catching a real divergence between spec and code.

### LeaderboardService — getAllEntries catch list aligned with Javadoc
The method's Javadoc promised "Read failures are logged
and treated as empty" but the catch list missed
UncheckedIOException, so IO errors propagated to the
caller. Added the missing exception type to match the
catch list already used in the sibling recordOrUpdate
method.

### TransactionPreviewService — null-checks added for service-layer consistency
previewPurchase and previewSale lacked `Objects.requireNonNull`
on any parameter. Brought them in line with the rest of
the service layer.

## Tests

Added null-check tests for GameService.buy and
GameService.sell overloads to verify the new contract.
Existing test failures (PlayerStatsService) resolved by
the formula correction.

## What is NOT in this PR

- A controller-to-service catch-pattern audit. Tightening
  null-checks on the service side changed the failure
  mode of those methods; we noted that controllers may
  not handle the new exceptions consistently, and
  deferred the cross-layer validation audit until the
  controller-layer Javadoc pass.
- A global uncaught-exception handler for runtime errors
  that escape typed catches. Deferred to the controller
  pass too — it makes more sense to set up the safety net
  once we know what controllers are catching today.
