### PR TITLE
refactor: move TradeController out of DetailTableCard into concrete subclasses

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/component/card/DetailTableCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/component/card/DetailTableCard.java
@@ -1,6 +1,5 @@
 package edu.ntnu.idatt2003.millions.view.ingame.component.card;
 
-import edu.ntnu.idatt2003.millions.controller.trade.TradeController;
 import edu.ntnu.idatt2003.millions.service.game.GameService;
 import edu.ntnu.idatt2003.millions.view.ingame.component.ChevronButton;
 import edu.ntnu.idatt2003.millions.view.ingame.component.table.RowCells;
@@ -24,16 +23,9 @@ import edu.ntnu.idatt2003.millions.view.ingame.component.table.RowCells;
 public abstract class DetailTableCard<T, Column> extends SortableTableCard<T, Column> {
 
     /**
-     * The controller used to open detail and trade dialogs.
-     * Accessible to subclasses for wiring chevron buttons and action callbacks.
-     */
-    protected final TradeController controller;
-
-    /**
      * Constructs a detail table card.
      *
      * @param gameService   the game service to observe
-     * @param controller    the controller used to open detail and trade dialogs
      * @param pageSize      the number of items shown per page
      * @param statusKey     i18n key for the metadata-row status pattern;
      *                      must accept two positional arguments (filtered count, total count)
@@ -41,12 +33,10 @@ public abstract class DetailTableCard<T, Column> extends SortableTableCard<T, Co
      */
     protected DetailTableCard(
             GameService gameService,
-            TradeController controller,
             int pageSize,
             String statusKey,
             String emptyStateKey) {
         super(gameService, pageSize, statusKey, emptyStateKey);
-        this.controller = controller;
     }
 
     /**

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/dashboard/portfolio/card/HoldingsCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/dashboard/portfolio/card/HoldingsCard.java
@@ -45,6 +45,7 @@ public class HoldingsCard extends DetailTableCard<Share, HoldingsSort.SortColumn
     private static final int PAGE_SIZE = 9;
 
     private final GameService gameService;
+    private final TradeController controller;
     private final PortfolioService portfolioService;
     private final HoldingsSort sort;
     private final TableTotalRow<HoldingsSort.SortColumn> totalRow;
@@ -58,9 +59,10 @@ public class HoldingsCard extends DetailTableCard<Share, HoldingsSort.SortColumn
      */
     public HoldingsCard(GameService gameService, TradeController controller,
                         PortfolioService portfolioService) {
-        super(gameService, controller, PAGE_SIZE,
+        super(gameService, PAGE_SIZE,
                 "dashboard.portfolio.holdings.status", "dashboard.portfolio.empty");
         this.gameService = gameService;
+        this.controller = controller;
         this.portfolioService = portfolioService;
         this.sort = new HoldingsSort(portfolioService, gameService.getCurrencyConverter());
         this.sortProvider = sort;

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/dashboard/watchlist/card/WatchlistCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/dashboard/watchlist/card/WatchlistCard.java
@@ -36,6 +36,7 @@ public class WatchlistCard extends DetailTableCard<WatchlistItem, WatchlistSort.
     private static final double COL_GAP = 8;
 
     private final GameService gameService;
+    private final TradeController controller;
     private final WatchlistRowRenderer rowRenderer;
     private final StyledText title;
 
@@ -47,8 +48,9 @@ public class WatchlistCard extends DetailTableCard<WatchlistItem, WatchlistSort.
      */
     public WatchlistCard(GameService gameService,
                          TradeController tradeController) {
-        super(gameService, tradeController, PAGE_SIZE, "watchlist.status", "watchlist.empty");
+        super(gameService, PAGE_SIZE, "watchlist.status", "watchlist.empty");
         this.gameService = gameService;
+        this.controller = tradeController;
 
         WatchlistSort sort = new WatchlistSort(gameService.getCurrencyConverter());
         this.sortProvider = sort;

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/exchange/stock/card/StocksCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/exchange/stock/card/StocksCard.java
@@ -27,6 +27,7 @@ public class StocksCard extends DetailTableCard<Stock, StocksSort.SortColumn> {
     private static final double ROW_HEIGHT = 34.0;
 
     private final GameService gameService;
+    private final TradeController controller;
     private final StocksSort sort;
     private final StocksRowRenderer rowRenderer;
     private final StyledText title;
@@ -38,8 +39,9 @@ public class StocksCard extends DetailTableCard<Stock, StocksSort.SortColumn> {
      * @param controller  the controller used to open buy/sell dialogs
      */
     public StocksCard(GameService gameService, TradeController controller) {
-        super(gameService, controller, PAGE_SIZE, "exchange.stocks.status", "exchange.stocks.empty");
+        super(gameService, PAGE_SIZE, "exchange.stocks.status", "exchange.stocks.empty");
         this.gameService = gameService;
+        this.controller = controller;
         this.sort = new StocksSort(
                 gameService.getCurrencyConverter(),
                 symbol -> gameService.getPlayer().isOnWatchlist(symbol));


### PR DESCRIPTION
DetailTableCard previously held a protected final TradeController controller field, meaning the abstract view base class depended directly on a concrete controller class. This violated the separation-of-concerns rule in SoC.md and made it impossible to subclass DetailTableCard without coupling to TradeController.

Changes:
- Removed TradeController field, constructor parameter, and import from DetailTableCard
- Added private final TradeController controller to HoldingsCard, StocksCard, and WatchlistCard - each initialized in its own constructor        
- Updated card-hierarchy.puml to reflect the corrected class structure

Result: DetailTableCard is now a pure abstract view class with no controller dependency. Public constructor signatures of all three concrete subclasses are unchanged, so no call sites needed updating.

