### PR TITLE
docs: add AI assistance javadoc to data values in test

### DIFF
--- a/src/test/java/edu/ntnu/idatt2003/millions/controller/game/StartControllerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/controller/game/StartControllerTest.java
@@ -41,6 +41,10 @@ class StartControllerTest {
     private boolean showMainCalled;
     private StartController controller;
 
+    /**
+     * Initializes test fixtures before each test.
+     * Test data values were generated with AI assistance and reviewed manually.
+     */
     @BeforeEach
     void setUp() {
         inputs = new StubInputs();

--- a/src/test/java/edu/ntnu/idatt2003/millions/factory/TransactionFactoryTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/factory/TransactionFactoryTest.java
@@ -30,6 +30,10 @@ class TransactionFactoryTest {
 
     private Share share;
 
+    /**
+     * Initializes test fixtures before each test.
+     * Test data values were generated with AI assistance and reviewed manually.
+     */
     @BeforeEach
     void setUp() {
         Stock stock = new Stock("DIS", "The Walt Disney Company",

--- a/src/test/java/edu/ntnu/idatt2003/millions/file/game/JsonGameFileHandlerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/file/game/JsonGameFileHandlerTest.java
@@ -51,6 +51,10 @@ class JsonGameFileHandlerTest {
     @TempDir
     Path tempDir;
 
+    /**
+     * Initializes test fixtures before each test.
+     * Test data values were generated with AI assistance and reviewed manually.
+     */
     @BeforeEach
     void setUp() {
         handler = new JsonGameFileHandler();

--- a/src/test/java/edu/ntnu/idatt2003/millions/file/leaderboard/JsonLeaderboardFileHandlerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/file/leaderboard/JsonLeaderboardFileHandlerTest.java
@@ -28,6 +28,10 @@ class JsonLeaderboardFileHandlerTest {
     @TempDir
     Path tempDir;
 
+    /**
+     * Initializes test fixtures before each test.
+     * Test data values were generated with AI assistance and reviewed manually.
+     */
     @BeforeEach
     void setUp() {
         handler = new JsonLeaderboardFileHandler();

--- a/src/test/java/edu/ntnu/idatt2003/millions/file/stock/CsvStockFileHandlerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/file/stock/CsvStockFileHandlerTest.java
@@ -38,6 +38,10 @@ class CsvStockFileHandlerTest {
     @TempDir
     Path tempDir;
 
+    /**
+     * Initializes test fixtures before each test.
+     * Test data values were generated with AI assistance and reviewed manually.
+     */
     @BeforeEach
     void setUp() {
         handler = new CsvStockFileHandler();

--- a/src/test/java/edu/ntnu/idatt2003/millions/keyboard/ActiveRegistryTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/keyboard/ActiveRegistryTest.java
@@ -17,6 +17,10 @@ class ActiveRegistryTest {
 
     private ActiveRegistry<Runnable> registry;
 
+    /**
+     * Initializes test fixtures before each test.
+     * Test data values were generated with AI assistance and reviewed manually.
+     */
     @BeforeEach
     void setUp() {
         registry = new ActiveRegistry<>();

--- a/src/test/java/edu/ntnu/idatt2003/millions/keyboard/KeyboardNavigationServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/keyboard/KeyboardNavigationServiceTest.java
@@ -31,6 +31,10 @@ class KeyboardNavigationServiceTest {
 
     private KeyboardNavigationService service;
 
+    /**
+     * Initializes test fixtures before each test.
+     * Test data values were generated with AI assistance and reviewed manually.
+     */
     @BeforeEach
     void setUp() {
         service = new KeyboardNavigationService();

--- a/src/test/java/edu/ntnu/idatt2003/millions/keyboard/ShortcutRegistryTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/keyboard/ShortcutRegistryTest.java
@@ -32,6 +32,10 @@ class ShortcutRegistryTest {
 
     private ShortcutRegistry registry;
 
+    /**
+     * Initializes test fixtures before each test.
+     * Test data values were generated with AI assistance and reviewed manually.
+     */
     @BeforeEach
     void setUp() {
         registry = new ShortcutRegistry();

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/currency/FixedRateCurrencyConverterTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/currency/FixedRateCurrencyConverterTest.java
@@ -33,6 +33,10 @@ class FixedRateCurrencyConverterTest {
     private static final Currency DKK = Currency.getInstance("DKK");
     private static final Currency JPY = Currency.getInstance("JPY");
 
+    /**
+     * Initializes test fixtures before each test.
+     * Test data values were generated with AI assistance and reviewed manually.
+     */
     @BeforeEach
     void setUp() {
         converter = new FixedRateCurrencyConverter();

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/exchange/ExchangeTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/exchange/ExchangeTest.java
@@ -38,6 +38,10 @@ class ExchangeTest {
     private Stock stock;
     private CurrencyConverter converter;
 
+    /**
+     * Initializes test fixtures before each test.
+     * Test data values were generated with AI assistance and reviewed manually.
+     */
     @BeforeEach
     void setUp() {
         stock = new Stock("DIS", "The Walt Disney Company",
@@ -365,6 +369,10 @@ class ExchangeTest {
 
         private Share share;
 
+        /**
+         * Initializes test fixtures before each test.
+         * Test data values were generated with AI assistance and reviewed manually.
+         */
         @BeforeEach
         void setUp() {
             share = new Share(stock, new BigDecimal("5"), new BigDecimal("100.00"));
@@ -515,6 +523,10 @@ class ExchangeTest {
         private Stock gainer;
         private Stock loser;
 
+        /**
+         * Initializes test fixtures before each test.
+         * Test data values were generated with AI assistance and reviewed manually.
+         */
         @BeforeEach
         void setUp() {
             gainer = new Stock("DCL", "Dara, Inc",
@@ -605,6 +617,10 @@ class ExchangeTest {
         private Stock gainer;
         private Stock loser;
 
+        /**
+         * Initializes test fixtures before each test.
+         * Test data values were generated with AI assistance and reviewed manually.
+         */
         @BeforeEach
         void setUp() {
             gainer = new Stock("DCL", "Dara, Inc",

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/exchange/RandomPriceSimulatorTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/exchange/RandomPriceSimulatorTest.java
@@ -17,6 +17,10 @@ class RandomPriceSimulatorTest {
 
     private RandomPriceSimulator simulator;
 
+    /**
+     * Initializes test fixtures before each test.
+     * Test data values were generated with AI assistance and reviewed manually.
+     */
     @BeforeEach
     void setUp() {
         simulator = new RandomPriceSimulator();

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/loan/LoanTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/loan/LoanTest.java
@@ -248,6 +248,10 @@ class LoanTest {
 
         private Loan loan;
 
+        /**
+         * Initializes test fixtures before each test.
+         * Test data values were generated with AI assistance and reviewed manually.
+         */
         @BeforeEach
         void setUp() {
             // principal=1000.00, rate=0.01, term=4, takenAtWeek=1; due week = 1+4 = 5
@@ -298,6 +302,10 @@ class LoanTest {
 
         private Loan loan;
 
+        /**
+         * Initializes test fixtures before each test.
+         * Test data values were generated with AI assistance and reviewed manually.
+         */
         @BeforeEach
         void setUp() {
             // principal=1000.00, rate=0.01 → weekly=10.00; term=4, takenAtWeek=1
@@ -334,6 +342,10 @@ class LoanTest {
 
         private Loan loan;
 
+        /**
+         * Initializes test fixtures before each test.
+         * Test data values were generated with AI assistance and reviewed manually.
+         */
         @BeforeEach
         void setUp() {
             // principal=1000.00, rate=0.01 → weekly=10.00; term=4, takenAtWeek=1; due week=5
@@ -377,6 +389,10 @@ class LoanTest {
 
         private Loan loan;
 
+        /**
+         * Initializes test fixtures before each test.
+         * Test data values were generated with AI assistance and reviewed manually.
+         */
         @BeforeEach
         void setUp() {
             // takenAtWeek=1, term=4; due week = 1 + 4 = 5

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/player/PlayerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/player/PlayerTest.java
@@ -46,6 +46,10 @@ class PlayerTest {
     private static final Currency NOK = Currency.getInstance("NOK");
     private static final Currency USD = Currency.getInstance("USD");
 
+    /**
+     * Initializes test fixtures before each test.
+     * Test data values were generated with AI assistance and reviewed manually.
+     */
     @BeforeEach
     void setUp() {
         player = new Player("Alva", new BigDecimal("1000.00"));
@@ -687,6 +691,10 @@ class PlayerTest {
 
         private LoanOffer offer;
 
+        /**
+         * Initializes test fixtures before each test.
+         * Test data values were generated with AI assistance and reviewed manually.
+         */
         @BeforeEach
         void setUpOffer() {
             // simple offer with generous maxPrincipal so tests can isolate capacity logic
@@ -1154,6 +1162,10 @@ class PlayerTest {
 
         private WatchlistEntry entry;
 
+        /**
+         * Initializes test fixtures before each test.
+         * Test data values were generated with AI assistance and reviewed manually.
+         */
         @BeforeEach
         void setUpEntry() {
             entry = new WatchlistEntry("AAPL", 1, "");

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/player/PortfolioTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/player/PortfolioTest.java
@@ -36,6 +36,10 @@ class PortfolioTest {
     private static final Currency USD = Currency.getInstance("USD");
     private static final Currency EUR = Currency.getInstance("EUR");
 
+    /**
+     * Initializes test fixtures before each test.
+     * Test data values were generated with AI assistance and reviewed manually.
+     */
     @BeforeEach
     void setUp() {
         // Arrange

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/stock/ShareTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/stock/ShareTest.java
@@ -27,6 +27,10 @@ class ShareTest {
     private Stock stock;
     private Share share;
 
+    /**
+     * Initializes test fixtures before each test.
+     * Test data values were generated with AI assistance and reviewed manually.
+     */
     @BeforeEach
     void setUp() {
         stock = new Stock("NKE", "Nike, Inc",

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/stock/StockTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/stock/StockTest.java
@@ -26,6 +26,10 @@ class StockTest {
 
     private Stock stock;
 
+    /**
+     * Initializes test fixtures before each test.
+     * Test data values were generated with AI assistance and reviewed manually.
+     */
     @BeforeEach
     void setUp() {
         stock = new Stock("NKE", "Nike, Inc",

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/transaction/PurchaseCalculatorTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/transaction/PurchaseCalculatorTest.java
@@ -28,6 +28,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class PurchaseCalculatorTest {
     private PurchaseCalculator calculator;
 
+    /**
+     * Initializes test fixtures before each test.
+     * Test data values were generated with AI assistance and reviewed manually.
+     */
     @BeforeEach
     void setUp() {
         Share share = new Share(

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/transaction/PurchaseTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/transaction/PurchaseTest.java
@@ -27,6 +27,10 @@ class PurchaseTest {
     private Player player;
     private Share share;
 
+    /**
+     * Initializes test fixtures before each test.
+     * Test data values were generated with AI assistance and reviewed manually.
+     */
     @BeforeEach
     void setUp() {
         player = new Player("Alva", new BigDecimal("10000.00"));
@@ -98,6 +102,10 @@ class PurchaseTest {
 
         private Purchase purchase;
 
+        /**
+         * Initializes test fixtures before each test.
+         * Test data values were generated with AI assistance and reviewed manually.
+         */
         @BeforeEach
         void setUp() {
             // Arrange

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/transaction/SaleTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/transaction/SaleTest.java
@@ -29,6 +29,10 @@ class SaleTest {
     private Player player;
     private Share share;
 
+    /**
+     * Initializes test fixtures before each test.
+     * Test data values were generated with AI assistance and reviewed manually.
+     */
     @BeforeEach
     void setUp() {
         player = new Player("Alva", new BigDecimal("10000.00"));
@@ -155,6 +159,10 @@ class SaleTest {
                 new BigDecimal("10"), new BigDecimal("50.00"));
         private final Sale otherSale = new Sale(otherShare, 1);
 
+        /**
+         * Initializes test fixtures before each test.
+         * Test data values were generated with AI assistance and reviewed manually.
+         */
         @BeforeEach
         void setUp() {
             sale = new Sale(share, 1);

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/transaction/SalesCalculatorTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/transaction/SalesCalculatorTest.java
@@ -28,6 +28,10 @@ class SalesCalculatorTest {
 
     private SalesCalculator calculator;
 
+    /**
+     * Initializes test fixtures before each test.
+     * Test data values were generated with AI assistance and reviewed manually.
+     */
     @BeforeEach
     void setUp() {
         Share share = new Share(

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/transaction/TransactionArchiveTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/transaction/TransactionArchiveTest.java
@@ -31,6 +31,10 @@ class TransactionArchiveTest {
     private TransactionArchive archive;
     private Share share;
 
+    /**
+     * Initializes test fixtures before each test.
+     * Test data values were generated with AI assistance and reviewed manually.
+     */
     @BeforeEach
     void setUp() {
         archive = new TransactionArchive();

--- a/src/test/java/edu/ntnu/idatt2003/millions/model/transaction/TransactionPreviewServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/model/transaction/TransactionPreviewServiceTest.java
@@ -33,6 +33,10 @@ class TransactionPreviewServiceTest {
     private CurrencyConverter converter;
     private Player player;
 
+    /**
+     * Initializes test fixtures before each test.
+     * Test data values were generated with AI assistance and reviewed manually.
+     */
     @BeforeEach
     void setUp() {
         service = new TransactionPreviewService();

--- a/src/test/java/edu/ntnu/idatt2003/millions/service/game/GameServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/service/game/GameServiceTest.java
@@ -64,6 +64,10 @@ class GameServiceTest {
     @TempDir
     Path tempDir;
 
+    /**
+     * Initializes test fixtures before each test.
+     * Test data values were generated with AI assistance and reviewed manually.
+     */
     @BeforeEach
     void setUp() throws GameSaveCorruptException {
         Stock stock = new Stock("EQNR", "Equinor ASA",
@@ -462,6 +466,10 @@ class GameServiceTest {
 
         private LoanOffer offer;
 
+        /**
+         * Initializes test fixtures before each test.
+         * Test data values were generated with AI assistance and reviewed manually.
+         */
         @BeforeEach
         void setUpLoan() {
             offer = new LoanOffer("standard", new BigDecimal("0.01"), 10,

--- a/src/test/java/edu/ntnu/idatt2003/millions/service/leaderboard/LeaderboardServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/service/leaderboard/LeaderboardServiceTest.java
@@ -37,6 +37,10 @@ class LeaderboardServiceTest {
     private LeaderboardService service;
     private CurrencyConverter identityConverter;
 
+    /**
+     * Initializes test fixtures before each test.
+     * Test data values were generated with AI assistance and reviewed manually.
+     */
     @BeforeEach
     void setUp() {
         fakeHandler = new FakeFileHandler();

--- a/src/test/java/edu/ntnu/idatt2003/millions/service/loan/LoanPreviewServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/service/loan/LoanPreviewServiceTest.java
@@ -23,6 +23,10 @@ class LoanPreviewServiceTest {
 
     private LoanPreviewService service;
 
+    /**
+     * Initializes test fixtures before each test.
+     * Test data values were generated with AI assistance and reviewed manually.
+     */
     @BeforeEach
     void setUp() {
         service = new LoanPreviewService();

--- a/src/test/java/edu/ntnu/idatt2003/millions/service/notification/NotificationServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/service/notification/NotificationServiceTest.java
@@ -34,6 +34,10 @@ class NotificationServiceTest {
             "fast", new BigDecimal("0.0015"), 15,
             new BigDecimal("50000.00"), LoanRiskLevel.MEDIUM);
 
+    /**
+     * Initializes test fixtures before each test.
+     * Test data values were generated with AI assistance and reviewed manually.
+     */
     @BeforeEach
     void setUp() {
         service = new NotificationService();
@@ -212,6 +216,10 @@ class NotificationServiceTest {
 
         private Stock ownedStock;
 
+        /**
+         * Initializes test fixtures before each test.
+         * Test data values were generated with AI assistance and reviewed manually.
+         */
         @BeforeEach
         void setupOwnedStock() {
             List<BigDecimal> prices = new ArrayList<>();

--- a/src/test/java/edu/ntnu/idatt2003/millions/service/player/PlayerStatsServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/service/player/PlayerStatsServiceTest.java
@@ -28,6 +28,10 @@ class PlayerStatsServiceTest {
     private PlayerStatsService service;
     private CurrencyConverter converter;
 
+    /**
+     * Initializes test fixtures before each test.
+     * Test data values were generated with AI assistance and reviewed manually.
+     */
     @BeforeEach
     void setUp() {
         service = new PlayerStatsService();

--- a/src/test/java/edu/ntnu/idatt2003/millions/service/player/PortfolioServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/service/player/PortfolioServiceTest.java
@@ -31,6 +31,10 @@ class PortfolioServiceTest {
     private PortfolioService service;
     private CurrencyConverter converter;
 
+    /**
+     * Initializes test fixtures before each test.
+     * Test data values were generated with AI assistance and reviewed manually.
+     */
     @BeforeEach
     void setUp() {
         service = new PortfolioService();

--- a/src/test/java/edu/ntnu/idatt2003/millions/service/player/RealizedReturnsServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/service/player/RealizedReturnsServiceTest.java
@@ -36,6 +36,10 @@ class RealizedReturnsServiceTest {
     private CurrencyConverter converter;
     private Player player;
 
+    /**
+     * Initializes test fixtures before each test.
+     * Test data values were generated with AI assistance and reviewed manually.
+     */
     @BeforeEach
     void setUp() {
         service = new RealizedReturnsService();

--- a/src/test/java/edu/ntnu/idatt2003/millions/service/stock/StockHistoryServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/service/stock/StockHistoryServiceTest.java
@@ -28,6 +28,10 @@ class StockHistoryServiceTest {
 
     private StockHistoryService service;
 
+    /**
+     * Initializes test fixtures before each test.
+     * Test data values were generated with AI assistance and reviewed manually.
+     */
     @BeforeEach
     void setUp() {
         service = new StockHistoryService();

--- a/src/test/java/edu/ntnu/idatt2003/millions/service/stock/StockStatsServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/service/stock/StockStatsServiceTest.java
@@ -27,6 +27,10 @@ class StockStatsServiceTest {
 
     private StockStatsService service;
 
+    /**
+     * Initializes test fixtures before each test.
+     * Test data values were generated with AI assistance and reviewed manually.
+     */
     @BeforeEach
     void setUp() {
         service = new StockStatsService();

--- a/src/test/java/edu/ntnu/idatt2003/millions/service/toast/ToastServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/service/toast/ToastServiceTest.java
@@ -17,6 +17,10 @@ class ToastServiceTest {
 
     private ToastService service;
 
+    /**
+     * Initializes test fixtures before each test.
+     * Test data values were generated with AI assistance and reviewed manually.
+     */
     @BeforeEach
     void setUp() {
         service = new ToastService();

--- a/src/test/java/edu/ntnu/idatt2003/millions/service/transaction/TransactionStatsServiceTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/service/transaction/TransactionStatsServiceTest.java
@@ -33,6 +33,10 @@ class TransactionStatsServiceTest {
     private TransactionStatsService service;
     private CurrencyConverter converter;
 
+    /**
+     * Initializes test fixtures before each test.
+     * Test data values were generated with AI assistance and reviewed manually.
+     */
     @BeforeEach
     void setUp() {
         service = new TransactionStatsService();

--- a/src/test/java/edu/ntnu/idatt2003/millions/util/currency/CurrencyFormatterTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/util/currency/CurrencyFormatterTest.java
@@ -23,6 +23,10 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class CurrencyFormatterTest {
 
+    /**
+     * Initializes test fixtures before each test.
+     * Test data values were generated with AI assistance and reviewed manually.
+     */
     @BeforeEach
     void setNorwegian() {
         // Pin to Norwegian so locale-sensitive assertions are deterministic.

--- a/src/test/java/edu/ntnu/idatt2003/millions/util/currency/CurrencyManagerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/util/currency/CurrencyManagerTest.java
@@ -19,6 +19,10 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class CurrencyManagerTest {
 
+    /**
+     * Initializes test fixtures before each test.
+     * Test data values were generated with AI assistance and reviewed manually.
+     */
     @BeforeEach
     void resetToDefault() {
         CurrencyManager.setCurrency(Currency.getInstance("USD"));

--- a/src/test/java/edu/ntnu/idatt2003/millions/util/currency/MoneyFormatterTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/util/currency/MoneyFormatterTest.java
@@ -24,6 +24,10 @@ class MoneyFormatterTest {
     @DisplayName("Norwegian locale")
     class NorwegianLocale {
 
+        /**
+         * Initializes test fixtures before each test.
+         * Test data values were generated with AI assistance and reviewed manually.
+         */
         @BeforeEach
         void setNorwegian() {
             LanguageManager.setLanguage(Language.NORWEGIAN);
@@ -102,6 +106,10 @@ class MoneyFormatterTest {
     @DisplayName("English locale")
     class EnglishLocale {
 
+        /**
+         * Initializes test fixtures before each test.
+         * Test data values were generated with AI assistance and reviewed manually.
+         */
         @BeforeEach
         void setEnglish() {
             LanguageManager.setLanguage(Language.ENGLISH);

--- a/src/test/java/edu/ntnu/idatt2003/millions/util/language/LanguageManagerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/millions/util/language/LanguageManagerTest.java
@@ -23,6 +23,10 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class LanguageManagerTest {
 
+    /**
+     * Initializes test fixtures before each test.
+     * Test data values were generated with AI assistance and reviewed manually.
+     */
     @BeforeEach
     void resetToNorwegian() {
         LanguageManager.setLanguage(Language.NORWEGIAN);


### PR DESCRIPTION
Adds a standardised JavaDoc comment to every @BeforeEach method across all 36 test classes (49 methods total) to document that test data was generated with AI assistance and subsequently reviewed manually.

Motivation:
Transparent use of AI tooling is an explicit requirement in IDATT2003. Documenting AI involvement at the point where test data is initialised makes the extent of AI assistance clear to reviewers and future maintainers, while also demonstrating critical and responsible use of AI tools.
Changes:
Added the following JavaDoc to every @BeforeEach method in the test suite:

java/**
 * Initializes test fixtures before each test.
 * Test data values were generated with AI assistance and reviewed manually.
 */