### PR TITLE
fix: nok currency native display inconsistency

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/dashboard/watchlist/card/StockInfoCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/dashboard/watchlist/card/StockInfoCard.java
@@ -14,15 +14,16 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 
 import java.math.BigDecimal;
+import java.util.Currency;
 import java.util.List;
 
 /**
  * A styled info card displaying key price data for a single stock.
  *
- * <p>Renders four rows inside a {@code modal-summary}-styled container:
+ * <p>Renders a horizontal meta row inside a {@code modal-summary}-styled container with:
  * <ul>
  *   <li>Current price in the stock's native currency</li>
- *   <li>Current price converted to NOK</li>
+ *   <li>Current price converted to NOK - omitted when the stock is already priced in NOK</li>
  *   <li>Weekly price change as a signed, colour-coded percentage</li>
  *   <li>A {@link SparklineChart} showing the recent price trend</li>
  * </ul>
@@ -32,10 +33,14 @@ import java.util.List;
 public class StockInfoCard extends VBox {
 
     private static final int SPARKLINE_WEEKS = 8;
+    private static final Currency NOK = Currency.getInstance("NOK");
     private final StockStatsService statsService = new StockStatsService();
 
     /**
      * Constructs a new {@link StockInfoCard} for the given stock.
+     *
+     * <p>When the stock's currency is NOK the NOK price cell is omitted from the
+     * meta row because it would duplicate the native price cell.</p>
      *
      * @param stock     the stock whose price data is displayed
      * @param converter the currency converter used to derive the NOK price
@@ -43,14 +48,15 @@ public class StockInfoCard extends VBox {
     public StockInfoCard(Stock stock, CurrencyConverter converter) {
         setSpacing(12);
 
+        boolean isNok = stock.getCurrency().equals(NOK);
         String currencyCode = stock.getCurrency().getCurrencyCode();
         BigDecimal price = stock.getSalesPrice();
-        BigDecimal priceNok = statsService.priceInNok(stock, converter);
+        BigDecimal priceNok = isNok ? null : statsService.priceInNok(stock, converter);
         BigDecimal changePercent = stock.getWeeklyChangePercent();
 
         getChildren().addAll(
                 buildStockSection(stock),
-                buildMetaRow(stock, currencyCode, price, priceNok, changePercent)
+                buildMetaRow(stock, currencyCode, price, priceNok, changePercent, isNok)
         );
     }
 
@@ -68,32 +74,43 @@ public class StockInfoCard extends VBox {
     }
 
     /**
-     * Builds the horizontal row of four vertical meta cells.
+     * Builds the horizontal row of meta cells.
+     *
+     * <p>For foreign-currency stocks the row contains four cells:
+     * native price, NOK price, weekly change percentage, and sparkline trend.
+     * When the stock is already priced in NOK the NOK price cell is omitted,
+     * leaving three cells: NOK price, weekly change percentage, and sparkline.</p>
      *
      * @param stock         the stock for sparkline data
      * @param currencyCode  the stock's currency code
      * @param price         the current price in native currency
-     * @param priceNok      the current price converted to NOK
+     * @param priceNok      the current price converted to NOK; {@code null} when {@code isNok} is true
      * @param changePercent the weekly change percentage
-     * @return an {@link HBox} containing the four vertical cells
+     * @param isNok         {@code true} when the stock's currency is NOK
+     * @return an {@link HBox} containing three or four vertical cells
      */
     private HBox buildMetaRow(Stock stock, String currencyCode,
                               BigDecimal price, BigDecimal priceNok,
-                              BigDecimal changePercent) {
-        String priceLabelText = LanguageManager.get("col.priceNative");
-
-        VBox priceCell = buildTextCell(
-                priceLabelText,
-                ChangeFormatter.formatPlain(price) + " " + currencyCode);
-
-        VBox priceNokCell = buildTextCell(
-                LanguageManager.get("col.priceNok"),
-                ChangeFormatter.formatPlain(priceNok) + " NOK");
-
+                              BigDecimal changePercent, boolean isNok) {
         VBox changeCell = buildChangeCell(changePercent);
         VBox trendCell = buildTrendCell(stock);
 
-        HBox row = new HBox(24, priceCell, priceNokCell, changeCell, trendCell);
+        HBox row;
+        if (isNok) {
+            VBox priceCell = buildTextCell(
+                    LanguageManager.get("col.priceNok"),
+                    ChangeFormatter.formatPlain(price) + " NOK");
+            row = new HBox(24, priceCell, changeCell, trendCell);
+        } else {
+            VBox priceCell = buildTextCell(
+                    LanguageManager.get("col.priceNative"),
+                    ChangeFormatter.formatPlain(price) + " " + currencyCode);
+            VBox priceNokCell = buildTextCell(
+                    LanguageManager.get("col.priceNok"),
+                    ChangeFormatter.formatPlain(priceNok) + " NOK");
+            row = new HBox(24, priceCell, priceNokCell, changeCell, trendCell);
+        }
+
         row.setAlignment(Pos.BOTTOM_LEFT);
         return row;
     }

--- a/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/exchange/stock/dialog/WeeklyChangeCard.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/view/ingame/exchange/stock/dialog/WeeklyChangeCard.java
@@ -19,11 +19,16 @@ import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 
 import java.text.MessageFormat;
+import java.util.Currency;
 import java.util.List;
 import java.util.Objects;
 
 /**
  * A self-contained weekly price-change card for a single {@link Stock}.
+ *
+ * <p>When the stock's currency is NOK the NOK-change column is omitted from the
+ * table, because it would be identical to the native-change column and therefore
+ * redundant. For all other currencies both columns are shown side by side.</p>
  */
 public class WeeklyChangeCard extends VBox {
 
@@ -35,6 +40,8 @@ public class WeeklyChangeCard extends VBox {
 
     /** Vertical gap between rows in the weekly-change {@link GridPane}. */
     private static final int TABLE_VGAP = 6;
+
+    private static final Currency NOK = Currency.getInstance("NOK");
 
     /**
      * Constructs a {@code WeeklyChangeCard} for the given stock and
@@ -110,6 +117,11 @@ public class WeeklyChangeCard extends VBox {
      * the list is empty (e.g. only week 1 selected with no transitions).
      * Rows are displayed newest first.
      *
+     * <p>When the stock's currency is NOK the NOK-change column is omitted because
+     * it would duplicate the native-change column. Foreign-currency stocks show both
+     * columns so the player can compare the change in the stock's own currency and
+     * in NOK side by side.</p>
+     *
      * @param stock the stock whose currency code labels the native-change column
      * @param rows  the pre-fetched {@link WeeklyPriceChange} rows, newest first
      * @return the populated {@link GridPane}, or an info label when {@code rows} is empty
@@ -119,6 +131,7 @@ public class WeeklyChangeCard extends VBox {
             return StyledText.detailLabel(LanguageManager.get("stockDetail.weeklyEmpty"));
         }
 
+        boolean isNok = stock.getCurrency().equals(NOK);
         String code = stock.getCurrency().getCurrencyCode();
 
         GridPane table = new GridPane();
@@ -126,7 +139,9 @@ public class WeeklyChangeCard extends VBox {
         table.setHgap(12);
         table.setVgap(TABLE_VGAP);
 
-        HPos[] alignments = {HPos.LEFT, HPos.RIGHT, HPos.RIGHT, HPos.RIGHT};
+        HPos[] alignments = isNok
+                ? new HPos[]{HPos.LEFT, HPos.RIGHT, HPos.RIGHT}
+                : new HPos[]{HPos.LEFT, HPos.RIGHT, HPos.RIGHT, HPos.RIGHT};
         for (HPos alignment : alignments) {
             ColumnConstraints col = new ColumnConstraints();
             col.setHgrow(Priority.ALWAYS);
@@ -134,20 +149,34 @@ public class WeeklyChangeCard extends VBox {
             table.getColumnConstraints().add(col);
         }
 
-        table.addRow(0,
-                StyledText.detailLabel(LanguageManager.get("col.week")),
-                StyledText.detailLabel(MessageFormat.format(
-                        LanguageManager.get("stockDetail.changeNative"), code)),
-                StyledText.detailLabel(LanguageManager.get("stockDetail.changeNok")),
-                StyledText.detailLabel(LanguageManager.get("stockDetail.changePct")));
+        if (isNok) {
+            table.addRow(0,
+                    StyledText.detailLabel(LanguageManager.get("col.week")),
+                    StyledText.detailLabel(LanguageManager.get("stockDetail.changeNok")),
+                    StyledText.detailLabel(LanguageManager.get("stockDetail.changePct")));
+        } else {
+            table.addRow(0,
+                    StyledText.detailLabel(LanguageManager.get("col.week")),
+                    StyledText.detailLabel(MessageFormat.format(
+                            LanguageManager.get("stockDetail.changeNative"), code)),
+                    StyledText.detailLabel(LanguageManager.get("stockDetail.changeNok")),
+                    StyledText.detailLabel(LanguageManager.get("stockDetail.changePct")));
+        }
 
         int rowIndex = 1;
         for (WeeklyPriceChange row : rows) {
-            table.addRow(rowIndex++,
-                    StyledText.detailValue(String.valueOf(row.week())),
-                    ChangeFormatter.styledAmount(row.nativeChange(), "detail-value"),
-                    ChangeFormatter.styledAmount(row.nokChange(), "detail-value"),
-                    ChangeFormatter.styledPercent(row.percentChange(), "detail-value"));
+            if (isNok) {
+                table.addRow(rowIndex++,
+                        StyledText.detailValue(String.valueOf(row.week())),
+                        ChangeFormatter.styledAmount(row.nokChange(), "detail-value"),
+                        ChangeFormatter.styledPercent(row.percentChange(), "detail-value"));
+            } else {
+                table.addRow(rowIndex++,
+                        StyledText.detailValue(String.valueOf(row.week())),
+                        ChangeFormatter.styledAmount(row.nativeChange(), "detail-value"),
+                        ChangeFormatter.styledAmount(row.nokChange(), "detail-value"),
+                        ChangeFormatter.styledPercent(row.percentChange(), "detail-value"));
+            }
         }
 
         return table;


### PR DESCRIPTION
## Problem
When a user uploads a custom stock file and selects NOK as the currency, certain UI components displayed redundant information: two columns or cells showing identical values because converting NOK → NOK produces the same number.
Specifically:

WeeklyChangeCard always rendered four columns — Week | Native change | NOK change | % — even when the stock was already priced in NOK, making the native and NOK columns identical.
StockInfoCard always rendered both a native price cell and a NOK price cell side by side, again showing the same value when the stock currency was NOK.
TransactionPreview had an incorrect Javadoc contract stating totalInNok could be null when the native currency is NOK. This was never true in practice, but posed a future NPE risk for callers that trusted the documentation.

## Changes

### WeeklyChangeCard

Added private static final Currency NOK constant.
buildTable() now checks stock.getCurrency().equals(NOK).
NOK stocks: 3-column table — Week | Change (NOK) | %.
Foreign-currency stocks: 4-column table as before — Week | Change (native) | Change (NOK) | %.

### StockInfoCard

Added private static final Currency NOK constant.
isNok flag computed once in the constructor and passed to buildMetaRow().
priceNok is only fetched from StockStatsService for foreign-currency stocks, avoiding a no-op converter call.
NOK stocks: 3-cell meta row — Price (NOK) | Weekly change | Trend.
Foreign-currency stocks: 4-cell meta row as before — Price (native) | Price (NOK) | Weekly change | Trend.

### TransactionPreview

Corrected the Javadoc to state that totalInNok is always non-null.
Clarified that when the stock's native currency is NOK, totalInNok equals total directly because CurrencyConverter returns the original amount unchanged when source and target currency are the same.
Kept the existing correct contract for profitInNok (null for purchases and for NOK-currency sales).