### PR TITLE
chore: BUMP version to v 3.0 for release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>edu.ntnu.idatt2003</groupId>
     <artifactId>millions</artifactId>
-    <version>3.0-SNAPSHOT</version>
+    <version>3.0</version>
 
     <properties>
         <maven.compiler.source>25</maven.compiler.source>


### PR DESCRIPTION
# build: release version 3.0

Bumps the project version from `3.0-SNAPSHOT` to `3.0` for the v3.0 release.

## Summary

This PR finalises the `3.0` release by dropping the `-SNAPSHOT` qualifier in `pom.xml`,
marking the version as a stable, released build rather than a development snapshot. The
release is tagged `v3.0`, following the existing `v1.0` / `v2.0` tagging convention.

## What changed

- `pom.xml`: `<version>3.0-SNAPSHOT</version>` → `<version>3.0</version>`.

## Release tag

An annotated tag `v3.0` has been created and pushed:

```
git tag -a v3.0 -m "Release 3.0"
git push origin v3.0
```

## Included in this release

The `3.0` line includes the recently merged work on `main`, notably the end-game
confirmation on the window close (X) button (PR #322 / *"feat: add endgamemodal to X"*),
so an in-progress game can no longer be closed without confirmation on either Windows or
macOS.

## Verification

- `pom.xml` parses and the project builds with the released version.
- `git ls-remote --tags origin` lists `refs/tags/v3.0` (annotated — the peeled
  `v3.0^{}` ref is present).