### PR TITLE
docs: add keyboard navigation doc

### DIFF
--- a/docs/keyboard_navigation.md
+++ b/docs/keyboard_navigation.md
@@ -1,0 +1,112 @@
+# Keyboard Navigation
+
+This document describes how keyboard navigation is implemented in the codebase, what shortcuts are available to a player, and how the underlying classes cooperate to make it work.
+
+---
+
+## Shortcut reference
+
+### During gameplay (in-game screen)
+
+| Keys | Action |
+|---|---|
+| `Cmd/Ctrl + 1` | Switch to the Dashboard view |
+| `Cmd/Ctrl + 2` | Switch to the Exchange view |
+| `Cmd/Ctrl + 3` | Switch to the Leaderboard view |
+| `Cmd/Ctrl + Enter` | Advance one week |
+| `Cmd/Ctrl + S` | Save the current game |
+| `Cmd/Ctrl + F` | Focus the search bar in the active view |
+| `Shift + 1–4` | Switch to tab 1–4 within the current view (e.g. Stocks / Portfolio sub-tabs on Exchange) |
+| `Enter` / `Space` | Activate (click) the currently focused button |
+
+### On the start screen
+
+| Keys | Action |
+|---|---|
+| `Shift + 1` | Switch to the New Game tab |
+| `Shift + 2` | Switch to the Load Game tab |
+
+### In tables and search bars
+
+| Keys | Action |
+|---|---|
+| `↑` / `↓` | Move selection up/down through table rows |
+| `Enter` / `Space` (on a row) | Open the detail view or confirm the selected row |
+| `↑` at the first row | Releases the key to `PageArrowDispatcher`, which scrolls the page up instead |
+| `↓` at the last row | Releases the key to `PageArrowDispatcher`, which scrolls the page down instead |
+| `↓` in search field | Moves focus to the first result row (if results exist); otherwise scrolls the page |
+| `Enter` in search field | Triggers the search |
+| `Escape` in search field | Clears the search field and returns focus to its parent container |
+
+### In dialogs and modals
+
+All dialogs and modals extend the base `Modal` class, which installs a scene-level key handler that applies to every dialog automatically.
+
+| Keys | Action |
+|---|---|
+| `Escape` | Closes the dialog and discards any unsaved input |
+| `Enter` / `Space` | Activates the currently focused button inside the dialog |
+
+Note that `GameOverModal` and `ForcedSaleDialog` intentionally override `close()` as a no-op, so `Escape` has no effect in those dialogs. The player must make an explicit choice before dismissing them.
+
+### General navigation
+
+| Keys | Action |
+|---|---|
+| `Tab` / `Shift+Tab` | Standard JavaFX focus traversal through interactive controls |
+| `↑` / `↓` (no focused control claiming them) | Scrolls the active page by 40 px per step |
+
+---
+
+## Architecture overview
+
+Keyboard handling is split across a small package (`keyboard/`) with three concerns: shortcut dispatch, arrow-key routing, and focus management.
+
+**`KeyboardNavigationService`** is the single entry point. It attaches one `EventFilter` to the app-lifetime `Scene` and dispatches every `KEY_PRESSED` event through two ordered registries:
+
+1. The **universal registry** - shortcuts that fire in any context (e.g. Enter to click the focused button).
+2. The **global registry** - application-wide shortcuts that are active during normal gameplay.
+
+Modal dialogs are naturally isolated: each dialog runs in its own `APPLICATION_MODAL` `Stage`, so global shortcuts on the main scene cannot fire while a dialog has focus.
+
+**`ShortcutRegistry`** backs both registries. It maps `KeyCombination` -> action in insertion order; the first match wins. Actions can be unconditional (`Runnable`) or conditional (`BooleanSupplier`), where returning `false` lets the event propagate.
+
+**`PageArrowDispatcher`** is installed in the capture phase on the window root so it sees arrow keys before any focused control. When UP or DOWN is pressed it checks, in order:
+
+1. Whether the focused node (or any ancestor) has registered a `VerticalArrowHandler` under the property key `millions.verticalArrowHandler`. If it has, the handler gets first refusal.
+2. Whether the focused node is a `TextArea`, `ComboBox`, or `Spinner`, which keep arrows natively.
+3. Otherwise it delegates to the active `PageScroller` (the `KeyboardScrollPane` wrapping the current view).
+
+**`ArrowKeyNavigator`** is a reusable helper that tracks a selected index and moves it in response to UP, DOWN, Enter, and Space events. Table components wire it to their row list.
+
+**`FocusRestorer`** snapshots the focused node before a UI rebuild and restores it (or falls back to a supplied node) afterwards via `Platform.runLater`.
+
+---
+
+## How the layers cooperate
+
+`MainController` calls `keyboardService.bindToNode(view.getRoot())`, which attaches the service to the scene as the root node enters it. All shortcuts are registered once in `registerShortcuts()`.
+
+Tab switching via `Shift+1–4` goes through `TabNavigationRegistry`, which holds at most one active `IntConsumer` at a time. Each view that has tabs registers its navigator as active when it becomes visible and clears it when it is replaced.
+
+`Cmd/Ctrl+F` goes through `SearchFocusRegistry`, which holds the currently active `SearchFocusProvider`. Views that contain a search bar implement this interface; views without one implement it as a no-op.
+
+When the application switches views, `PageFocusProvider.focusPageEntry()` is called on the incoming view to land focus on the most appropriate control, so the player can immediately use the keyboard without clicking first.
+
+---
+
+## Key classes and interfaces
+
+| Class / Interface | Responsibility |
+|---|---|
+| `KeyboardNavigationService` | Attaches to the scene; owns and dispatches through both registries |
+| `ShortcutRegistry` | Maps `KeyCombination` → action; evaluates in insertion order |
+| `PageArrowDispatcher` | Routes UP/DOWN in capture phase; delegates to handlers or `PageScroller` |
+| `ArrowKeyNavigator` | Tracks selection index; handles UP/DOWN/Enter/Space for linear lists |
+| `KeyboardScrollPane` | Implements `PageScroller`; scrolls 40 px per arrow step |
+| `VerticalArrowHandler` | Strategy interface a control registers to claim arrow keys |
+| `FocusRestorer` | Snapshots and restores focus around UI rebuilds |
+| `TabNavigationRegistry` | Tracks the active tab navigator; delegates `Shift+1–4` to it |
+| `SearchFocusRegistry` | Tracks the active search provider; delegates `Cmd/Ctrl+F` to it |
+| `PageFocusProvider` | Interface for views that expose a keyboard entry point |
+| `SearchFocusProvider` | Interface for views that contain a search bar |

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/component/table/RowCells.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/component/table/RowCells.java
@@ -56,7 +56,7 @@ public final class RowCells<Column> {
      * @param column the column key to look up
      * @return the mapped node, or {@code null} if the column was not added to this builder
      */
-    Node get(Column column) {
+    public Node get(Column column) {
         return cells.get(column);
     }
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/component/table/RowHighlighter.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/component/table/RowHighlighter.java
@@ -2,7 +2,9 @@ package edu.ntnu.idatt2003.millions.view.ingame.component.table;
 
 import javafx.scene.Node;
 import javafx.scene.layout.Region;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -34,23 +36,29 @@ final class RowHighlighter {
     }
 
     /**
-     * Binds an anchor's focus state to the {@code is-focus} highlight of its row.
+     * Binds the focus state of all nodes in a row to the {@code is-focus} highlight.
+     * The highlight is applied when any node in the row is focused and removed only
+     * when none of them are focused.
      *
-     * @param gridRow the grid row the anchor belongs to
-     * @param anchor  the node focused when the row is navigated to
+     * @param gridRow  the grid row the nodes belong to
+     * @param rowNodes all interactive nodes in the row
      */
-    void bindFocus(int gridRow, Node anchor) {
+    void bindFocus(int gridRow, Collection<Node> rowNodes) {
         Region background = rowBackgrounds.get(gridRow);
         if (background == null) {
             return;
         }
-        anchor.focusedProperty().addListener((obs, was, isFocused) -> {
-            if (isFocused) {
-                addClass(background, FOCUS_CLASS);
-            } else {
-                removeClass(background, FOCUS_CLASS);
-            }
-        });
+        List<Node> nodes = List.copyOf(rowNodes);
+        for (Node node : nodes) {
+            node.focusedProperty().addListener((obs, was, isFocused) -> {
+                boolean anyFocused = nodes.stream().anyMatch(Node::isFocused);
+                if (anyFocused) {
+                    addClass(background, FOCUS_CLASS);
+                } else {
+                    removeClass(background, FOCUS_CLASS);
+                }
+            });
+        }
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/component/table/SortColumnTable.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/component/table/SortColumnTable.java
@@ -18,6 +18,7 @@ import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Region;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Supplier;
@@ -203,7 +204,7 @@ public class SortColumnTable<Column> {
      */
     public void addSelectableRow(int gridRow, Node focusAnchor, Runnable onEnter, RowCells<Column> cells) {
         addRow(gridRow, cells);
-        registerSelectableRow(gridRow, focusAnchor, onEnter);
+        registerSelectableRow(gridRow, focusAnchor, onEnter, cells.nodes());
         for (Node node : cells.nodes()) {
             if (!(node instanceof ButtonBase)) {
                 node.addEventHandler(MouseEvent.MOUSE_CLICKED, e -> {
@@ -227,10 +228,10 @@ public class SortColumnTable<Column> {
      * @param focusAnchor the node focused when this row is reached
      * @param onEnter     action invoked on Enter or Space
      */
-    private void registerSelectableRow(int gridRow, Node focusAnchor, Runnable onEnter) {
+    private void registerSelectableRow(int gridRow, Node focusAnchor, Runnable onEnter, Collection<Node> rowNodes) {
         int index = rows.size();
         rows.add(new NavigableRow(focusAnchor, onEnter));
-        rowHighlighter.bindFocus(gridRow, focusAnchor);
+        rowHighlighter.bindFocus(gridRow, rowNodes);
         focusAnchor.getProperties().put(
                 PageArrowDispatcher.ARROW_HANDLER_KEY,
                 (VerticalArrowHandler) event -> handleRowArrow(event, index));

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/exchange/stock/card/StocksCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/exchange/stock/card/StocksCard.java
@@ -10,6 +10,7 @@ import edu.ntnu.idatt2003.millions.view.ingame.component.card.DetailTableCard;
 import edu.ntnu.idatt2003.millions.view.ingame.component.table.RowCells;
 import edu.ntnu.idatt2003.millions.view.ingame.component.table.SortColumnTable;
 import edu.ntnu.idatt2003.millions.view.ingame.exchange.stock.StocksSort;
+import javafx.scene.Node;
 import javafx.scene.control.Button;
 
 import java.text.MessageFormat;
@@ -77,6 +78,12 @@ public class StocksCard extends DetailTableCard<Stock, StocksSort.SortColumn> {
     protected RowCells<StocksSort.SortColumn> buildRowCells(Stock item, int rowIndex) {
         return rowRenderer.buildRow(item)
                 .put(StocksSort.SortColumn.DETAILS, buildDetailChevron(item));
+    }
+
+    @Override
+    protected Node focusAnchorFor(Stock item, RowCells<StocksSort.SortColumn> cells) {
+        Node chevron = cells.get(StocksSort.SortColumn.DETAILS);
+        return chevron != null ? chevron : cells.firstNode();
     }
 
     @Override


### PR DESCRIPTION
## Summary
Fixes two keyboard navigation bugs discovered during documentation review, removes dead code left over from the keyboard PR, and adds a missing test class for ActiveRegistry.

## Background

While writing the keyboard navigation documentation, two behavioural bugs were found in the table interaction layer. Both are regressions from the keyboard PR: the focus anchor contract was not followed consistently across all table cards, and the row highlight was bound only to the anchor node rather than to the full row. FocusRestorer was also identified as dead cod, it was written for the keyboard PR but the problem it was meant to solve ended up being handled differently, leaving the class and its 14 tests with no production usage.

## Changes
### Keyboard navigation markdown documentation
Added documentation on how to use the keyboard functionality with the apps defined shortcuts, and the architecture overview, how it is used and connected.

### Bug: Enter/Space on a stock row toggled the watchlist star instead of opening detail
SortableTableCard.focusAnchorFor() defaults to cells.firstNode(). In HoldingsCard the detail chevron is inserted first in buildRowCells(), so it becomes the anchor and Enter fires the correct action. In StocksCard the watchlist star is inserted first by StocksRowRenderer, making it the anchor. When Enter was pressed, fireCurrentButton() in the universal registry fired the star button before onRowEnter could run.
Fixed by overriding focusAnchorFor() in StocksCard to return the DETAILS chevron. RowCells.get() was made public to allow this.

### Bug: Row focus highlight was lost when tabbing between controls within a row
RowHighlighter.bindFocus() listened only to the focus anchor's focusedProperty(). Tabbing to a star, buy button, or chevron in the same row moved focus away from the anchor, removing the is-focus class even though focus was still within the row.
Fixed by changing bindFocus() to accept all row nodes and apply the highlight as long as any node in the row is focused. SortColumnTable now passes cells.nodes() through registerSelectableRow().
