### PR TITLE
feat: route window close through end-game confirmation

### DIFF
--- a/leaderboard.json
+++ b/leaderboard.json
@@ -97,5 +97,16 @@
     "status": "NOVICE",
     "outcome": "ACTIVE",
     "lastUpdated": "2026-05-26T17:30:13.021465Z"
+  },
+  {
+    "sessionId": "c0caae5d-da56-4abb-af56-727019d7bae6",
+    "playerName": "dara",
+    "startingCapital": 1000,
+    "finalNetWorth": 1000,
+    "returnPercent": 0.0,
+    "weeksPlayed": 1,
+    "status": "NOVICE",
+    "outcome": "ACTIVE",
+    "lastUpdated": "2026-05-27T11:36:44.927135Z"
   }
 ]

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/game/MainController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/game/MainController.java
@@ -32,6 +32,10 @@ import java.util.logging.Logger;
 /**
  * Controller for the main view of the application.
  * Handles save, exit, and advance-week actions, and registers global keyboard shortcuts.
+ *
+ * <p>Both the title-bar close button (Windows) and the native window close request
+ * (macOS) are routed through {@link #handleExitGame()} so the player always sees the
+ * end-game confirmation dialog before the window closes.</p>
  */
 public class MainController {
 
@@ -71,6 +75,11 @@ public class MainController {
         titleBar.setOnNewGame(this::handleNewGame);
         titleBar.setOnSave(this::handleSaveGame);
         titleBar.setOnExit(this::handleExitGame);
+        titleBar.setOnCloseRequest(this::handleExitGame);
+        stage.setOnCloseRequest(event -> {
+            event.consume();
+            handleExitGame();
+        });
         gameService.addObserver(titleBar::onGameUpdated);
         this.view = new MainView(
                 stage,

--- a/src/main/java/edu/ntnu/idatt2003/millions/controller/game/StartController.java
+++ b/src/main/java/edu/ntnu/idatt2003/millions/controller/game/StartController.java
@@ -355,9 +355,15 @@ public class StartController {
     /**
      * Displays the start screen on the primary stage, binds UI events,
      * and registers global keyboard shortcuts on the start scene.
+     *
+     * <p>Clears any window close-request handler installed by
+     * {@link MainController}, so on the start screen the native (macOS) close
+     * button closes the window directly: there is no active game to confirm
+     * exiting from.</p>
      */
     public void show() {
         bindEvents();
+        stage.setOnCloseRequest(null);
         stage.setTitle("Millions");
         stage.getScene().setRoot(view.getRoot());
         registerShortcuts();


### PR DESCRIPTION
# feat: add end-game confirmation to the window close (X) button

Closes the issue *"feat: add endgamemodal to X"*.

## Summary

The player could previously exit the game without any confirmation by clicking the
window close button in the top corner. This PR routes both the Windows custom close
button and the native macOS close control through the **same** end-game confirmation
dialog that the in-app *"Exit game"* action already uses, so an in-progress game can no
longer be closed by accident.

The existing `EndGameDialog` and `MainController.handleExitGame()` are reused as-is — no
new modal was created. The change only adds the wiring needed to reach them from the X
button, on both platforms.

## What changed

**1. Title-bar close seam (view layer)**

- `TitleBar` gains a default, no-op `setOnCloseRequest(Runnable)` method. `MacTitleBar`
  and `NoOpTitleBar` inherit the no-op (macOS has no custom close control), so only
  `WindowsTitleBar` overrides it.
- `WindowsTitleBar` now stores an `onCloseRequest` callback (defaulting to
  `stage::close`) and the custom close button fires that callback instead of closing the
  stage directly. The default keeps the start-screen behaviour unchanged.

**2. Controller wiring (controller layer)**

- `MainController` connects both close paths to the existing exit confirmation:
  - `titleBar.setOnCloseRequest(this::handleExitGame)` — Windows custom X button.
  - `stage.setOnCloseRequest(...)` with `event.consume()` — native macOS X button.
- `StartController.show()` clears the close-request handler, so the native X on the
  start screen closes the window directly (no active game to confirm exiting from).

Programmatic `stage.close()` (run by the dialog's continue action) does **not** fire
`WINDOW_CLOSE_REQUEST`, so there is no risk of an infinite confirmation loop.

## Why it's structured this way

- **Separation of concerns:** the view no longer decides what closing the window means;
  it delegates that decision to the controller.
- **DRY:** both platforms and the existing *"Exit game"* menu action route to a single
  `handleExitGame()` — one source of truth for the exit flow.
- **Polymorphism:** the `TitleBar` interface default method lets the macOS and start-screen
  title bars stay unaware of the close-confirmation flow.

## Keyboard / accessibility

The dialog reuses `EndGameDialog`, so the existing keyboard behaviour is preserved: up/down
arrows move the selection, Enter confirms the focused option, and ESC cancels.

## Testing

Per agreement this change was verified manually (no UI test harness exists in the project):

- In-game, clicking the X (Windows custom button / macOS native control) shows the
  end-game confirmation dialog.
- Selecting an option closes the window as expected, with no confirmation loop.
- On the start screen, the X closes the window directly.
- Keyboard navigation in the dialog (arrows / Enter / ESC) works as before.

## Note: unexpected repository history

While preparing this change, the local repository ended up in an inconsistent state: there
were **multiple clones of the project on the same machine with diverging local history**
(e.g. a `...-clean3` working copy alongside the main one), and several leftover branches
from an earlier history-restore incident (`rescue/alva-history-to-restore`,
`rescue/github-main-before-alva-restore`). This caused the change to briefly exist as
uncommitted work in one clone while another clone showed a clean tree, which made it look
as though the commit had been lost.

The work was consolidated onto a single clone synced with `origin` before this PR was
opened, and the change is committed on its own feature branch. No history on `main` was
rewritten. Leftover rescue branches and the duplicate clone can be cleaned up separately —
flagging it here for awareness so reviewers know why the branch graph around this period
looks noisy.

## Commits

- `feat: add close-request callback seam to title bar`
- `feat: route window close through end-game confirmation`