### PR TITLE
fix: unify ENTER and SPACE activation across all buttons

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/game/MainController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/game/MainController.java
@@ -258,6 +258,9 @@ public class MainController {
         keyboardService.universalShortcuts().register(
             new KeyCodeCombination(KeyCode.ENTER), this::fireCurrentButton
         );
+        keyboardService.universalShortcuts().register(
+            new KeyCodeCombination(KeyCode.SPACE), this::fireCurrentButton
+        );
         var reg = keyboardService.globalShortcuts();
         reg.register(new KeyCodeCombination(KeyCode.DIGIT1, KeyCombination.SHORTCUT_DOWN), view::showDashboard);
         reg.register(new KeyCodeCombination(KeyCode.DIGIT2, KeyCombination.SHORTCUT_DOWN), view::showExchange);

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/component/modal/Modal.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/component/modal/Modal.java
@@ -91,17 +91,8 @@ public abstract class Modal {
     }
 
     /**
-     * Handles key events for this modal. ESC closes the modal.
-     *
-     * <p>This method is registered directly on the modal's own {@link javafx.scene.Scene}
-     * event filter in {@link #show()}, giving each modal isolated keyboard handling
-     * without participating in the application-wide {@code KeyboardNavigationService}
-     * context stack (modals use their own {@link javafx.stage.Stage} and are naturally
-     * isolated).</p>
-     *
-     * <p>Subclasses that need additional shortcuts should override this method
-     * and call {@code super.handleKeyPressed(event)} to preserve ESC behaviour.</p>
-     *
+     * Scene-level key handler. ESC closes; ENTER/SPACE fires the focused {@link Button}.
+     * *
      * @param event the key event
      * @return {@code true} if the event was handled
      */
@@ -110,6 +101,14 @@ public abstract class Modal {
             close();
             event.consume();
             return true;
+        }
+        if (event.getCode() == KeyCode.ENTER || event.getCode() == KeyCode.SPACE) {
+            javafx.scene.Node focused = stage.getScene().getFocusOwner();
+            if (focused instanceof Button button) {
+                button.fire();
+                event.consume();
+                return true;
+            }
         }
         return false;
     }


### PR DESCRIPTION
## Problem

Keyboard activation was inconsistent across the app. Standard Button nodes in the main scene responded to both keys, but buttons inside modals only responded to SPACE (JavaFX native), ENTER did nothing. This affected all modal windows: buy/sell dialogs, transaction receipts, loan application, loan repayment receipt, and confirmation dialogs (end game, forced sale, game over).
Root cause: KeyboardNavigationService with ENTER → fireCurrentButton() is bound to the main scene only. Modal windows own a separate Stage and Scene, so the main scene's shortcuts never reach them.

## Changes
Modal.handleKeyPressed()
Added ENTER and SPACE to fire the focused Button. Guard on instanceof Button ensures TextField nodes are unaffected — their own ENTER handlers (in TransactionDialog, LoanApplicationDialog) continue to work normally.
MainController.registerShortcuts()
Added SPACE → fireCurrentButton() alongside the existing ENTER binding. JavaFX already fires buttons on SPACE natively, but registering it explicitly makes the behaviour symmetrical and ensures the event is consumed consistently.

##Affected surfaces

All Modal subclasses automatically inherit the fix: TransactionDialog, TransactionReceipt, LoanApplicationDialog, LoanRepaymentReceipt, EndGameDialog, ForcedSaleDialog, GameOverModal.

##Not changed

ArrowKeyNavigator and SortColumnTable already handled both keys correctly and are untouched.