### PR TITLE
docs: javadoc pass and audit-driven cleanups across the controller layer

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/millions/App.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/App.java
@@ -1,16 +1,22 @@
 package edu.ntnu.idatt2003.millions;
 
 import edu.ntnu.idatt2003.millions.controller.StartController;
+import edu.ntnu.idatt2003.millions.util.LanguageManager;
 import edu.ntnu.idatt2003.millions.util.OsDetector;
 import edu.ntnu.idatt2003.millions.util.StylesheetLoader;
 import javafx.application.Application;
+import javafx.application.Platform;
 import javafx.geometry.Rectangle2D;
 import javafx.scene.Scene;
+import javafx.scene.control.Alert;
 import javafx.scene.layout.StackPane;
 import javafx.scene.paint.Color;
 import javafx.stage.Screen;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Entry point for the Millions application.
@@ -23,8 +29,15 @@ import javafx.stage.StageStyle;
  */
 public class App extends Application {
 
+    private static final Logger LOGGER = Logger.getLogger(App.class.getName());
+
     @Override
     public void start(Stage stage) {
+        Thread.currentThread().setUncaughtExceptionHandler(
+                (_, throwable) -> handleUncaught(throwable));
+        Thread.setDefaultUncaughtExceptionHandler(
+                (_, throwable) -> handleUncaught(throwable));
+
         if (OsDetector.isMac()) {
             stage.initStyle(StageStyle.UNIFIED);
         } else {
@@ -45,6 +58,19 @@ public class App extends Application {
 
         new StartController(stage).show();
         stage.show();
+    }
+
+    private void handleUncaught(Throwable throwable) {
+        LOGGER.log(Level.SEVERE, throwable,
+                () -> "Uncaught exception on " + Thread.currentThread().getName());
+        Platform.runLater(this::showErrorDialog);
+    }
+
+    private void showErrorDialog() {
+        Alert alert = new Alert(Alert.AlertType.ERROR);
+        alert.setHeaderText(null);
+        alert.setContentText(LanguageManager.get("error.unexpected"));
+        alert.showAndWait();
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/EndGameActions.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/EndGameActions.java
@@ -1,0 +1,24 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
+package edu.ntnu.idatt2003.millions.controller;
+
+import java.util.function.BooleanSupplier;
+
+/**
+ * Bundles the four end-of-game action callbacks passed to
+ * {@link GameOverController} and forwarded through the modal/dialog chain.
+ *
+ * @param onNewGame     pure navigation executed after the current session ends
+ *                      (e.g. return to start screen, close the window)
+ * @param saveAction    saves the game; returns {@code true} on success so
+ *                      callers can gate navigation on a successful save
+ * @param sellAllAction liquidates all positions and records the leaderboard
+ *                      entry before navigating
+ * @param noSaveAction  pre-navigation action for the no-save path
+ *                      (e.g. {@code gameService::recordLeaderboardEntry})
+ */
+public record EndGameActions(
+        Runnable onNewGame,
+        BooleanSupplier saveAction,
+        Runnable sellAllAction,
+        Runnable noSaveAction
+) {}

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/ForcedSaleController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/ForcedSaleController.java
@@ -6,9 +6,12 @@ import edu.ntnu.idatt2003.millions.model.loan.InsufficientSaleProceedsException;
 import edu.ntnu.idatt2003.millions.model.player.Player;
 import edu.ntnu.idatt2003.millions.model.stock.Share;
 import edu.ntnu.idatt2003.millions.service.GameService;
+import edu.ntnu.idatt2003.millions.util.LanguageManager;
 import edu.ntnu.idatt2003.millions.view.dialog.ForcedSaleDialog;
 
 import java.math.BigDecimal;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -20,6 +23,8 @@ import java.util.Map;
  * and delegates the confirmed sale to {@link GameService}.
  */
 public class ForcedSaleController {
+
+    private static final Logger LOGGER = Logger.getLogger(ForcedSaleController.class.getName());
 
     private final GameService gameService;
 
@@ -63,6 +68,9 @@ public class ForcedSaleController {
             dialog.closeOnConfirm();
         } catch (InsufficientSaleProceedsException e) {
             dialog.showError(e.getMessage());
+        } catch (IllegalStateException e) {
+            dialog.showError(LanguageManager.get("error.gameOver"));
+            LOGGER.log(Level.INFO, "Forced sale blocked — game is over", e);
         }
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/ForcedSaleController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/ForcedSaleController.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.controller;
 
 import edu.ntnu.idatt2003.millions.model.calculator.SalesCalculator;
@@ -19,15 +20,20 @@ import java.util.Map;
 
 /**
  * Controller for the forced-sale flow triggered when the player cannot cover
- * weekly interest from cash. Builds and shows the {@link ForcedSaleDialog},
- * and delegates the confirmed sale to {@link GameService}.
+ * weekly obligations from cash.
  */
+@SuppressWarnings("ClassCanBeRecord")
 public class ForcedSaleController {
 
     private static final Logger LOGGER = Logger.getLogger(ForcedSaleController.class.getName());
 
     private final GameService gameService;
 
+    /**
+     * Constructs a new ForcedSaleController backed by the given game service.
+     *
+     * @param gameService the game service used to execute the forced sale
+     */
     public ForcedSaleController(GameService gameService) {
         this.gameService = gameService;
     }

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/GameOverController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/GameOverController.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.controller;
 
 import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
@@ -10,9 +11,7 @@ import java.math.BigDecimal;
 import java.util.function.BooleanSupplier;
 
 /**
- * Controller for the game-over flow. Collects the end-of-game context
- * (week, obligations, liquidation value) and delegates rendering to
- * {@link GameOverModal}.
+ * Controller for the game-over flow.
  */
 public class GameOverController {
 
@@ -23,6 +22,16 @@ public class GameOverController {
     private final Runnable sellAllAction;
     private final Runnable noSaveAction;
 
+    /**
+     * Constructs a new GameOverController.
+     *
+     * @param gameService   the game service used to read end-of-game state
+     * @param ownerStage    the stage that owns the game-over modal
+     * @param onNewGame     action invoked when the player chooses to start a new game
+     * @param saveAction    action invoked to save the game; returns {@code true} on success
+     * @param sellAllAction action invoked to liquidate all positions before exiting
+     * @param noSaveAction  action invoked when the player exits without saving
+     */
     public GameOverController(GameService gameService, Stage ownerStage, Runnable onNewGame,
                               BooleanSupplier saveAction, Runnable sellAllAction, Runnable noSaveAction) {
         this.gameService = gameService;

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/GameOverController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/GameOverController.java
@@ -23,7 +23,7 @@ public class GameOverController {
      *
      * @param gameService the game service used to read end-of-game state
      * @param ownerStage  the stage that owns the game-over modal
-     * @param actions     the four end-of-game action callbacks
+     * @param actions     the four end-of-game action callbacks; see {@link EndGameActions}
      */
     public GameOverController(GameService gameService, Stage ownerStage, EndGameActions actions) {
         this.gameService = gameService;

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/GameOverController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/GameOverController.java
@@ -8,7 +8,6 @@ import edu.ntnu.idatt2003.millions.view.dialog.GameOverModal;
 import javafx.stage.Stage;
 
 import java.math.BigDecimal;
-import java.util.function.BooleanSupplier;
 
 /**
  * Controller for the game-over flow.
@@ -17,29 +16,19 @@ public class GameOverController {
 
     private final GameService gameService;
     private final Stage ownerStage;
-    private final Runnable onNewGame;
-    private final BooleanSupplier saveAction;
-    private final Runnable sellAllAction;
-    private final Runnable noSaveAction;
+    private final EndGameActions actions;
 
     /**
      * Constructs a new GameOverController.
      *
-     * @param gameService   the game service used to read end-of-game state
-     * @param ownerStage    the stage that owns the game-over modal
-     * @param onNewGame     action invoked when the player chooses to start a new game
-     * @param saveAction    action invoked to save the game; returns {@code true} on success
-     * @param sellAllAction action invoked to liquidate all positions before exiting
-     * @param noSaveAction  action invoked when the player exits without saving
+     * @param gameService the game service used to read end-of-game state
+     * @param ownerStage  the stage that owns the game-over modal
+     * @param actions     the four end-of-game action callbacks
      */
-    public GameOverController(GameService gameService, Stage ownerStage, Runnable onNewGame,
-                              BooleanSupplier saveAction, Runnable sellAllAction, Runnable noSaveAction) {
+    public GameOverController(GameService gameService, Stage ownerStage, EndGameActions actions) {
         this.gameService = gameService;
         this.ownerStage = ownerStage;
-        this.onNewGame = onNewGame;
-        this.saveAction = saveAction;
-        this.sellAllAction = sellAllAction;
-        this.noSaveAction = noSaveAction;
+        this.actions = actions;
     }
 
     /**
@@ -56,6 +45,6 @@ public class GameOverController {
         BigDecimal totalLiquidationValue = player.getTotalLiquidationValue(converter);
 
         new GameOverModal(failedWeek, totalObligations, totalLiquidationValue, ownerStage,
-                onNewGame, saveAction, sellAllAction, noSaveAction).show();
+                actions.onNewGame(), actions.saveAction(), actions.sellAllAction(), actions.noSaveAction()).show();
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/LoanController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/LoanController.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.controller;
 
 import edu.ntnu.idatt2003.millions.model.loan.ExcessiveDebtException;
@@ -19,8 +20,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Controller for loan-related actions.
- * Opens the loan application dialog and delegates confirmation to {@link GameService}.
+ * Controller for loan-related actions: applying for loans, repaying loans, and viewing loan details.
  */
 public class LoanController {
 
@@ -29,13 +29,17 @@ public class LoanController {
     private final GameService gameService;
     private final LoanPreviewService previewService = new LoanPreviewService();
 
+    /**
+     * Constructs a new LoanController backed by the given game service.
+     *
+     * @param gameService the game service used to apply and repay loans
+     */
     public LoanController(GameService gameService) {
         this.gameService = gameService;
     }
 
     /**
      * Opens the loan application dialog for the given offer.
-     * The dialog is modal and blocks until the player confirms or cancels.
      *
      * @param offer the loan offer the player wants to apply for
      */
@@ -67,7 +71,7 @@ public class LoanController {
     }
 
     /**
-     * Returns the current game week. Used by modals that need temporal context.
+     * Returns the current game week.
      *
      * @return the current exchange week
      */
@@ -75,6 +79,11 @@ public class LoanController {
         return gameService.getExchange().getWeek();
     }
 
+    /**
+     * Returns whether the current game has ended.
+     *
+     * @return {@code true} if the game is over
+     */
     public boolean isGameOver() {
         return gameService.isGameOver();
     }
@@ -91,7 +100,9 @@ public class LoanController {
 
     /**
      * Validates whether the player may borrow {@code amount} right now.
-     * Returns empty if allowed; present with an i18n error key if not.
+     *
+     * @param amount the requested loan amount
+     * @return empty if allowed; present with an i18n error key if the amount exceeds the player's capacity
      */
     private Optional<String> validateLoanAmount(BigDecimal amount) {
         BigDecimal capacity = gameService.getPlayer()
@@ -104,7 +115,9 @@ public class LoanController {
 
     /**
      * Validates whether the player can afford to repay {@code loan} right now.
-     * Returns empty if allowed; present with an i18n error key if not.
+     *
+     * @param loan the loan the player wants to repay
+     * @return empty if the player has sufficient cash; present with an i18n error key if not
      */
     private Optional<String> validateRepay(Loan loan) {
         if (gameService.getPlayer().getCash().compareTo(loan.principal()) < 0) {

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/LoanController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/LoanController.java
@@ -10,16 +10,21 @@ import edu.ntnu.idatt2003.millions.view.dashboard.loans.dialog.LoanApplicationDi
 import edu.ntnu.idatt2003.millions.view.dashboard.loans.dialog.LoanDetailsModal;
 import edu.ntnu.idatt2003.millions.view.dashboard.loans.dialog.LoanRepaymentReceipt;
 import edu.ntnu.idatt2003.millions.view.dashboard.loans.dialog.RepayLoanDialog;
+import edu.ntnu.idatt2003.millions.util.LanguageManager;
 import javafx.application.Platform;
 
 import java.math.BigDecimal;
 import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Controller for loan-related actions.
  * Opens the loan application dialog and delegates confirmation to {@link GameService}.
  */
 public class LoanController {
+
+    private static final Logger LOGGER = Logger.getLogger(LoanController.class.getName());
 
     private final GameService gameService;
     private final LoanPreviewService previewService = new LoanPreviewService();
@@ -114,6 +119,9 @@ public class LoanController {
             dialog.close();
         } catch (ExcessiveDebtException e) {
             dialog.showError(e.getMessage());
+        } catch (IllegalStateException e) {
+            dialog.showError(LanguageManager.get("error.gameOver"));
+            LOGGER.log(Level.INFO, "Take loan blocked — game is over", e);
         }
     }
 
@@ -128,6 +136,9 @@ public class LoanController {
                     new LoanRepaymentReceipt(loan, loanIndex, balanceBefore, balanceAfter, week).show());
         } catch (IllegalArgumentException e) {
             dialog.showError(e.getMessage());
+        } catch (IllegalStateException e) {
+            dialog.showError(LanguageManager.get("error.gameOver"));
+            LOGGER.log(Level.INFO, "Repay loan blocked — game is over", e);
         }
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/MainController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/MainController.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.controller;
 
 import edu.ntnu.idatt2003.millions.keyboard.KeyboardNavigationService;
@@ -27,8 +28,7 @@ import java.util.logging.Logger;
 
 /**
  * Controller for the main view of the application.
- * Handles save, exit, advance-week actions and global keyboard shortcuts.
- * Delegates game state changes to {@code GameService}.
+ * Handles save, exit, and advance-week actions, and registers global keyboard shortcuts.
  */
 public class MainController {
 
@@ -47,8 +47,9 @@ public class MainController {
     /**
      * Constructs a new MainController and creates the main view.
      *
-     * @param stage       the primary stage
-     * @param gameService the game manager containing player and exchange
+     * @param stage        the primary stage
+     * @param gameService  the game manager containing player and exchange
+     * @param toastService the service used to display in-app toast notifications
      */
     public MainController(Stage stage, GameService gameService, ToastService toastService) {
         this.stage = stage;
@@ -132,11 +133,11 @@ public class MainController {
     }
 
     /**
-     * Writes the game to {@code file} and shows a success toast.
-     * On failure clears the stored path and shows an error toast so the
-     * player can pick a new location on the next attempt.
+     * Saves the game to the given file. On IO failure, clears the stored save path
+     * so the player is prompted to pick a new location on the next attempt.
      *
-     * @return true on success, false on failure
+     * @param file the file to save to
+     * @return {@code true} on success, {@code false} if the game has no active state or writing fails
      */
     private boolean saveToFile(File file) {
         try {

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/MainController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/MainController.java
@@ -56,11 +56,12 @@ public class MainController {
         this.gameService = gameService;
         this.toastService = toastService;
         this.forcedSaleController = new ForcedSaleController(gameService);
-        this.gameOverController = new GameOverController(gameService, stage,
+        EndGameActions gameOverActions = new EndGameActions(
                 () -> new StartController(stage, gameService).show(),
                 this::handleSaveGame,
                 this::sellAllAndExit,
                 this::recordLeaderboardEntry);
+        this.gameOverController = new GameOverController(gameService, stage, gameOverActions);
         TradeController tradeController = new TradeController(gameService, toastService);
         LoanController loanController = new LoanController(gameService);
         TitleBar titleBar = TitleBarFactory.create(stage, gameService);

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/MainController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/MainController.java
@@ -20,7 +20,10 @@ import javafx.stage.FileChooser;
 import javafx.stage.Stage;
 
 import java.io.File;
+import java.io.UncheckedIOException;
 import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Controller for the main view of the application.
@@ -28,6 +31,8 @@ import java.util.Optional;
  * Delegates game state changes to {@code GameService}.
  */
 public class MainController {
+
+    private static final Logger LOGGER = Logger.getLogger(MainController.class.getName());
 
     private final Stage stage;
     private final MainView view;
@@ -53,8 +58,8 @@ public class MainController {
         this.gameOverController = new GameOverController(gameService, stage,
                 () -> new StartController(stage, gameService).show(),
                 this::handleSaveGame,
-                gameService::sellAllAndExit,
-                gameService::recordLeaderboardEntry);
+                this::sellAllAndExit,
+                this::recordLeaderboardEntry);
         TradeController tradeController = new TradeController(gameService, toastService);
         LoanController loanController = new LoanController(gameService);
         TitleBar titleBar = TitleBarFactory.create(stage, gameService);
@@ -83,12 +88,22 @@ public class MainController {
     private void handleAdvanceWeek() {
         int nextWeek = gameService.getExchange().getWeek() + 1;
         if (gameService.getPlayer().canCoverObligationsThisWeek(nextWeek)) {
-            gameService.advanceWeek();
+            try {
+                gameService.advanceWeek();
+            } catch (IllegalStateException e) {
+                toastService.show(LanguageManager.get("error.gameOver"), ToastType.ERROR);
+                LOGGER.log(Level.INFO, "Advance week blocked — game is over", e);
+            }
         } else if (gameService.getPlayer().canCoverWithFullLiquidation(
                 nextWeek, gameService.getCurrencyConverter())) {
             forcedSaleController.open(nextWeek);
         } else {
-            gameService.declareGameOver();
+            try {
+                gameService.declareGameOver();
+            } catch (IllegalStateException e) {
+                toastService.show(LanguageManager.get("error.gameOver"), ToastType.ERROR);
+                LOGGER.log(Level.INFO, "Declare game over blocked — game is over", e);
+            }
             gameOverController.open(nextWeek);
         }
     }
@@ -128,10 +143,33 @@ public class MainController {
             gameService.saveGame(file);
             toastService.show(LanguageManager.get("toast.gameSaved"), ToastType.SUCCESS);
             return true;
-        } catch (RuntimeException e) {
-            gameService.clearCurrentSaveFile();
-            toastService.show(LanguageManager.get("toast.gameSaveFailed"), ToastType.ERROR);
+        } catch (IllegalStateException e) {
+            toastService.show(LanguageManager.get("error.noActiveGame"), ToastType.ERROR);
+            LOGGER.log(Level.WARNING, "Save blocked — no active game", e);
             return false;
+        } catch (UncheckedIOException e) {
+            gameService.clearCurrentSaveFile();
+            toastService.show(LanguageManager.get("error.saveFailed"), ToastType.ERROR);
+            LOGGER.log(Level.WARNING, "Save failed — IO error", e);
+            return false;
+        }
+    }
+
+    private void sellAllAndExit() {
+        try {
+            gameService.sellAllAndExit();
+        } catch (IllegalStateException e) {
+            toastService.show(LanguageManager.get("error.gameOver"), ToastType.ERROR);
+            LOGGER.log(Level.INFO, "sellAllAndExit blocked — game is over", e);
+        }
+    }
+
+    private void recordLeaderboardEntry() {
+        try {
+            gameService.recordLeaderboardEntry();
+        } catch (IllegalStateException e) {
+            toastService.show(LanguageManager.get("error.gameOver"), ToastType.ERROR);
+            LOGGER.log(Level.INFO, "recordLeaderboardEntry blocked — game is over", e);
         }
     }
 
@@ -148,8 +186,8 @@ public class MainController {
                 "newGame.sellAllAndStartNew",
                 "newGame.startNewWithoutSaving",
                 this::handleSaveGame,
-                gameService::sellAllAndExit,
-                gameService::recordLeaderboardEntry,
+                this::sellAllAndExit,
+                this::recordLeaderboardEntry,
                 this::showStartView
         ).show();
     }
@@ -163,8 +201,8 @@ public class MainController {
                 "exit.sellAllAndExit",
                 "exit.exitWithoutSaving",
                 this::handleSaveGame,
-                gameService::sellAllAndExit,
-                gameService::recordLeaderboardEntry,
+                this::sellAllAndExit,
+                this::recordLeaderboardEntry,
                 stage::close
         ).show();
     }
@@ -219,7 +257,7 @@ public class MainController {
         reg.register(new KeyCodeCombination(KeyCode.DIGIT1, KeyCombination.SHORTCUT_DOWN), view::showDashboard);
         reg.register(new KeyCodeCombination(KeyCode.DIGIT2, KeyCombination.SHORTCUT_DOWN), view::showExchange);
         reg.register(new KeyCodeCombination(KeyCode.DIGIT3, KeyCombination.SHORTCUT_DOWN), view::showLeaderboard);
-        reg.register(new KeyCodeCombination(KeyCode.S, KeyCombination.SHORTCUT_DOWN), () -> handleSaveGame());
+        reg.register(new KeyCodeCombination(KeyCode.S, KeyCombination.SHORTCUT_DOWN), this::handleSaveGame);
         reg.register(new KeyCodeCombination(KeyCode.ENTER, KeyCombination.SHORTCUT_DOWN), this::handleAdvanceWeek);
         reg.register(new KeyCodeCombination(KeyCode.F, KeyCombination.SHORTCUT_DOWN), searchFocusRegistry::focusActive);
         reg.registerTabShortcuts(

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/StartController.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.controller;
 
 import edu.ntnu.idatt2003.millions.file.game.GameSaveCorruptException;
@@ -33,12 +34,9 @@ import javafx.stage.Stage;
  * file selection for stock data and saved games, as well as
  * starting or loading a game session.</p>
  *
- * <p>UI-input validation is delegated to {@link StartInputValidator}. File
- * validation on selection is delegated to {@link edu.ntnu.idatt2003.millions.service.GameService},
- * which performs a trial parse without mutating game state.</p>
- *
- * <p>Errors are surfaced via {@code errorSink} and successes via {@code successSink},
- * both injected as {@link java.util.function.Supplier} consumers for i18n support.</p>
+ * <p>UI-input validation is delegated to {@link StartInputValidator}. Files
+ * selected or dropped onto the screen are validated immediately by trial-parsing
+ * them before their paths are accepted.</p>
  */
 public class StartController {
 
@@ -53,10 +51,6 @@ public class StartController {
 
     /**
      * Constructs a new StartController with a default {@link GameService}.
-     *
-     * <p>This constructor is used by the application startup flow. It delegates
-     * to {@link #StartController(Stage, GameService)} so alternate startup paths
-     * can inject their own game manager.</p>
      *
      * @param stage the primary application stage
      * @throws NullPointerException if stage is null
@@ -76,14 +70,6 @@ public class StartController {
         this(stage, gameService, new StartView(TitleBarFactory.createForStartScreen(stage).getNode()));
     }
 
-    /**
-     * Intermediate constructor that resolves the {@link StartView} before delegating
-     * to the full DI constructor.
-     *
-     * @param stage       the primary application stage
-     * @param gameService the game manager used to create or load game state
-     * @param startView   the already-constructed start view
-     */
     private StartController(Stage stage, GameService gameService, StartView startView) {
         this(stage, gameService,
                 startView,
@@ -145,11 +131,6 @@ public class StartController {
         this.successSink = Objects.requireNonNull(successSink, "Success sink cannot be null");
     }
 
-    /**
-     * Injects callbacks into the view for all interactive controls.
-     * The view wires these callbacks to its own controls internally,
-     * so the controller never accesses individual UI components directly.
-     */
     private void bindEvents() {
         view.setOnStartGame(this::handleStartGame);
         view.setOnLoadGame(this::handleLoadGame);
@@ -159,12 +140,6 @@ public class StartController {
         view.setOnSaveFileDrop(this::validateAndSetSaveFile);
     }
 
-    /**
-     * Opens a file chooser for selecting a stock data file (CSV).
-     * If a file is chosen, it is validated immediately via
-     * {@link #validateAndSetStockFile(File)}. The file path is only
-     * stored if the file parses without errors.
-     */
     private void handleBrowseStockFile() {
         FileChooser chooser = new FileChooser();
         chooser.setTitle(LanguageManager.get("start.chooser.stock.title"));
@@ -176,12 +151,6 @@ public class StartController {
         }
     }
 
-    /**
-     * Opens a file chooser for selecting a previously saved game file (JSON).
-     * If a file is chosen, it is validated immediately via
-     * {@link #validateAndSetSaveFile(File)}. The file path is only
-     * stored if the file parses without errors.
-     */
     private void handleBrowseSaveFile() {
         FileChooser chooser = new FileChooser();
         chooser.setTitle(LanguageManager.get("start.chooser.save.title"));
@@ -194,13 +163,18 @@ public class StartController {
     }
 
     /**
-     * Validates the given stock file by attempting to parse it immediately.
-     * If parsing succeeds, the file path is stored in the view. If parsing
-     * fails, the file path is cleared and the error is shown to the user
-     * via the {@link #errorSink} so they cannot proceed with an invalid file.
+     * Validates the given CSV stock file and registers its path if valid;
+     * clears the path and shows an error to the user if not.
      *
      * <p>Package-private visibility allows controller tests in this package
      * to invoke the handler directly without simulating a drag-and-drop event.</p>
+     *
+     * <p>Parses the file as a side-effect-free validation step: the handler is
+     * constructed locally and the parsed result is discarded. The only outcome is
+     * whether the file is well-formed, which determines whether the path is stored
+     * on {@code inputs}. Validation deliberately does NOT route through
+     * {@code gameService} because {@code createNewGame()} would mutate game state,
+     * and we only want to verify the file before the user confirms.</p>
      *
      * @param file the CSV file to validate and register
      */
@@ -221,13 +195,18 @@ public class StartController {
     }
 
     /**
-     * Validates the given save file by attempting to parse it immediately.
-     * If parsing succeeds, the file path is stored in the view. If parsing
-     * fails, the file path is cleared and the error is shown to the user
-     * via the {@link #errorSink} so they cannot proceed with a corrupt save file.
+     * Validates the given JSON save file and registers its path if valid;
+     * clears the path and shows an error to the user if not.
      *
      * <p>Package-private visibility allows controller tests in this package
      * to invoke the handler directly without simulating a drag-and-drop event.</p>
+     *
+     * <p>Parses the file as a side-effect-free validation step: the handler is
+     * constructed locally and the parsed result is discarded. The only outcome is
+     * whether the save file is well-formed, which determines whether the path is
+     * stored on {@code inputs}. Validation deliberately does NOT route through
+     * {@code gameService.loadGame()} because that would mutate game state, and we
+     * only want to verify the file before the user confirms.</p>
      *
      * @param file the JSON save file to validate and register
      */
@@ -285,7 +264,6 @@ public class StartController {
             return;
         }
 
-        // All inputs valid — delegate to service
         runOrShowError(() -> {
             String validatedName     = StartInputValidator.requireName(name);
             BigDecimal parsedCapital = StartInputValidator.parseCapital(capital);
@@ -311,10 +289,10 @@ public class StartController {
         String suffix = " " + LanguageManager.get("error.missing.suffix");
         List<String> lower = fields.stream().map(String::toLowerCase).toList();
         String message = lower.size() == 1
-                ? lower.get(0) + suffix
+                ? lower.getFirst() + suffix
                 : String.join(", ", lower.subList(0, lower.size() - 1))
                   + " " + LanguageManager.get("error.and") + " "
-                  + lower.get(lower.size() - 1) + suffix;
+                  + lower.getLast() + suffix;
         return Character.toUpperCase(message.charAt(0)) + message.substring(1);
     }
 
@@ -357,9 +335,7 @@ public class StartController {
     private void runOrShowError(GameAction action) {
         try {
             action.execute();
-        } catch (GameSaveCorruptException exception) {
-            resolveLocalizedError(exception.getI18nKey(), exception.getArgs());
-        } catch (InvalidStockDataException exception) {
+        } catch (GameSaveCorruptException | InvalidStockDataException exception) {
             resolveLocalizedError(exception.getI18nKey(), exception.getArgs());
         } catch (IllegalArgumentException | IllegalStateException | UncheckedIOException exception) {
             errorSink.accept(exception::getMessage);
@@ -372,9 +348,6 @@ public class StartController {
         errorSink.accept(() -> MessageFormat.format(LanguageManager.get(key), args));
     }
 
-    /**
-     * Shows the main view using the active {@link GameService}.
-     */
     private void showMainView() {
         showMainViewAction.run();
     }
@@ -382,11 +355,6 @@ public class StartController {
     /**
      * Displays the start screen on the primary stage, binds UI events,
      * and registers global keyboard shortcuts on the start scene.
-     *
-     * <p>Swaps the app-lifetime scene root to this view's root node. Window
-     * visibility and maximised state are managed by
-     * {@link edu.ntnu.idatt2003.millions.App} on startup and remain in effect
-     * for the lifetime of the application.</p>
      */
     public void show() {
         bindEvents();

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/StartInputValidator.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/StartInputValidator.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.controller;
 
 import java.io.File;
@@ -11,8 +12,6 @@ import java.util.Optional;
  * <p>This utility keeps simple UI-input validation out of {@link StartController}
  * while staying in the controller layer. It does not contain domain business rules.</p>
  *
- * <p>Provides format validators for player name and starting capital that return
- * i18n error keys, and path validators for stock and save files.</p>
  */
 final class StartInputValidator {
 
@@ -51,10 +50,6 @@ final class StartInputValidator {
 
     /**
      * Parses and validates a starting capital string.
-     *
-     * <p>Throws {@link IllegalArgumentException} if the value is null, blank,
-     * or not greater than zero. Throws {@link NumberFormatException} if the
-     * value cannot be parsed as a {@link BigDecimal}.</p>
      *
      * @param capital the capital text entered by the user
      * @return the parsed capital as a {@link BigDecimal}
@@ -125,7 +120,7 @@ final class StartInputValidator {
             if (parsed.compareTo(BigDecimal.ZERO) <= 0) {
                 return Optional.of("error.capital.zero");
             }
-        } catch (NumberFormatException e) {
+        } catch (NumberFormatException _) {
             return Optional.of("error.capital.invalid");
         }
         return Optional.empty();

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/TradeController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/TradeController.java
@@ -19,6 +19,8 @@ import java.math.BigDecimal;
 import java.text.MessageFormat;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Controller for portfolio actions (buy, sell, sell all, view details, and watchlist).
@@ -32,6 +34,7 @@ import java.util.Optional;
  */
 public class TradeController {
 
+    private static final Logger LOGGER = Logger.getLogger(TradeController.class.getName());
     private static final int MAX_QUANTITY_SCALE = 4;
     private static final BigDecimal MIN_TRANSACTION_VALUE_NOK = BigDecimal.ONE;
 
@@ -133,6 +136,10 @@ public class TradeController {
      * @param symbol the ticker symbol of the stock to toggle
      */
     public void toggleWatchlist(String symbol) {
+        if (symbol == null || symbol.isBlank()) {
+            LOGGER.log(Level.WARNING, "Watchlist toggle rejected — blank symbol");
+            return;
+        }
         boolean isWatched = gameService.getPlayer().isOnWatchlist(symbol);
         String label = buildWatchlistLabel(symbol);
         try {
@@ -147,11 +154,12 @@ public class TradeController {
                         MessageFormat.format(LanguageManager.get("toast.watchlist.added"), label),
                         ToastType.SUCCESS);
             }
-        } catch (RuntimeException e) {
+        } catch (IllegalArgumentException e) {
             String errorKey = isWatched
                     ? "toast.watchlist.removeFailed"
                     : "toast.watchlist.addFailed";
             toastService.show(LanguageManager.get(errorKey), ToastType.ERROR);
+            LOGGER.log(Level.WARNING, "Watchlist toggle failed", e);
         }
     }
 
@@ -162,14 +170,19 @@ public class TradeController {
      * @param symbol the ticker symbol of the stock to remove
      */
     public void removeFromWatchlist(String symbol) {
+        if (symbol == null || symbol.isBlank()) {
+            LOGGER.log(Level.WARNING, "Watchlist remove rejected — blank symbol");
+            return;
+        }
         String label = buildWatchlistLabel(symbol);
         try {
             gameService.removeFromWatchlist(symbol);
             toastService.show(
                     MessageFormat.format(LanguageManager.get("toast.watchlist.removed"), label),
                     ToastType.SUCCESS);
-        } catch (RuntimeException e) {
+        } catch (IllegalArgumentException e) {
             toastService.show(LanguageManager.get("toast.watchlist.removeFailed"), ToastType.ERROR);
+            LOGGER.log(Level.WARNING, "Watchlist remove failed", e);
         }
     }
 
@@ -194,7 +207,15 @@ public class TradeController {
      * @param newNote the new note text
      */
     public void updateWatchlistNote(String symbol, String newNote) {
-        gameService.updateWatchlistNote(symbol, newNote);
+        if (symbol == null || symbol.isBlank()) {
+            LOGGER.log(Level.WARNING, "Watchlist note update rejected — blank symbol");
+            return;
+        }
+        try {
+            gameService.updateWatchlistNote(symbol, newNote);
+        } catch (IllegalArgumentException e) {
+            LOGGER.log(Level.WARNING, "Watchlist note update failed", e);
+        }
     }
 
     // Dialog opening

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/TradeController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/TradeController.java
@@ -206,6 +206,7 @@ public class TradeController {
             gameService.updateWatchlistNote(symbol, newNote);
         } catch (IllegalArgumentException e) {
             LOGGER.log(Level.WARNING, "Watchlist note update failed", e);
+            toastService.show(LanguageManager.get("toast.watchlist.updateNoteFailed"), ToastType.ERROR);
         }
     }
 
@@ -262,11 +263,7 @@ public class TradeController {
             Platform.runLater(() ->
                     new BuyReceipt(transaction, balanceBefore, balanceAfter, preview).show());
         } catch (IllegalArgumentException | IllegalStateException e) {
-            String message = e.getMessage();
-            if (message == null || message.isBlank()) {
-                message = e.getClass().getSimpleName();
-            }
-            dialog.showError(message);
+            dialog.showError(resolveErrorMessage(e));
         }
     }
 
@@ -287,12 +284,20 @@ public class TradeController {
             Platform.runLater(() ->
                     new SellReceipt(transaction, balanceBefore, balanceAfter, preview).show());
         } catch (IllegalArgumentException | IllegalStateException e) {
-            String message = e.getMessage();
-            if (message == null || message.isBlank()) {
-                message = e.getClass().getSimpleName();
-            }
-            dialog.showError(message);
+            dialog.showError(resolveErrorMessage(e));
         }
+    }
+
+    /**
+     * Returns a user-readable error message for the given exception. Falls back to the
+     * exception's simple class name when the message is null or blank.
+     *
+     * @param e the exception to extract a message from
+     * @return the exception's message, or its class name as fallback
+     */
+    private static String resolveErrorMessage(Exception e) {
+        String message = e.getMessage();
+        return (message == null || message.isBlank()) ? e.getClass().getSimpleName() : message;
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/TradeController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/TradeController.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.controller;
 
 import edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter;
@@ -23,14 +24,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Controller for portfolio actions (buy, sell, sell all, view details, and watchlist).
- * Opens the corresponding dialogs and delegates the actual transactions
- * to the model via {@link GameService}. Shows {@link ToastService} feedback
- * for watchlist mutations.
- *
- * <p>Provides read-only operations such as {@link #previewBuy(Stock, BigDecimal)}
- * and {@link #getCurrentBalance()} for views that need to display
- * derived data without performing a mutation.</p>
+ * Controller for portfolio actions: buy, sell, sell-all, watchlist management,
+ * stock details, and read-only previews.
  */
 public class TradeController {
 
@@ -55,8 +50,6 @@ public class TradeController {
         this.previewService = new TransactionPreviewService();
     }
 
-    // ---- Read-only operations (called by views) ----
-
     /**
      * Returns the player's current cash balance.
      *
@@ -67,8 +60,7 @@ public class TradeController {
     }
 
     /**
-     * Returns the current currency converter, used by views that call
-     * read services directly with a currency converter argument.
+     * Returns the current currency converter.
      *
      * @return the active currency converter
      */
@@ -76,6 +68,11 @@ public class TradeController {
         return gameService.getCurrencyConverter();
     }
 
+    /**
+     * Returns whether the current game has ended.
+     *
+     * @return {@code true} if the game is over
+     */
     public boolean isGameOver() {
         return gameService.isGameOver();
     }
@@ -186,12 +183,6 @@ public class TradeController {
         }
     }
 
-    /**
-     * Builds the display label used in watchlist toast messages.
-     *
-     * @param symbol the ticker symbol to build a label for
-     * @return the display label
-     */
     private String buildWatchlistLabel(String symbol) {
         Exchange exchange = gameService.getExchange();
         if (exchange.hasStock(symbol)) {
@@ -217,8 +208,6 @@ public class TradeController {
             LOGGER.log(Level.WARNING, "Watchlist note update failed", e);
         }
     }
-
-    // Dialog opening
 
     /**
      * Opens the buy dialog for the given stock and executes the purchase
@@ -255,8 +244,6 @@ public class TradeController {
         dialog.setOnConfirm(quantity -> sell(share, quantity, dialog));
         dialog.show();
     }
-
-    // Mutating operations
 
     private void buy(Stock stock, BigDecimal quantity, BuyDialog dialog) {
         BigDecimal balanceBefore = gameService.getPlayer().getCash();

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/LocalizedException.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/LocalizedException.java
@@ -1,0 +1,29 @@
+package edu.ntnu.idatt2003.millions.file;
+
+/**
+ * Implemented by exceptions that carry an i18n key and format arguments instead
+ * of a pre-resolved error message. Callers can catch the interface type and
+ * resolve the message at display time via
+ * {@link java.text.MessageFormat#format(String, Object...)} against the user's
+ * current language bundle.
+ *
+ * <p>This separation lets the file and domain layers stay language-agnostic —
+ * they raise structured exceptions and leave string resolution to the
+ * presentation layer.</p>
+ */
+public interface LocalizedException {
+
+    /**
+     * Returns the resource-bundle key for the error message template.
+     *
+     * @return the i18n key; never null
+     */
+    String getI18nKey();
+
+    /**
+     * Returns the format arguments for the i18n message template.
+     *
+     * @return the format arguments; never null, may be empty
+     */
+    Object[] getArgs();
+}

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/game/GameFileHandler.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/game/GameFileHandler.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.file.game;
 
 import edu.ntnu.idatt2003.millions.model.exchange.Exchange;
@@ -7,7 +8,6 @@ import java.io.File;
 
 /**
  * Interface for reading and writing game state to and from files.
- * Implementations may support different file formats, such as JSON.
  */
 public interface GameFileHandler {
 
@@ -16,7 +16,7 @@ public interface GameFileHandler {
      *
      * @param player   the player whose state should be saved
      * @param exchange the exchange whose state should be saved
-     * @param gameOver whether the game has ended (bankruptcy)
+     * @param gameOver whether the game has ended
      * @param file     the file to save the game state to
      * @throws NullPointerException if player, exchange or file is null
      */

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/game/GameSaveCorruptException.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/game/GameSaveCorruptException.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.file.game;
 
 import java.util.Arrays;
@@ -7,14 +8,11 @@ import java.util.Arrays;
  * conform to the expected JSON schema — for example, a required field is missing,
  * has the wrong type, or the file is truncated.
  *
- * <p>This is a recoverable failure. Callers should catch it, inform the player that
- * the save file is corrupt, and offer to start a new game instead.
+ * <p>This is a recoverable failure.
  *
  * <p>The exception carries an opaque {@link #i18nKey} and structured {@link #args}
- * (typically the filename) rather than a pre-resolved string. Callers in the
- * controller layer resolve the key at display time via {@code LanguageManager} so
- * that the message is always shown in the user's current language, including if the
- * locale changes while the error is visible.
+ * (typically the filename) rather than a pre-resolved string, so the message can
+ * be rendered in the user's current language at display time.
  *
  * <p>{@link #getMessage()} returns a fallback string intended for logging and
  * debugging only — it is not the user-facing message.
@@ -22,7 +20,7 @@ import java.util.Arrays;
 public class GameSaveCorruptException extends Exception {
 
     private final String i18nKey;
-    private final Object[] args;
+    private final transient Object[] args;
 
     /**
      * Creates an exception with an i18n key and structured arguments but no chained cause.
@@ -38,8 +36,6 @@ public class GameSaveCorruptException extends Exception {
 
     /**
      * Creates an exception with an i18n key, structured arguments, and a chained cause.
-     * Use this constructor when wrapping a lower-level exception such as a
-     * {@link com.google.gson.JsonParseException}.
      *
      * @param i18nKey the resource-bundle key identifying the error message template
      * @param args    the format arguments (e.g. the filename); may be null or empty
@@ -53,7 +49,6 @@ public class GameSaveCorruptException extends Exception {
 
     /**
      * Returns the resource-bundle key for the error message template.
-     * Controllers pass this to {@code LanguageManager.get(key)} at display time.
      *
      * @return the i18n key
      */

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/game/GameSaveCorruptException.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/game/GameSaveCorruptException.java
@@ -1,6 +1,7 @@
 // Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.file.game;
 
+import edu.ntnu.idatt2003.millions.file.LocalizedException;
 import java.util.Arrays;
 
 /**
@@ -17,7 +18,7 @@ import java.util.Arrays;
  * <p>{@link #getMessage()} returns a fallback string intended for logging and
  * debugging only — it is not the user-facing message.
  */
-public class GameSaveCorruptException extends Exception {
+public class GameSaveCorruptException extends Exception implements LocalizedException {
 
     private final String i18nKey;
     private final transient Object[] args;

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/game/GameSaveCorruptException.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/game/GameSaveCorruptException.java
@@ -17,6 +17,9 @@ import java.util.Arrays;
  *
  * <p>{@link #getMessage()} returns a fallback string intended for logging and
  * debugging only — it is not the user-facing message.
+ *
+ * <p>Implements {@link LocalizedException} so callers can catch it alongside other
+ * i18n-aware exceptions in a single multi-catch block.
  */
 public class GameSaveCorruptException extends Exception implements LocalizedException {
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/game/GameState.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/game/GameState.java
@@ -1,17 +1,15 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.file.game;
 
 import edu.ntnu.idatt2003.millions.model.exchange.Exchange;
 import edu.ntnu.idatt2003.millions.model.player.Player;
 
 /**
- * Represents the full game state returned after loading a saved game.
- * Acts as a simple data container for transferring the player and exchange
- * state from a file handler to managers.
- * Used as the return type of {@link GameFileHandler#loadGame(java.io.File)}.
+ * Snapshot of the full game state returned by {@link GameFileHandler#loadGame}.
  *
- * @param player   the player state loaded from file
- * @param exchange the exchange state loaded from file
- * @param gameOver whether the game had ended (bankruptcy) when it was saved
+ * @param player   the deserialized player
+ * @param exchange the deserialized exchange
+ * @param gameOver whether the game had ended when the save was written
  */
 public record GameState(Player player, Exchange exchange, boolean gameOver) {
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/game/JsonGameFileHandler.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/game/JsonGameFileHandler.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.file.game;
 
 import com.google.gson.*;
@@ -17,27 +18,15 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * Handles reading and writing of game state to and from JSON files.
- * Uses Gson for serialization and deserialization.
- * Transactions are serialized with a type field to distinguish
- * between purchases and sales when loading the game back.
+ * Persists and restores game state as JSON.
  *
- * <p>This class is pure infrastructure: it does not own domain decisions,
- * such as which {@link edu.ntnu.idatt2003.millions.model.currency.CurrencyConverter}
- * implementation to use. Callers (typically
- * {@link edu.ntnu.idatt2003.millions.service.GameService}) are responsible for
- * reinitializing the loaded {@link Exchange} with a converter via
- * {@link Exchange#reinitialize} before it is used.
+ * <p>The loaded {@link Exchange} has no transient fields populated; callers must
+ * invoke {@link Exchange#reinitialize} before the exchange is used.
  */
 public class JsonGameFileHandler implements GameFileHandler {
 
     private final Gson gson;
 
-    /**
-     * Constructs a new JsonGameFileHandler.
-     * Configures Gson with a custom serializer for transactions
-     * and pretty printing for readable output.
-     */
     public JsonGameFileHandler() {
         this.gson = new GsonBuilder()
                 .registerTypeAdapterFactory(new TransactionAdapterFactory())
@@ -47,11 +36,10 @@ public class JsonGameFileHandler implements GameFileHandler {
 
     /**
      * Saves the current game state to a JSON file.
-     * The file will contain the player state (money, portfolio,
-     * transaction archive) and the exchange state (stocks, prices, week).
      *
      * @param player   the player whose state should be saved
      * @param exchange the exchange whose state should be saved
+     * @param gameOver whether the game has ended
      * @param file     the file to save the game state to
      * @throws NullPointerException if player, exchange or file is null
      * @throws UncheckedIOException if the file cannot be written to
@@ -76,13 +64,9 @@ public class JsonGameFileHandler implements GameFileHandler {
 
     /**
      * Loads a saved game state from a JSON file.
-     * Deserializes the player and exchange from the file, then relinks
-     * each share in the player's portfolio to the correct stock reference
-     * from the exchange.
      *
-     * <p>The returned {@link Exchange} has not yet had its transient fields
-     * (random source, currency converter) populated. Callers must invoke
-     * {@link Exchange#reinitialize} before using the exchange.
+     * <p>The returned {@link Exchange} has no transient fields populated;
+     * callers must invoke {@link Exchange#reinitialize} before using the exchange.
      *
      * @param file the file to load the game state from
      * @return a {@link GameState} containing the deserialized player and exchange
@@ -101,6 +85,14 @@ public class JsonGameFileHandler implements GameFileHandler {
         }
     }
 
+    /**
+     * Parses a game state from the given reader.
+     *
+     * @param reader the source to read JSON from
+     * @param label  a human-readable identifier for the source (used in error messages)
+     * @return the deserialized game state
+     * @throws GameSaveCorruptException if the JSON is invalid or required fields are missing
+     */
     GameState parse(Reader reader, String label) throws GameSaveCorruptException {
         JsonObject gameState;
         try {
@@ -149,7 +141,7 @@ public class JsonGameFileHandler implements GameFileHandler {
             TypeAdapter<T> delegate = gson.getDelegateAdapter(this, type);
             TypeAdapter<JsonElement> elementAdapter = gson.getAdapter(JsonElement.class);
 
-            return new TypeAdapter<T>() {
+            return new TypeAdapter<>() {
                 @Override
                 public void write(JsonWriter out, T value) throws IOException {
                     JsonObject obj = delegate.toJsonTree(value).getAsJsonObject();

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/leaderboard/JsonLeaderboardFileHandler.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/leaderboard/JsonLeaderboardFileHandler.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.file.leaderboard;
 
 import com.google.gson.*;
@@ -15,8 +16,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * JSON-backed leaderboard storage. Uses Gson with a small type adapter for
- * {@link Instant} since Gson does not handle it out of the box.
+ * JSON-backed leaderboard storage with atomic writes.
  *
  * <p>Writes are atomic: the new content is first written to a sibling
  * {@code .tmp} file, then moved over the target file. On the same filesystem
@@ -57,15 +57,13 @@ public class JsonLeaderboardFileHandler implements LeaderboardFileHandler {
         try (FileReader reader = new FileReader(file)) {
             return parse(reader);
         } catch (IOException e) {
-            throw new IllegalStateException(
-                    "Could not read leaderboard file: " + file.getName(), e);
+            throw new UncheckedIOException(
+                    "Failed to read leaderboard file: " + file.getName(), e);
         }
     }
 
     /**
      * Parses leaderboard entries from an already-opened reader.
-     * The file-absent short-circuit and file-open I/O concerns remain in
-     * {@link #readAll(File)}; this method handles only JSON deserialisation.
      *
      * @param reader the reader positioned at the start of a JSON leaderboard array
      * @return a mutable list of entries; empty if the JSON is {@code null} or {@code []}
@@ -107,17 +105,21 @@ public class JsonLeaderboardFileHandler implements LeaderboardFileHandler {
             try (FileWriter writer = new FileWriter(tmp.toFile())) {
                 gson.toJson(entries, writer);
             }
-            try {
-                Files.move(tmp, target,
-                        StandardCopyOption.REPLACE_EXISTING,
-                        StandardCopyOption.ATOMIC_MOVE);
-            } catch (UnsupportedOperationException atomicNotSupported) {
-                // Fall back to non-atomic move on file systems that don't support it.
-                Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING);
-            }
+            moveAtomicallyIfSupported(tmp, target);
         } catch (IOException e) {
             throw new UncheckedIOException(
                     "Failed to write leaderboard file: " + file.getName(), e);
+        }
+    }
+
+    private static void moveAtomicallyIfSupported(Path source, Path target) throws IOException {
+        try {
+            Files.move(source, target,
+                    StandardCopyOption.REPLACE_EXISTING,
+                    StandardCopyOption.ATOMIC_MOVE);
+        } catch (UnsupportedOperationException _) {
+            // Fall back to non-atomic move on file systems that don't support it.
+            Files.move(source, target, StandardCopyOption.REPLACE_EXISTING);
         }
     }
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/leaderboard/LeaderboardCorruptException.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/leaderboard/LeaderboardCorruptException.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.file.leaderboard;
 
 /**
@@ -5,13 +6,8 @@ package edu.ntnu.idatt2003.millions.file.leaderboard;
  * not conform to the expected JSON schema — for example, the file contains invalid
  * JSON or an unexpected structure.
  *
- * <p>This is a recoverable failure. Callers should catch it, treat the leaderboard
- * as empty or unavailable, and log the problem rather than crashing. The rest of
- * the game must continue normally even if the leaderboard is unreadable.
- *
- * <p>Note: this exception covers content-level corruption only. File-system failures
- * (unreadable file, missing permissions) are reported as {@link IllegalStateException}
- * by the reader. See {@link JsonLeaderboardFileHandler} for the exact split.
+ * <p>This exception covers content-level corruption only. File-system failures
+ * (unreadable file, missing permissions) are reported as {@link java.io.UncheckedIOException}.
  */
 public class LeaderboardCorruptException extends Exception {
 
@@ -26,8 +22,6 @@ public class LeaderboardCorruptException extends Exception {
 
     /**
      * Creates an exception with a descriptive message and a chained cause.
-     * Use this constructor when wrapping a lower-level exception such as a
-     * {@link com.google.gson.JsonParseException}.
      *
      * @param message a human-readable description of the parse failure
      * @param cause   the lower-level exception that triggered this one

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/leaderboard/LeaderboardFileHandler.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/leaderboard/LeaderboardFileHandler.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.file.leaderboard;
 
 import edu.ntnu.idatt2003.millions.model.leaderboard.LeaderboardEntry;
@@ -7,7 +8,6 @@ import java.util.List;
 
 /**
  * Reads and writes the application leaderboard to and from a file.
- * Implementations may support different formats, such as JSON.
  *
  * <p>Implementations must tolerate a missing file on read — that is the normal
  * state before the first entry is recorded — and return an empty list rather

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/stock/CsvStockFileHandler.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/stock/CsvStockFileHandler.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.file.stock;
 
 import edu.ntnu.idatt2003.millions.model.stock.Stock;
@@ -18,8 +19,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * Implementation of {@link StockFileHandler} for reading and writing
- * stock data to and from CSV files.
+ * Reads and writes stock data to and from CSV files.
  *
  * <p>Each line in the file represents a stock on the form:
  * {@code symbol,name,price}. Lines starting with {@code #} and
@@ -37,40 +37,15 @@ import java.util.Objects;
 public class CsvStockFileHandler implements StockFileHandler {
 
     /**
-     * Default currency assigned to parsed stocks when no currency is supplied
-     * by the caller. Used by the no-currency overloads to preserve previous
-     * behaviour.
+     * Default currency assigned to parsed stocks when no currency is supplied by the caller.
      */
     private static final Currency DEFAULT_CURRENCY = Currency.getInstance("USD");
 
-    /**
-     * Delimiter used to separate fields in the CSV file.
-     */
     private static final String DELIMITER = ",";
-
-    /**
-     * Prefix used to identify comment lines in the CSV file.
-     */
     private static final String COMMENT_PREFIX = "#";
-
-    /**
-     * Expected number of fields per stock entry in the CSV file.
-     */
     private static final int EXPECTED_FIELDS = 3;
-
-    /**
-     * Index of the stock symbol field in a CSV line.
-     */
     private static final int SYMBOL_INDEX = 0;
-
-    /**
-     * Index of the stock name field in a CSV line.
-     */
     private static final int NAME_INDEX = 1;
-
-    /**
-     * Index of the stock price field in a CSV line.
-     */
     private static final int PRICE_INDEX = 2;
 
     /**
@@ -81,6 +56,7 @@ public class CsvStockFileHandler implements StockFileHandler {
      * @return a list of stocks parsed from the file
      * @throws NullPointerException      if path is null
      * @throws UncheckedIOException      if the file cannot be read
+     * @throws EmptyStockFileException   if the file contains no valid stock entries
      * @throws InvalidStockDataException if any data line has the wrong column count
      *                                   or a non-numeric price field
      */
@@ -124,6 +100,7 @@ public class CsvStockFileHandler implements StockFileHandler {
      * @return a list of stocks parsed from the stream
      * @throws NullPointerException      if inputStream is null
      * @throws UncheckedIOException      if the stream cannot be read
+     * @throws EmptyStockFileException   if the stream contains no valid stock entries
      * @throws InvalidStockDataException if any data line has the wrong column count
      *                                   or a non-numeric price field
      */
@@ -208,17 +185,7 @@ public class CsvStockFileHandler implements StockFileHandler {
                             "error.stock.csv.blankName", new Object[]{lineNumber, line.trim()});
                 }
                 String rawPrice = fields[PRICE_INDEX].trim();
-                BigDecimal price;
-                try {
-                    price = new BigDecimal(rawPrice);
-                } catch (NumberFormatException e) {
-                    throw new InvalidStockDataException(
-                            "error.stock.csv.nonNumericPrice", new Object[]{rawPrice, lineNumber, line.trim()});
-                }
-                if (price.compareTo(BigDecimal.ZERO) <= 0) {
-                    throw new InvalidStockDataException(
-                            "error.stock.csv.nonPositivePrice", new Object[]{rawPrice, lineNumber, line.trim()});
-                }
+                BigDecimal price = parsePrice(rawPrice, lineNumber, line.trim());
                 result.add(new Stock(symbol, name, new ArrayList<>(List.of(price)), currency));
             }
         } catch (IOException e) {
@@ -228,6 +195,31 @@ public class CsvStockFileHandler implements StockFileHandler {
             throw new EmptyStockFileException(source);
         }
         return result;
+    }
+
+    /**
+     * Parses and validates the price field from a CSV line.
+     *
+     * @param rawPrice   the trimmed price string from the CSV field
+     * @param lineNumber the 1-based line number, for error messages
+     * @param rawLine    the trimmed full line, for error messages
+     * @return the validated positive price
+     * @throws InvalidStockDataException if the price is non-numeric or non-positive
+     */
+    private BigDecimal parsePrice(String rawPrice, int lineNumber, String rawLine)
+            throws InvalidStockDataException {
+        BigDecimal price;
+        try {
+            price = new BigDecimal(rawPrice);
+        } catch (NumberFormatException _) {
+            throw new InvalidStockDataException(
+                    "error.stock.csv.nonNumericPrice", new Object[]{rawPrice, lineNumber, rawLine});
+        }
+        if (price.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new InvalidStockDataException(
+                    "error.stock.csv.nonPositivePrice", new Object[]{rawPrice, lineNumber, rawLine});
+        }
+        return price;
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/stock/EmptyStockFileException.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/stock/EmptyStockFileException.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.file.stock;
 
 /**
@@ -8,10 +9,6 @@ package edu.ntnu.idatt2003.millions.file.stock;
  * completely empty or contains only blank lines and comment lines (starting with
  * {@code #}), leaving no stock data to load into the exchange.
  *
- * <p>Callers that only need to know that the stock file is unusable can catch the
- * parent class {@link InvalidStockDataException}. Callers that want to distinguish
- * between a malformed line and a structurally empty file can catch this subclass
- * directly.
  */
 public class EmptyStockFileException extends InvalidStockDataException {
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/stock/InvalidStockDataException.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/stock/InvalidStockDataException.java
@@ -30,7 +30,7 @@ import java.util.Arrays;
 public class InvalidStockDataException extends Exception {
 
     private final String i18nKey;
-    private final Object[] args;
+    private final transient Object[] args;
 
     /**
      * Creates an exception with an i18n key and structured arguments but no chained cause.

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/stock/InvalidStockDataException.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/stock/InvalidStockDataException.java
@@ -26,6 +26,9 @@ import java.util.Arrays;
  *
  * <p>{@link EmptyStockFileException} is a subclass for the case where the file
  * contains no valid stock entries at all.
+ *
+ * <p>Implements {@link LocalizedException} so callers can catch it alongside other
+ * i18n-aware exceptions in a single multi-catch block.
  */
 public class InvalidStockDataException extends Exception implements LocalizedException {
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/stock/InvalidStockDataException.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/stock/InvalidStockDataException.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.file.stock;
 
 import java.util.Arrays;
@@ -17,9 +18,7 @@ import java.util.Arrays;
  *
  * <p>The exception carries an opaque {@link #getI18nKey() i18nKey} and structured
  * {@link #getArgs() args} (typically line number and raw line content) rather than
- * a pre-resolved string. Callers in the controller layer resolve the key at display
- * time via {@code LanguageManager} so the message is shown in the user's current
- * language.
+ * a pre-resolved string.
  *
  * <p>{@link #getMessage()} returns a fallback string intended for logging and
  * debugging only — it is not the user-facing message.
@@ -59,7 +58,6 @@ public class InvalidStockDataException extends Exception {
 
     /**
      * Returns the resource-bundle key for the error message template.
-     * Controllers pass this to {@code LanguageManager.get(key)} at display time.
      *
      * @return the i18n key
      */

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/stock/InvalidStockDataException.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/stock/InvalidStockDataException.java
@@ -1,6 +1,7 @@
 // Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.file.stock;
 
+import edu.ntnu.idatt2003.millions.file.LocalizedException;
 import java.util.Arrays;
 
 /**
@@ -26,7 +27,7 @@ import java.util.Arrays;
  * <p>{@link EmptyStockFileException} is a subclass for the case where the file
  * contains no valid stock entries at all.
  */
-public class InvalidStockDataException extends Exception {
+public class InvalidStockDataException extends Exception implements LocalizedException {
 
     private final String i18nKey;
     private final transient Object[] args;

--- a/src/main/java/edu/ntnu/idatt2003/millions/file/stock/StockFileHandler.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/file/stock/StockFileHandler.java
@@ -1,3 +1,4 @@
+// Javadoc generated with AI assistance - reviewed and approved by author.
 package edu.ntnu.idatt2003.millions.file.stock;
 
 import edu.ntnu.idatt2003.millions.model.stock.Stock;
@@ -9,8 +10,6 @@ import java.util.List;
 
 /**
  * Interface for reading and writing stock data to and from files.
- * Implementations of this interface handle a specific file format,
- * making it easy to add support for new formats in the future.
  *
  * <p>Reading is exposed for both file paths and arbitrary input streams,
  * which lets callers parse classpath resources or in-memory data without
@@ -45,11 +44,9 @@ public interface StockFileHandler {
     List<Stock> readStocks(Path path, Currency currency) throws InvalidStockDataException;
 
     /**
-     * Reads stock data from the given input stream. Useful for parsing
-     * classpath resources or in-memory data without writing to disk.
-     * The caller retains ownership of the stream and is responsible for
-     * closing it. Stocks are tagged with the implementation's default
-     * currency.
+     * Reads stock data from the given input stream. The caller retains
+     * ownership of the stream and is responsible for closing it. Stocks
+     * are tagged with the implementation's default currency.
      *
      * @param inputStream the input stream to read from
      * @return a list of stocks parsed from the stream

--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -44,6 +44,7 @@ error.stock.csv.blankName=Blank company name at line {0}: "{1}"
 error.stock.csv.nonNumericPrice=Non-numeric price "{0}" at line {1}: "{2}"
 error.stock.csv.nonPositivePrice=Negative price "{0}" at line {1}: "{2}"
 error.stock.csv.emptyFile=Stock file is empty or contains no valid entries: "{0}"
+error.unexpected=An unexpected error occurred. See the log for details.
 start.chooser.stock.title=Select stock file
 start.chooser.save.title=Select saved game file
 # Navbar

--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -45,6 +45,9 @@ error.stock.csv.nonNumericPrice=Non-numeric price "{0}" at line {1}: "{2}"
 error.stock.csv.nonPositivePrice=Negative price "{0}" at line {1}: "{2}"
 error.stock.csv.emptyFile=Stock file is empty or contains no valid entries: "{0}"
 error.unexpected=An unexpected error occurred. See the log for details.
+error.gameOver=Action could not be performed - the game is over.
+error.noActiveGame=No active game to save.
+error.saveFailed=Save failed. See the log for details.
 start.chooser.stock.title=Select stock file
 start.chooser.save.title=Select saved game file
 # Navbar

--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -552,6 +552,7 @@ watchlist.remove.cancel=Cancel
 toast.watchlist.added={0} added to watchlist
 toast.watchlist.removed={0} removed from watchlist
 toast.watchlist.addFailed=Could not add stock to watchlist
+toast.watchlist.updateNoteFailed=Could not update the note for the watchlisted stock
 toast.watchlist.removeFailed=Could not remove stock from watchlist
 
 

--- a/src/main/resources/i18n/messages_no.properties
+++ b/src/main/resources/i18n/messages_no.properties
@@ -542,4 +542,5 @@ watchlist.remove.cancel=Avbryt
 toast.watchlist.added={0} lagt til i overvåkningslisten
 toast.watchlist.removed={0} fjernet fra overvåkningslisten
 toast.watchlist.addFailed=Kunne ikke legge til aksjen i overvåkningslisten
+toast.watchlist.updateNoteFailed=Kunne ikke oppdatere notatet for aksjen i overvåkningslisten
 toast.watchlist.removeFailed=Kunne ikke fjerne aksjen fra overvåkningslisten

--- a/src/main/resources/i18n/messages_no.properties
+++ b/src/main/resources/i18n/messages_no.properties
@@ -45,6 +45,9 @@ error.stock.csv.nonNumericPrice=Ugyldig pris "{0}" på linje {1}: "{2}"
 error.stock.csv.nonPositivePrice=Negativ pris "{0}" på linje {1}: "{2}"
 error.stock.csv.emptyFile=Aksjefilen er tom eller inneholder ingen gyldige oppføringer: "{0}"
 error.unexpected=En uventet feil oppstod. Sjekk loggen for detaljer.
+error.gameOver=Handlingen kunne ikke utføres - spillet er over.
+error.noActiveGame=Ingen aktivt spill å lagre.
+error.saveFailed=Lagring feilet. Sjekk loggen for detaljer.
 start.chooser.stock.title=Velg aksjedatafil
 start.chooser.save.title=Velg lagringsfil
 # Navbar

--- a/src/main/resources/i18n/messages_no.properties
+++ b/src/main/resources/i18n/messages_no.properties
@@ -44,6 +44,7 @@ error.stock.csv.blankName=Tomt selskapsnavn på linje {0}: "{1}"
 error.stock.csv.nonNumericPrice=Ugyldig pris "{0}" på linje {1}: "{2}"
 error.stock.csv.nonPositivePrice=Negativ pris "{0}" på linje {1}: "{2}"
 error.stock.csv.emptyFile=Aksjefilen er tom eller inneholder ingen gyldige oppføringer: "{0}"
+error.unexpected=En uventet feil oppstod. Sjekk loggen for detaljer.
 start.chooser.stock.title=Velg aksjedatafil
 start.chooser.save.title=Velg lagringsfil
 # Navbar


### PR DESCRIPTION
25 commits covering the file, controller, and exception
layers. The work follows the same pattern established in
the earlier model-layer and service-layer PRs: Javadoc
audit on every public method, with substantive code
changes driven by findings surfaced during the audit.

This PR is larger than the previous two because the
controller audit revealed systemic gaps in
validation and error-handling that warranted dedicated
fixes before the Javadoc could honestly describe what
each method does.

## File-layer Javadoc

Class-level and public-method Javadoc updated for:
GameFileHandler, GameState, JsonGameFileHandler,
JsonLeaderboardFileHandler, LeaderboardCorruptException,
LeaderboardFileHandler, EmptyStockFileException,
InvalidStockDataException, StockFileHandler.

Also tightened CsvStockFileHandler (SonarQube fix from
earlier service PR follow-up) and marked args fields
transient on the two i18n exception classes to silence
java:S1948.

## Controller-layer audit and fixes

A read-only audit of all 7 controllers identified
inconsistent validation and error-handling. Five
small fixes addressed the gaps in priority order:

### 1. Global uncaught-exception handler in App.start
JavaFX event handlers that threw RuntimeException or
NPE previously surfaced as silent failures or stderr
stack-traces. The new global handler logs SEVERE and
shows a localized error dialog as a last-resort safety
net. Specific exception types still get specific catches
upstream — the global handler is what catches what
slips through.

### 2. MainController exception handling
Five service-call sites (advanceWeek, declareGameOver,
sellAllAndExit, recordLeaderboardEntry, saveGame) had
either no try-catch or an overly broad
catch (RuntimeException). Replaced with typed catches
that show specific user feedback (game-over toast, save
failure toast). NullPointerException deliberately stays
uncaught — it indicates a programming bug and should
surface to the global handler.

### 3. LoanController and ForcedSaleController game-over catches
Both controllers relied on GameService to throw
IllegalStateException when the game is over but didn't
catch it. Added IllegalStateException catches with
"action could not be performed — game is over" toasts,
matching the convention established in MainController.

### 4. TradeController watchlist cleanup
Three watchlist methods (toggle, remove, updateNote)
caught generic RuntimeException without logging the
message, and none validated the symbol parameter
before delegating. Replaced broad catches with typed
IllegalArgumentException catches that log the message,
and added blank-symbol guards. NPE and other unexpected
errors fall through to the global handler.

### 5. Additional follow-ups from the audit
- updateWatchlistNote was silent on failure even after
  the watchlist cleanup. Added an error toast to match
  the failure-toast pattern used by its siblings.
- buy and sell duplicated error-message normalization
  logic. Extracted into a small private helper
  (resolveErrorMessage). Full template extraction was
  considered and deliberately rejected — the variations
  require four substitutable lambdas plus a custom
  functional interface, which would be harder to read
  than the current duplication.

## Substantive design refactors

### LocalizedException interface
GameSaveCorruptException and InvalidStockDataException
both carried an i18n key + args payload and were caught
with identical bodies in StartController. SonarQube
flagged the duplication, but multi-catch wasn't
possible without a common type. Introduced
LocalizedException interface that both exceptions
implement. The two catches collapse into one
multi-catch.

This refactor was previously deferred under "rule of
three" (wait for a third use-case before generalizing).
We collapsed that decision because: two concrete
examples with identical structure, the interface is a
2-method minimum that doesn't lock future exceptions
into anything restrictive, and the SonarQube finding
made the duplication visible in static analysis. "Rule
of three" is a heuristic against speculative
abstraction, not a rule against acting on proven
duplication.

### EndGameActions record
GameOverController constructor took 6 parameters; 4 of
them were callbacks always supplied together by
MainController. Extracted into a record. Diagnosed
coherence first (all four answer "how do you want to
close this game?") to avoid making a record for the
sake of parameter-count alone. The refactor pays off in
two places: GameOverController drops from 6 to 3
parameters, GameOverModal loses four stored fields.

### StartController validator pattern documented
A Part B finding flagged the direct instantiation of
CsvStockFileHandler and JsonGameFileHandler in
validateAndSetStockFile and validateAndSetSaveFile as a
testability gap. Diagnosis showed the handlers are
stateless local parsing tools, not dependencies — both
methods discard the parsed result and exist only to
validate file content before storing a path. Tests use
@TempDir with real files, which is the correct strategy
for parse-validation. Documented the deliberate intent
in Javadoc to prevent the same false-positive
observation in the future.

### Toast and validation conventions confirmed
Two error-feedback patterns coexist: toast for the main
window (MainController) and dialog-internal feedback
for modal dialogs (LoanController, ForcedSaleController,
TradeController dialogs). The choice reflects where the
user's attention is — if they're in a modal, the error
goes there; if they're in the main window, toast.
