### PR TITLE
test: update getweeklychange tests to expect week-one zero-change row

### DIFF
--- a/src/test/java/edu/ntnu/idatt2003/millions/service/stock/StockHistoryServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/service/stock/StockHistoryServiceTest.java
@@ -298,29 +298,29 @@ class StockHistoryServiceTest {
         }
 
         @Test
-        @DisplayName("Should clamp the lower bound to week two when fromWeek is one")
-        void clampsLowerBoundToWeekTwo() {
+        @DisplayName("Should include a zero-change row for week one when fromWeek is one")
+        void includesWeekOneZeroChangeRowWhenFromWeekIsOne() {
             // Arrange
             Stock stock = usdStock(100, 110, 105, 120, 126);
 
-            // Act: from week 1 -> first change row is week 2, not week 1
+            // Act: from week 1 -> rows 3, 2 plus a zero-change row for week 1
             List<WeeklyPriceChange> rows = service.getWeeklyChanges(stock, converter(), 1, 3);
 
             // Assert
-            assertEquals(List.of(3, 2), weeksOf(rows));
+            assertEquals(List.of(3, 2, 1), weeksOf(rows));
         }
 
         @Test
-        @DisplayName("Should return an empty list when the range ends before week two")
-        void returnsEmptyWhenRangeEndsBeforeWeekTwo() {
+        @DisplayName("Should return a single zero-change row for week one when range is one to one")
+        void returnsWeekOneZeroChangeRowWhenRangeIsOneToOne() {
             // Arrange
             Stock stock = usdStock(100, 110, 105);
 
-            // Act: range [1, 1] contains no transition week
+            // Act: range [1, 1] contains no transition, but week 1 zero-change row is appended
             List<WeeklyPriceChange> rows = service.getWeeklyChanges(stock, converter(), 1, 1);
 
             // Assert
-            assertTrue(rows.isEmpty());
+            assertEquals(List.of(1), weeksOf(rows));
         }
 
         @Test


### PR DESCRIPTION
The two failing tests assumed that getWeeklyChanges would clamp the lower bound to week 2 and return an empty list when the range ended before week 2. This was the behaviour before we included week 1 in changeweekcard.

This did not match the intended behaviour: when fromWeek <= 1, the service appends a zero-change row for week 1 so that callers like WeeklyChangeCard can display the full history from the opening week.
Updated both test names and assertions to expect the week-one row in the result.