### PR TITLE
feat: add chevron to stockrangingcard

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/exchange/ExchangeView.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/exchange/ExchangeView.java
@@ -107,7 +107,7 @@ public class ExchangeView extends VBox implements SearchFocusProvider, PageFocus
 
     private void showOverview() {
         if (overviewView == null) {
-            overviewView = new ExchangeOverview(gameService);
+            overviewView = new ExchangeOverview(gameService, controller);
         }
         activeTabProvider = null;
         contentArea.getChildren().setAll(overviewView);

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/exchange/overview/ExchangeOverview.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/exchange/overview/ExchangeOverview.java
@@ -1,5 +1,6 @@
 package edu.ntnu.idatt2003.millions.view.ingame.exchange.overview;
 
+import edu.ntnu.idatt2003.millions.controller.trade.TradeController;
 import edu.ntnu.idatt2003.millions.service.game.GameService;
 import edu.ntnu.idatt2003.millions.view.ingame.exchange.overview.card.GainersCard;
 import edu.ntnu.idatt2003.millions.view.ingame.exchange.overview.card.LosersCard;
@@ -15,9 +16,6 @@ import javafx.scene.layout.VBox;
  * View for the exchange overview tab.
  * Assembles market summary cards ({@link TotalStocksCard}, {@link GainersCard},
  * {@link LosersCard}) and ranked winner/loser tables ({@link StockRankingCard}).
- *
- * <p>Every card registers as its own observer and refreshes itself, so this view
- * only assembles the layout and holds no observer logic of its own.</p>
  */
 public class ExchangeOverview extends VBox {
 
@@ -27,9 +25,9 @@ public class ExchangeOverview extends VBox {
      * Constructs a new ExchangeOverview.
      *
      * @param gameService the game manager containing player and exchange
-     * @throws NullPointerException if gameService is null
+     * @param controller  the controller used to open stock detail modals
      */
-    public ExchangeOverview(GameService gameService) {
+    public ExchangeOverview(GameService gameService, TradeController controller) {
         setSpacing(16);
 
         HBox statCards = new HBox(16,
@@ -39,10 +37,10 @@ public class ExchangeOverview extends VBox {
         );
 
         StockRankingCard winnersTable = new StockRankingCard(
-                gameService, "exchange.overview.weeklyWinners",
+                gameService, controller, "exchange.overview.weeklyWinners",
                 exchange -> exchange.getGainers(RANKING_LIMIT));
         StockRankingCard losersTable = new StockRankingCard(
-                gameService, "exchange.overview.weeklyLosers",
+                gameService, controller, "exchange.overview.weeklyLosers",
                 exchange -> exchange.getLosers(RANKING_LIMIT));
 
         winnersTable.setMaxWidth(Double.MAX_VALUE);

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/exchange/overview/card/GainersCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/exchange/overview/card/GainersCard.java
@@ -6,7 +6,6 @@ import edu.ntnu.idatt2003.millions.view.ingame.component.card.WidgetCard;
 
 /**
  * Widget card displaying the number of stocks that rose in price this week.
- * Updates automatically on each week advance via {@link edu.ntnu.idatt2003.millions.observer.GameObserver}.
  */
 public class GainersCard extends WidgetCard {
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/exchange/overview/card/LosersCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/exchange/overview/card/LosersCard.java
@@ -6,7 +6,6 @@ import edu.ntnu.idatt2003.millions.view.ingame.component.card.WidgetCard;
 
 /**
  * Widget card displaying the number of stocks that fell in price this week.
- * Updates automatically on each week advance via {@link edu.ntnu.idatt2003.millions.observer.GameObserver}.
  */
 public class LosersCard extends WidgetCard {
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/exchange/overview/card/StockRankingCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/exchange/overview/card/StockRankingCard.java
@@ -1,5 +1,6 @@
 package edu.ntnu.idatt2003.millions.view.ingame.exchange.overview.card;
 
+import edu.ntnu.idatt2003.millions.controller.trade.TradeController;
 import edu.ntnu.idatt2003.millions.model.exchange.Exchange;
 import edu.ntnu.idatt2003.millions.model.stock.Stock;
 import edu.ntnu.idatt2003.millions.service.game.GameService;
@@ -7,10 +8,12 @@ import edu.ntnu.idatt2003.millions.util.format.ChangeFormatter;
 import edu.ntnu.idatt2003.millions.util.language.LanguageManager;
 import edu.ntnu.idatt2003.millions.util.format.TableCells;
 import edu.ntnu.idatt2003.millions.view.component.StyledText;
+import edu.ntnu.idatt2003.millions.view.ingame.component.ChevronButton;
 import edu.ntnu.idatt2003.millions.view.ingame.component.card.Card;
 import edu.ntnu.idatt2003.millions.view.ingame.component.table.RowCells;
 import edu.ntnu.idatt2003.millions.view.ingame.component.table.SortColumnTable;
 import edu.ntnu.idatt2003.millions.view.ingame.component.table.TableColumnDef;
+import java.text.MessageFormat;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
@@ -18,46 +21,41 @@ import javafx.geometry.HPos;
 import javafx.scene.control.Label;
 
 /**
- * Card displaying a ranked list of stocks with their current price and weekly
- * percentage change. Used for both winners and losers in the exchange overview.
- *
- * <p>Extends {@link Card}, so it registers as a game and language observer through
- * the base class and refreshes itself: {@link #onGameUpdated()} and
- * {@link #onLanguageChanged()} both re-render the rows from the supplied
- * {@code selector}, which picks the stocks to show (e.g. gainers or losers) out of
- * the current {@link Exchange}. Rendered as a {@link SortColumnTable} with five
- * non-sortable columns so cell height and padding match the other dashboard tables.</p>
+ * Card displaying a ranked list of stocks with price and weekly change.
+ * Used for both winners and losers in the exchange overview.
  */
 public class StockRankingCard extends Card {
 
-    private static final double COL_TICKER   = 18;
-    private static final double COL_COMPANY  = 35;
-    private static final double COL_CURRENCY = 13;
-    private static final double COL_PRICE    = 10;
-    private static final double COL_CHANGE   = 10;
+    private static final double COL_DETAILS =  15;
+    private static final double COL_TICKER = 10;
+    private static final double COL_COMPANY = 40;
+    private static final double COL_PRICE = 20;
+    private static final double COL_CHANGE = 15;
 
-    /** Column keys for the ranking table; non-sortable, used only as {@link RowCells} keys. */
-    private enum Col { TICKER, COMPANY, CURRENCY, PRICE, CHANGE }
+    /** Column keys for the ranking table; all non-sortable. */
+    private enum Col { TICKER, COMPANY, PRICE, CHANGE, DETAILS}
 
     private final GameService gameService;
+    private final TradeController controller;
     private final String titleKey;
     private final Function<Exchange, List<Stock>> selector;
     private final StyledText titleLabel;
     private final SortColumnTable<Col> table;
 
     /**
-     * Constructs a StockRankingCard.
+     * Constructs a {@code StockRankingCard}.
      *
      * @param gameService the game service supplying the exchange and observer registration
-     * @param titleKey    the i18n key for the table title
-     * @param selector    selects which stocks to display from the current exchange,
-     *                    e.g. {@code ex -> ex.getGainers(5)}
+     * @param controller  the controller used to open the stock detail modal
+     * @param titleKey    i18n key for the table title
+     * @param selector    selects which stocks to display, e.g. {@code ex -> ex.getGainers(5)}
      * @throws NullPointerException if any argument is null
      */
-    public StockRankingCard(GameService gameService, String titleKey,
-                            Function<Exchange, List<Stock>> selector) {
+    public StockRankingCard(GameService gameService, TradeController controller,
+                            String titleKey, Function<Exchange, List<Stock>> selector) {
         super(gameService);
         this.gameService = gameService;
+        this.controller = Objects.requireNonNull(controller, "controller cannot be null");
         this.titleKey = Objects.requireNonNull(titleKey, "titleKey cannot be null");
         this.selector = Objects.requireNonNull(selector, "selector cannot be null");
         setSpacing(12);
@@ -69,28 +67,20 @@ public class StockRankingCard extends Card {
         renderCurrent();
     }
 
-    /**
-     * Re-renders the ranking rows with the latest stocks from the exchange.
-     */
+    /** Re-renders rows with the latest exchange data. */
     @Override
     public void onGameUpdated() {
         renderCurrent();
     }
 
-    /**
-     * Refreshes the title and re-renders all rows to reflect the active
-     * language and currency.
-     */
+    /** Refreshes the title and re-renders all rows. */
     @Override
     protected void onLanguageChanged() {
         titleLabel.setText(LanguageManager.get(titleKey));
         renderCurrent();
     }
 
-    /**
-     * Clears and rebuilds the table from the stocks the {@code selector} picks out
-     * of the current exchange, showing an empty-state message when there are none.
-     */
+    /** Clears and rebuilds the table from the stocks returned by {@code selector}. */
     private void renderCurrent() {
         List<Stock> stocks = selector.apply(gameService.getExchange());
         table.clearRows();
@@ -106,36 +96,55 @@ public class StockRankingCard extends Card {
     }
 
     /**
-     * Builds and inserts one data row for the given stock at the specified row index.
+     * Builds and inserts one selectable data row for {@code stock}.
      *
-     * @param rowIndex the grid row to write to (row 0 is reserved for the header)
+     * @param rowIndex grid row index (row 0 is the header)
      * @param stock    the stock to display
      */
     private void addDataRow(int rowIndex, Stock stock) {
         Label changeLabel = ChangeFormatter.styledPercent(
                 stock.getWeeklyChangePercent(), "table-cell");
-        table.addRow(rowIndex, RowCells.<Col>builder()
+        ChevronButton chevron = new ChevronButton(
+                () -> openDetail(stock), "tooltip.stocks.chevron");
+        chevron.setFocusTraversable(true);
+
+        RowCells<Col> cells = RowCells.<Col>builder()
                 .put(Col.TICKER, TableCells.data(stock.getSymbol()))
-                .put(Col.COMPANY, TableCells.data(stock.getCompany()))
-                .put(Col.CURRENCY, TableCells.data(stock.getCurrency().getCurrencyCode()))
+                .put(Col.COMPANY,TableCells.data(stock.getCompany()))
                 .put(Col.PRICE, TableCells.data(ChangeFormatter.formatPlain(stock.getSalesPrice())))
-                .put(Col.CHANGE, changeLabel));
+                .put(Col.CHANGE, changeLabel)
+                .put(Col.DETAILS,chevron);
+
+        table.addSelectableRow(rowIndex, chevron, () -> openDetail(stock), cells);
+    }
+
+    /**
+     * Opens the stock detail modal for {@code stock}.
+     *
+     * @param stock the stock to show details for
+     */
+    private void openDetail(Stock stock) {
+        controller.openStockDetail(stock);
     }
 
     /**
      * Returns the column definitions for this table.
-     * Called by {@link SortColumnTable} on every header refresh so that labels
-     * reflect the active language and currency.
      *
-     * @return a list of five {@link TableColumnDef} in display order
+     * @return ordered list of {@link TableColumnDef}
      */
     private List<TableColumnDef<Col>> columnDefs() {
+        List<Stock> stocks = selector.apply(gameService.getExchange());
+        String currencyCode = stocks.isEmpty()
+                ? "" : stocks.get(0).getCurrency().getCurrencyCode();
+        String priceHeader = MessageFormat.format(
+                LanguageManager.get("col.priceNative"), currencyCode);
+
         return List.of(
-                TableColumnDef.nonSortable(Col.TICKER,   "col.ticker",      COL_TICKER,   HPos.LEFT),
-                TableColumnDef.nonSortable(Col.COMPANY,  "col.stock",       COL_COMPANY,  HPos.LEFT),
-                TableColumnDef.nonSortable(Col.CURRENCY, "col.currency",    COL_CURRENCY, HPos.LEFT),
-                TableColumnDef.nonSortable(Col.PRICE,    "col.priceNative", COL_PRICE,    HPos.RIGHT),
-                TableColumnDef.nonSortable(Col.CHANGE,   "col.change",      COL_CHANGE,   HPos.RIGHT)
+                TableColumnDef.nonSortable(Col.TICKER,"col.ticker", COL_TICKER, HPos.LEFT),
+                TableColumnDef.nonSortable(Col.COMPANY, "col.stock", COL_COMPANY, HPos.LEFT),
+                new TableColumnDef<>(() -> priceHeader, Col.PRICE, false, null, COL_PRICE, HPos.RIGHT),
+                TableColumnDef.nonSortable(Col.CHANGE,  "col.change", COL_CHANGE, HPos.RIGHT),
+                TableColumnDef.nonSortable(Col.DETAILS, "col.details", COL_DETAILS, HPos.CENTER)
         );
     }
 }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/exchange/overview/card/TotalStocksCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/exchange/overview/card/TotalStocksCard.java
@@ -1,12 +1,12 @@
 package edu.ntnu.idatt2003.millions.view.ingame.exchange.overview.card;
 
+import edu.ntnu.idatt2003.millions.observer.GameObserver;
 import edu.ntnu.idatt2003.millions.service.game.GameService;
 import edu.ntnu.idatt2003.millions.view.component.StyledText;
 import edu.ntnu.idatt2003.millions.view.ingame.component.card.WidgetCard;
 
 /**
  * Widget card displaying the total number of stocks listed on the exchange.
- * Updates automatically on each week advance via {@link edu.ntnu.idatt2003.millions.observer.GameObserver}.
  */
 public class TotalStocksCard extends WidgetCard {
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/exchange/stock/StocksSort.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/exchange/stock/StocksSort.java
@@ -15,10 +15,6 @@ import javafx.geometry.HPos;
 
 /**
  * Defines sortable columns and comparators for the stocks table.
- *
- * <p>Provides {@link #getColumnDefs()} so {@link SortColumnTable}
- * can build a header row with the correct labels, widths, alignments and sort keys.
- * Resolves i18n labels on every call so language changes are picked up automatically.</p>
  */
 public class StocksSort extends SortProvider<Stock, StocksSort.SortColumn> {
 

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/exchange/stock/card/PriceHistoryCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/exchange/stock/card/PriceHistoryCard.java
@@ -1,4 +1,4 @@
-package edu.ntnu.idatt2003.millions.view.ingame.exchange.stock.dialog;
+package edu.ntnu.idatt2003.millions.view.ingame.exchange.stock.card;
 
 import edu.ntnu.idatt2003.millions.util.format.ChangeFormatter;
 import edu.ntnu.idatt2003.millions.util.language.LanguageManager;
@@ -22,7 +22,7 @@ import java.util.Objects;
  * on the right, oldest week first. Purely presentational: it receives a ready price
  * list and renders it. Reuses the shared {@code content-scroll} scroll styling.</p>
  */
-public class PriceHistoryList extends VBox {
+public class PriceHistoryCard extends VBox {
 
     /**
      * Constructs a {@code PriceHistoryList} for the given prices.
@@ -33,7 +33,7 @@ public class PriceHistoryList extends VBox {
      * @throws NullPointerException     if {@code prices} or {@code currency} is {@code null}
      * @throws IllegalArgumentException if {@code prices} is empty
      */
-    public PriceHistoryList(List<BigDecimal> prices, Currency currency) {
+    public PriceHistoryCard(List<BigDecimal> prices, Currency currency) {
         Objects.requireNonNull(prices, "prices must not be null");
         Objects.requireNonNull(currency, "currency must not be null");
         if (prices.isEmpty()) {

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/exchange/stock/dialog/StockDetailModal.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/exchange/stock/dialog/StockDetailModal.java
@@ -8,6 +8,7 @@ import edu.ntnu.idatt2003.millions.util.language.LanguageManager;
 import edu.ntnu.idatt2003.millions.view.ingame.component.modal.Modal;
 import edu.ntnu.idatt2003.millions.view.component.StyledText;
 import edu.ntnu.idatt2003.millions.view.ingame.component.chart.TimeSeriesChart;
+import edu.ntnu.idatt2003.millions.view.ingame.exchange.stock.card.PriceHistoryCard;
 import javafx.application.Platform;
 import javafx.geometry.Pos;
 import javafx.scene.control.Button;
@@ -177,7 +178,7 @@ public class StockDetailModal extends Modal {
         chartSection.getStyleClass().add("stock-detail-panel");
         HBox.setHgrow(chartSection, Priority.ALWAYS);
 
-        PriceHistoryList list = new PriceHistoryList(stock.getHistoricalPrices(),
+        PriceHistoryCard list = new PriceHistoryCard(stock.getHistoricalPrices(),
                 stock.getCurrency());
         list.setMaxHeight(CHART_HEIGHT);
         VBox listSection = new VBox(8,


### PR DESCRIPTION
## Summary
StockRankingCard (used for weekly winners and losers on the exchange overview) was a read-only table with no interactivity. This PR brings it in line with StocksCard, HoldingsCard, and WatchlistCard by adding a details chevron, hover/focus row highlighting, and keyboard navigation.

## Changes

### StockRankingCard

Added TradeController field to open the stock detail modal via openDetail(Stock)
Added DETAILS column (enum + column def) with a ChevronButton as the focus anchor
Switched from table.addRow() to table.addSelectableRow(), which wires hover/focus highlight, arrow-key navigation, and Enter/Space activation for free
Fixed column widths to sum to 100% (previously 84–96% depending on state)
Fixed the price column header: col.priceNative is a MessageFormat pattern ("Kurs {0}"); the header now resolves the currency code dynamically from the first stock in the selector result instead of displaying the literal {0} placeholder